### PR TITLE
Allow starting the module directly at the extension selection (bnc#888566)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 18 13:34:05 UTC 2014 - lslezak@suse.cz
+
+- allow starting the module directly at the extension selection
+  screen when invoked from "repositories" Yast module (bnc#888566)
+- 3.1.105
+
+-------------------------------------------------------------------
 Mon Aug 18 13:49:45 CEST 2014 - schubi@suse.de
 
 - Autoyast: Moving registration to first stage of installation.

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.104
+Version:        3.1.105
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_scc.rb
+++ b/src/clients/inst_scc.rb
@@ -589,7 +589,7 @@ module Yast
       }
 
       sequence = {
-        "ws_start" => "check",
+        "ws_start" => workflow_start,
         "check" => {
           :auto       => :auto,
           :abort      => :abort,
@@ -628,6 +628,13 @@ module Yast
 
       log.info "Starting scc sequence"
       Sequencer.Run(aliases, sequence)
+    end
+
+    # which dialog should be displayed at start
+    def workflow_start
+      log.debug "WFM.Args: #{WFM.Args}"
+      WFM.Args.include?("select_extensions") && Registration::Registration.is_registered? ?
+        "select_addons" : "check"
     end
 
     def init_registration


### PR DESCRIPTION
...when invoked from "repositories" Yast module
- 3.1.105
