### PR TITLE
Fixed fingerprint export (bnc#897449)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon Sep 22 12:09:53 UTC 2014 - lslezak@suse.cz
+
+- fixed crash at AutoYast export at the end of installation when
+  a SMT certificate has been imported (export the fingerprint value
+  instead of the Fingerprint object which cannot be serialized to
+  Autoyast XML) (bnc#897449)
+- 3.1.123
+
+-------------------------------------------------------------------
 Tue Sep 16 08:54:54 UTC 2014 - lslezak@suse.cz
 
 - properly mark children addons as registered when loading the

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.122
+Version:        3.1.123
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -224,7 +224,7 @@ module Registration
       end
 
       # remember the imported certificate fingerprint for Autoyast export
-      Storage::InstallationOptions.instance.imported_cert_sha256_fingerprint = cert.fingerprint(Fingerprint::SHA256)
+      Storage::InstallationOptions.instance.imported_cert_sha256_fingerprint = cert.fingerprint(Fingerprint::SHA256).value
       log.info "Certificate import result: #{result}"
       true
     end


### PR DESCRIPTION
`Fingerprint` object was returned in the `Export` function instead of the string value.
