### PR TITLE
save repositories before refreshing added services

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Feb 13 11:17:39 UTC 2014 - lslezak@suse.cz
+
+- save repositories before refreshing added services (otherwise
+  pkg-bindings will treat them as removed by the service refresh
+  and unloads them)
+- 3.1.5
+
+-------------------------------------------------------------------
 Wed Feb 12 14:12:23 UTC 2014 - lslezak@suse.cz
 
 - pass the repository services returned by SCC to libzypp

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.4
+Version:        3.1.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_scc.rb
+++ b/src/clients/inst_scc.rb
@@ -109,6 +109,11 @@ module Yast
 
     # add the services to libzypp and load (refresh) them
     def add_services(product_services, credentials)
+      # save repositories before refreshing added services (otherwise
+      # pkg-bindings will treat them as removed by the service refresh and
+      # unload them)
+      Pkg.SourceSaveAll
+
       # each registered product
       product_services.each do |product_service|
         # services for the each product


### PR DESCRIPTION
- otherwise pkg-bindings will treat them as removed by the service refresh and
  unload them)
- 3.1.5
