### PR TITLE
fixed undefined method (bnc#872012)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr  4 10:56:53 UTC 2014 - lslezak@suse.cz
+
+- fixed undefined method (bnc#872012)
+- 3.1.29
+
+-------------------------------------------------------------------
 Thu Apr  3 07:17:20 UTC 2014 - lslezak@suse.cz
 
 - avoid client class redefinition (bnc#871651)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.28
+Version:        3.1.29
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_scc.rb
+++ b/src/clients/inst_scc.rb
@@ -518,7 +518,7 @@ module Yast
       end
 
       ret = ::Registration::SccHelpers.catch_registration_errors do
-        product_services = ::Registration::Helpers.run_with_feedback(
+        product_services = Popup.Feedback(
           n_("Registering Product...", "Registering Products...", products.size),
           _("Contacting the SUSE Customer Center server")) do
 


### PR DESCRIPTION
- 3.1.29

`run_with_feedback()` has been moved to `Popup`, this appearance was not updated.
