### PR TITLE
fixed accepting more than one extension EULA (bnc#881078)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun  3 16:08:38 UTC 2014 - lslezak@suse.cz
+
+- fixed accepting more than one extension EULA (bnc#881078)
+- 3.1.64
+
+-------------------------------------------------------------------
 Tue Jun  3 12:38:47 UTC 2014 - jsrain@suse.cz
 
 - UX improvements for registration server selection (bnc#878649)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.63
+Version:        3.1.64
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/addon_eula_dialog.rb
+++ b/src/lib/registration/ui/addon_eula_dialog.rb
@@ -100,6 +100,7 @@ module Registration
           action = "abort"
           ret = Yast::ProductLicense.HandleLicenseDialogRet(arg_ref(eulas), base_product, action)
           log.debug "EULA dialog result: #{ret}"
+          Yast::ProductLicense.CleanUp()
 
           accepted = ret == :accepted
           log.info "EULA accepted: #{accepted}"


### PR DESCRIPTION
`ProductLicense` module needs to be reset after use otherwise the next call gets broken (it expects a widget with the previous license). 
