### PR TITLE
fixed wrong method name causing crash when adding repositories (bnc#875412)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May  2 12:01:45 UTC 2014 - lslezak@suse.cz
+
+- ask user to import an unknown SSL certificate (bnc#874745)
+- fixed wrong method name causing crash when adding repositories
+  (bnc#875412)
+
+-------------------------------------------------------------------
 Wed Apr 30 12:26:52 UTC 2014 - lslezak@suse.cz
 
 - added a nil check when reading the long product name to avoid

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -191,7 +191,7 @@ module Registration
         data
       end
 
-      service_names = product_services.map(&:services).flatten.map(&:name)
+      service_names = product_services.map(&:sources).flatten.map(&:name)
       log.info "Added services: #{service_names.inspect}"
 
       # select only repositories belonging to the product services

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -62,7 +62,7 @@ describe "Registration::SwMgmt" do
     before do
       service = double
       expect(service).to receive(:name).and_return(service_name)
-      expect(services).to receive(:services).and_return([service])
+      expect(services).to receive(:sources).and_return([service])
 
       expect(yast_pkg).to receive(:SourceGetCurrent).with(false).and_return(repos.keys)
       repos.each do |id, repo|


### PR DESCRIPTION
It's `sources` (not `services`), see https://github.com/SUSE/connect/blob/master/lib/suse/connect/service.rb#L6
