### PR TITLE
fixed failure in AutoYast autoupgrade mode (bnc#899168)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Oct  2 15:06:22 UTC 2014 - lslezak@suse.cz
+
+- fixed failure in AutoYast autoupgrade mode when the upgraded
+  system was not registered (in that case the system is newly
+  registered) (bnc#899168)
+- 3.1.126
+
+-------------------------------------------------------------------
 Mon Sep 29 08:42:17 UTC 2014 - lslezak@suse.cz
 
 - fixed AutoYast autoupgrade - use the SMT server from the AutoYast

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.125
+Version:        3.1.126
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/scc_auto.rb
+++ b/src/clients/scc_auto.rb
@@ -159,8 +159,8 @@ module Yast
       # nil = use the default URL
       switch_registration(url)
 
-      # try updating the registration in AutoUpgrade mode
-      if Mode.update
+      # update the registration in AutoUpgrade mode if the old system was registered
+      if Mode.update && old_system_registered?
         updated = update_registration
         log.info "Registration updated: #{updated}"
         return updated
@@ -261,9 +261,6 @@ module Yast
     end
 
     def update_registration
-      # the old system was not registered
-      return false unless prepare_update
-
       return false unless update_system_registration
       return false unless update_base_product
       return false unless update_addons
@@ -298,7 +295,7 @@ module Yast
       ::Registration::SwMgmt.select_addon_products
     end
 
-    def prepare_update
+    def old_system_registered?
       ::Registration::SwMgmt.copy_old_credentials(Installation.destdir)
 
       # update the registration using the old credentials


### PR DESCRIPTION
when the upgraded system was not registered the upgrade obviously failed
(rather do a new registration in that case)
- 3.1.126
