### PR TITLE
Add slp service dialog for registration | part of FATE#316384

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb 21 08:02:38 UTC 2014 - vmoravec@suse.com
+
+- Add SLP service discovery dialog for registration (FATE#316384)
+- 3.1.8
+
+-------------------------------------------------------------------
 Fri Feb 14 16:09:13 UTC 2014 - lslezak@suse.cz
 
 - display progress when adding registered services

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.7
+Version:        3.1.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -32,6 +32,7 @@ Requires:       yast2-pkg-bindings >= 2.17.20
 Requires:       yast2-ruby-bindings >= 3.1.7
 # SCC API library
 Requires:       rubygem-scc_api
+Requires:       yast2-slp >= 3.1.2
 
 BuildRequires:  yast2 >= 2.23.13
 BuildRequires:  update-desktop-files
@@ -40,6 +41,7 @@ BuildRequires:  yast2-devtools >= 3.1.6
 BuildArch:      noarch
 
 Summary:        YaST2 - Registration Module
+Url:            https://github.com/yast/yast-registration
 
 %description
 The registration module to register products and/or to fetch an update

--- a/src/clients/discover_registration_services.rb
+++ b/src/clients/discover_registration_services.rb
@@ -1,0 +1,119 @@
+module Yast
+  import 'SlpService'
+  import 'UI'
+  import 'Label'
+  import 'Report'
+
+  class DiscoverRegistrationServicesClient < Client
+    include Yast::Logger
+
+    REGISTRATION_SERVICES = {
+      'susemanager' => 'SUSE Manager'
+    }
+
+    SUPPORTED_SERVICES = REGISTRATION_SERVICES.keys
+
+    attr_reader :services
+
+    def initialize
+      @services = []
+    end
+
+    def main
+      busy_box do
+        log.info(
+          "Searching for SLP registration services of type #{SUPPORTED_SERVICES.join(', ')}"
+        )
+        SUPPORTED_SERVICES.each do |service_name|
+          services.concat(SlpService.all(service_name))
+        end
+      end
+
+      if services.empty?
+        return Report.Message _('No registration server found')
+      else
+        log.info(
+          "Found #{services.size} services: #{services.map(&:slp_url).join(', ')}"
+        )
+      end
+
+      select_registration_service
+    end
+
+    private
+
+    def select_registration_service
+      UI.OpenDialog(
+        Opt(:decorated),
+        VBox(
+          Label(_('Available local registration servers')),
+          VSpacing(0.6),
+          RadioButtonGroup(
+            Id(:services),
+            Left(
+              HVSquash(
+                VBox(*services_radio_buttons)
+              )
+            )
+          ),
+          ButtonBox(
+            PushButton(Id(:ok), Label.OKButton),
+            PushButton(Id(:cancel), Label.CancelButton)
+          )
+        )
+      )
+
+      loop do
+        dialog_result = UI.UserInput
+        case dialog_result
+        when :ok
+          selected = UI.QueryWidget(Id(:services), :CurrentButton)
+          if !selected
+            Report.Error(_('Please select one of the registration servers'))
+            next
+          end
+          select_service(services[selected.to_i])
+          UI.CloseDialog
+          break
+        when :cancel
+          UI.CloseDialog
+          break
+        end
+      end
+    end
+
+    def select_service(service)
+      log.info("Selected registration service: #{service.inspect}")
+      #TODO Assign the service to a module or a global object now
+    end
+
+    def services_radio_buttons
+      services.map.with_index do |service, index|
+        Left(
+          RadioButton(
+            Id(index.to_s),
+            service_description(service),
+            false
+          )
+        )
+      end
+    end
+
+    def service_description(service)
+      name = REGISTRATION_SERVICES[service.name]
+      url  = "#{service.protocol}://#{service.host}:#{service.port} "
+      attributes = service.attributes.to_h.map do |name, value|
+        "#{name}=#{value} "
+      end
+      "#{name}  #{url}  #{attributes.join}"
+    end
+
+    def busy_box
+      Popup.ShowFeedback(_('Searching for registration servers...'), '')
+      yield
+    ensure
+      Popup.ClearFeedback
+    end
+  end
+  DiscoverRegistrationServicesClient.new.main
+end


### PR DESCRIPTION
Currently there is SUSE Manager slp service as the only option for registration.
This client is going to be used during the installation workflow to show the user the registration servers/options.
The TODO mark is where the user selection will be passed to.
