### PR TITLE
save the repository credentials to /mnt during upgrade (bnc#876151)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May  7 13:17:23 UTC 2014 - lslezak@suse.cz
+
+- Save the repository credentials to /mnt during upgrade (libzypp
+  is already switched to the target system) (bnc#876151)
+- 3.1.49
+
+-------------------------------------------------------------------
 Wed May  7 11:38:30 UTC 2014 - lslezak@suse.cz
 
 - fixed setting the repository status (to properly enable e.g. the

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.48
+Version:        3.1.49
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -146,6 +146,14 @@ module Registration
         credentials_file = Helpers.credentials_from_url(source.url)
 
         if credentials_file
+          if Mode.update
+            # at update libzypp is already switched to /mnt target,
+            # update the path accordingly
+            credentials_file = File.join(Installation.destdir,
+              ::SUSE::Connect::Credentials::DEFAULT_CREDENTIALS_DIR,
+              credentials_file)
+            log.info "Using #{credentials_file} credentials path in update mode"
+          end
           # TODO FIXME: SCC currenly does not return credentials for the service,
           # just reuse the global credentials and save to a different file
           service_credentials = credentials.dup

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -97,6 +97,7 @@ describe "Registration::SwMgmt" do
       SUSE::Connect::Service.new({service_name => service_url}, ["SLES12-Pool"],
         ["SLES12-Pool"])
     end
+    let(:yast_mode) { double("Yast::Mode") }
 
     before do
       expect(yast_pkg).to receive(:SourceSaveAll).and_return(true).twice
@@ -112,6 +113,9 @@ describe "Registration::SwMgmt" do
       repos.each do |id, repo|
         allow(yast_pkg).to receive(:SourceGeneralData).with(id).and_return(repo)
       end
+
+      stub_const("Yast::Mode", yast_mode)
+      expect(yast_mode).to receive(:update).and_return(false)
     end
 
     it "it creates a new service if the service does not exist yet" do


### PR DESCRIPTION
libzypp is already switched to the target system
- 3.1.49
