### PR TITLE
Check for old SMT server API when registration fails (bnc#889503)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 19 14:17:23 UTC 2014 - lslezak@suse.cz
+
+- check for old SMT server API when registration fails, display
+  error about outdated SMT server (bnc#889503)
+- 3.1.106
+
+-------------------------------------------------------------------
 Mon Aug 18 13:34:05 UTC 2014 - lslezak@suse.cz
 
 - allow starting the module directly at the extension selection

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.105
+Version:        3.1.106
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/downloader.rb
+++ b/src/lib/registration/downloader.rb
@@ -26,6 +26,7 @@ require "yast"
 require "net/http"
 require "uri"
 require "openssl"
+require "registration/exceptions"
 
 module Registration
 
@@ -69,7 +70,7 @@ module Registration
         download_file(location, insecure: insecure, redirection_count: redirection_count - 1)
       else
         log.error "HTTP request failed: Error #{response.code}:#{response.message}: #{response.body}"
-        raise "Downloading #{file_url} failed: #{response.message}"
+        raise DownloadError, "Downloading #{file_url} failed: #{response.message}"
       end
     end
 

--- a/src/lib/registration/exceptions.rb
+++ b/src/lib/registration/exceptions.rb
@@ -33,4 +33,7 @@ module Registration
       @service = service
     end
   end
+
+  class DownloadError < RuntimeError
+  end
 end

--- a/src/lib/registration/smt_status.rb
+++ b/src/lib/registration/smt_status.rb
@@ -1,0 +1,50 @@
+
+require "uri"
+require "yast"
+
+require "registration/downloader"
+
+module Registration
+
+  # Check SMT server status, check supported API
+  class SmtStatus
+    include Yast::Logger
+
+    attr_reader :url, :insecure
+
+    def initialize(url, insecure: false)
+      @url = url.is_a?(URI) ? url : URI(url)
+      @insecure = insecure
+    end
+
+    # check whether (old) NCC API is present at the server
+    def ncc_api_present?
+      download_url = ncc_api_url
+      log.info "Checking NCC API presence: #{download_url}"
+
+      begin
+        Downloader.download(download_url, insecure: insecure)
+        log.info "NCC API found"
+        return true
+      rescue DownloadError
+        log.info "Download failed, NCC API probably not present"
+        return false
+      end
+    end
+
+    private
+
+    # created NCC API URL for testing API presence
+    def ncc_api_url
+      # create an URI copy, the URL will be modified
+      ncc_url = url.dup
+
+      # NCC API should provide "/center/regsvc?command=listproducts" query
+      ncc_url.path = "/center/regsvc"
+      ncc_url.query = "command=listproducts"
+
+      ncc_url
+    end
+  end
+
+end

--- a/test/downloader_spec.rb
+++ b/test/downloader_spec.rb
@@ -45,7 +45,7 @@ describe "Registration::Downloader" do
       expect_any_instance_of(Net::HTTP).to receive(:request).
         with(an_instance_of(Net::HTTP::Get)).and_return(index)
 
-      expect{Registration::Downloader.download(url)}.to raise_error RuntimeError,
+      expect{Registration::Downloader.download(url)}.to raise_error Registration::DownloadError,
         "Downloading #{url} failed: Not Found"
     end
 

--- a/test/smt_status_spec.rb
+++ b/test/smt_status_spec.rb
@@ -1,0 +1,35 @@
+#! /usr/bin/env rspec
+
+require_relative "spec_helper"
+require_relative "yast_stubs"
+
+describe "Registration::SmtStatus" do
+  before do
+    stub_yast_require
+    require "registration/smt_status"
+  end
+
+  let(:url) { "https://example.com" }
+  subject { Registration::SmtStatus.new(url) }
+
+  describe "#ncc_api_present?" do
+    let(:expected_url) { URI("#{url}/center/regsvc?command=listproducts") }
+
+    it "returns true when /center/regsvc?command=listproducts returns OK" do
+      expect(Registration::Downloader).to receive(:download).
+        with(expected_url, :insecure => false).
+        and_return(true)
+
+      expect(subject.ncc_api_present?).to be_true
+    end
+
+    it "returns false otherwise" do
+      expect(Registration::Downloader).to receive(:download).
+        with(expected_url, :insecure => false).
+        and_raise(Registration::DownloadError)
+
+      expect(subject.ncc_api_present?).to be_false
+    end
+  end
+
+end


### PR DESCRIPTION
display error about outdated SMT server
- 3.1.106
