### PR TITLE
Collect product rename also for the base product (bsc#925700)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr  8 15:31:18 UTC 2015 - lslezak@suse.cz
+
+- collect product rename also for the base product (the internal
+  SLES-for-SAP product identifier has been changed) (bsc#925700)
+- 3.1.129.1
+
+-------------------------------------------------------------------
 Thu Nov  6 08:32:36 UTC 2014 - lslezak@suse.cz
 
 - display correct default EULA translation for extensions/modules

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.129
+Version:        3.1.129.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -68,6 +68,9 @@ module Registration
         log.info "Register product result: #{service}"
         set_registered(product_ident)
 
+        renames = collect_renames([service.product])
+        SwMgmt.update_product_renames(renames)
+
         service
       end
     end
@@ -78,6 +81,9 @@ module Registration
         service = SUSE::Connect::YaST.upgrade_product(product_ident, params)
         log.info "Upgrade product result: #{service}"
         set_registered(product_ident)
+
+        renames = collect_renames([service.product])
+        SwMgmt.update_product_renames(renames)
 
         service
       end
@@ -225,12 +231,15 @@ module Registration
       default_params.merge(params)
     end
 
-    def collect_renames(addons)
+    # collect product renames
+    # @param products [Array<SUSE::Connect::Remote::Product>] remote products received from SCC
+    # @return [Hash] hash with product renames: { old_name => new_name }
+    def collect_renames(products)
       renames = {}
 
-      addons.each do |addon|
-        if addon.former_identifier && addon.identifier != addon.former_identifier
-          renames[addon.former_identifier] = addon.identifier
+      products.each do |product|
+        if product.former_identifier && product.identifier != product.former_identifier
+          renames[product.former_identifier] = product.identifier
         end
       end
 

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -36,10 +36,12 @@ describe "Registration::Registration" do
 
     it "adds the selected product and returns added zypp services" do
       product = {
-        "arch"         => "x86_64",
-        "name"         => "sle-sdk",
-        "version"      => "12",
-        "release_type" => nil
+        "arch"              => "x86_64",
+        "name"              => "sle-sdk",
+        "version"           => "12",
+        "release_type"      => nil,
+        "identifier"        => "SLES_SAP",
+        "former_identifier" => "SUSE_SLES_SAP"
       }
 
       service_data = {
@@ -57,6 +59,10 @@ describe "Registration::Registration" do
       expect(Registration::Addon).to receive(:find_all).and_return(available_addons)
       expect(available_addons.find { |addon| addon.identifier == "sle-sdk" }).to \
         receive(:registered)
+
+      # the received product renames are passed to the software management
+      expect(Registration::SwMgmt).to receive(:update_product_renames)
+        .with("SUSE_SLES_SAP" => "SLES_SAP")
 
       allow(File).to receive(:exist?).with(
         SUSE::Connect::Credentials::GLOBAL_CREDENTIALS_FILE).and_return(true)


### PR DESCRIPTION
- the internal SLES-for-SAP product identifier has been changed

- 3.1.129.1

See the details in https://bugzilla.novell.com/show_bug.cgi?id=925700
