### PR TITLE
small fixes

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,16 @@
 -------------------------------------------------------------------
+Mon May  5 15:54:04 UTC 2014 - lslezak@suse.cz
+
+- initialize the connection object when reading addons
+  (otherwise a "nil" bug appears when going back in the
+  installation workflow)
+- cache the registration server URL (to use the same server when
+  going back)
+- added "nil" check for long product description
+- typo in a logger call
+- 3.1.45
+
+-------------------------------------------------------------------
 Mon May  5 15:34:47 UTC 2014 - jreidinger@suse.com
 
 - add product name when something wrong happen with addon

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.44
+Version:        3.1.45
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_scc.rb
+++ b/src/clients/inst_scc.rb
@@ -115,8 +115,7 @@ module Yast
           # reset the user input in case an exception is raised
           ret = nil
 
-          url = ::Registration::Helpers.registration_url
-          @registration = ::Registration::Registration.new(url)
+          init_registration
 
           ::Registration::SccHelpers.catch_registration_errors do
             distro_target = ::Registration::SwMgmt.find_base_product["register_target"]
@@ -456,7 +455,7 @@ module Yast
 
       addons.each do |addon|
         label = addon.short_name
-        label << " (#{addon.long_name})" unless addon.long_name.empty?
+        label << " (#{addon.long_name})" if addon.long_name && !addon.long_name.empty?
 
         box[box.size] = MinWidth(REG_CODE_WIDTH, InputField(Id(addon.product_ident), label,
             @known_reg_codes.fetch(addon.product_ident, "")))
@@ -569,6 +568,8 @@ module Yast
           "version" => a.version
         }
       end
+
+      init_registration
 
       product_succeed = product.map do |product|
         ::Registration::SccHelpers.catch_registration_errors("#{product["name"]}:") do
@@ -736,6 +737,12 @@ module Yast
       log.info "Starting scc sequence"
       Sequencer.Run(aliases, sequence)
     end
+
+    def init_registration
+      url = ::Registration::Helpers.registration_url
+      @registration = ::Registration::Registration.new(url)
+    end
+
   end unless defined?(InstSccClient)
 end
 

--- a/src/lib/registration/storage.rb
+++ b/src/lib/registration/storage.rb
@@ -53,7 +53,7 @@ module Registration
       end
     end
 
-    class Cache < Struct.new(:available_addons)
+    class Cache < Struct.new(:available_addons, :reg_url)
       include Singleton
     end
 

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -260,7 +260,7 @@ module Registration
         if repo
           yield(repo)
         else
-          log.warning "Repository '#{repo_alias}' was not found, skipping"
+          log.warn "Repository '#{repo_alias}' was not found, skipping"
         end
       end
     end

--- a/test/helpers_spec.rb
+++ b/test/helpers_spec.rb
@@ -18,13 +18,13 @@ describe "Registration::Helpers" do
       stub_const("Yast::Mode", yast_mode)
       stub_const("Yast::Linuxrc", yast_linuxrc)
       stub_const("Yast::WFM", yast_wfm)
+      # reset the cache befor each test
+      ::Registration::Storage::Cache.instance.reg_url = nil
     end
 
     context "at installation" do
       before do
-        allow(yast_mode).to receive(:installation).and_return(true)
-        allow(yast_mode).to receive(:update).and_return(false)
-        allow(yast_mode).to receive(:normal).and_return(false)
+        allow(yast_mode).to receive(:mode).and_return("installation")
       end
 
       context "no local registration server is announced via SLP" do
@@ -65,9 +65,8 @@ describe "Registration::Helpers" do
 
     context "at installed system" do
       before do
-        allow(yast_mode).to receive(:normal).and_return(true)
-        allow(yast_mode).to receive(:update).and_return(false)
-        allow(yast_mode).to receive(:installation).and_return(false)
+        allow(yast_mode).to receive(:mode).and_return("normal")
+
         # FIXME: stub SLP service discovery, later add config file reading
         expect(yast_wfm).to receive(:call).with("discover_registration_services").and_return(nil)
       end


### PR DESCRIPTION
- initialize the connection object when reading addons (otherwise a "nil" bug
  appears when going back in the installation workflow)
- cache the registration server URL (to use the same server when going back)
- added "nil" check for long product description
- typo in a logger call
- 3.1.45
