### PR TITLE
Read proxy credentials from .curlrc file (bnc#885957)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 28 14:06:14 UTC 2014 - lslezak@suse.cz
+
+- read proxy credentials from .curlrc file (bnc#885957)
+- do not ask for network configuration in Autoyast mode
+- 3.1.112
+
+-------------------------------------------------------------------
 Tue Aug 26 18:34:07 UTC 2014 - ancor@suse.com
 
 - Added proper handling for the user clicking the cancel button in

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.111
+Version:        3.1.112
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -66,9 +66,9 @@ module Registration
         true
       rescue SocketError, Errno::ENETUNREACH => e
         log.error "Network error: #{e.class}: #{e.message}"
-        # Error popup
-        if Yast::Mode.installation || Yast::Mode.update
+        if (Yast::Mode.installation || Yast::Mode.update) && !(Yast::Mode.autoinst || Yast::Mode.autoupgrade)
           if Yast::Popup.YesNo(
+              # Error popup
               _("Network is not configured, the registration server cannot be reached.\n" +
                   "Do you want to configure the network now?"))
 

--- a/src/lib/registration/downloader.rb
+++ b/src/lib/registration/downloader.rb
@@ -27,6 +27,7 @@ require "net/http"
 require "uri"
 require "openssl"
 require "registration/exceptions"
+require "suse/toolkit/curlrc_dotfile"
 
 module Registration
 
@@ -46,6 +47,12 @@ module Registration
 
       file_url = URI(file_url) unless file_url.is_a?(URI)
       http = Net::HTTP.new(file_url.host, file_url.port)
+
+      if http.proxy?
+        log.info "Reading proxy credentials..."
+        http.proxy_user = SUSE::Toolkit::CurlrcDotfile.new.username
+        http.proxy_pass = SUSE::Toolkit::CurlrcDotfile.new.password
+      end
 
       # switch to HTTPS connection if needed
       if file_url.is_a? URI::HTTPS


### PR DESCRIPTION
- do not ask for network configuration in Autoyast mode
- tested in the latest build   :white_check_mark: 
- 3.1.112
