### PR TITLE
pass also "release_type" product parameter (bnc#873194)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr 14 10:52:16 UTC 2014 - lslezak@suse.cz
+
+- pass also "release_type" product parameter (bnc#873194)
+- 3.1.33
+
+-------------------------------------------------------------------
 Fri Apr 11 12:14:04 UTC 2014 - lslezak@suse.cz
 
 - use generic SLP service name for both SMT and SUSE Manager

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.32
+Version:        3.1.33
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -101,7 +101,8 @@ module Registration
       product_info = {
         "name"    => base_product["name"],
         "arch"    => base_product["arch"],
-        "version" => base_product["version"]
+        "version" => base_product["version"],
+        "release_type" => base_product["flavor"]
       }
 
       log.info("Base product to register: #{product_info}")


### PR DESCRIPTION
- 3.1.33

This is the Yast part of the fix.

Note: SCC uses `release_type` term, while libzypp `flavor` (see https://github.com/yast/yast-pkg-bindings/blob/master/src/Resolvable_Properties.cc#L376 and https://github.com/openSUSE/libzypp/blob/master/zypp/Product.h#L88)
