### PR TITLE
disable rmv 2.1.0 at Travis, it's broken currently...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
-# rvm 2.1.0 is currently broken at Travis, disabling temporarily...
-#  - "2.1.0"
+  - "2.1.0"
   - "2.0.0"
+matrix:
+  allow_failures:
+    - rvm: "2.1.0"
 script: bundle exec rake -f Rakefile.travis


### PR DESCRIPTION
See e.g. https://travis-ci.org/yast/yast-registration/jobs/24249782:

<tt>The command "rvm use 2.1.0 --install --binary --fuzzy" failed and exited with 2 during setup.</tt>
