### PR TITLE
Support for re-registering extensions and modules (FATE#318800)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 14 13:31:12 UTC 2015 - lslezak@suse.cz
+
+- added support for re-registering extensions and modules
+  (FATE#318800)
+- 3.1.131
+
+-------------------------------------------------------------------
 Fri Apr 24 06:56:06 UTC 2015 - lslezak@suse.cz
 
 - allow registering add-ons installed from media (fate#318505)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.130
+Version:        3.1.131
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_scc.rb
+++ b/src/clients/inst_scc.rb
@@ -250,7 +250,7 @@ module Yast
     def workflow_aliases
       {
         # skip this when going back
-        "check"                  => [->() { registration_check }, true],
+        "check"                  => ->() { registration_check },
         "register"               => ->() { register_base_system },
         "select_addons"          => ->() { select_addons },
         "select_addons_rereg"    => ->() { select_addons(reregistration: true) },
@@ -298,6 +298,7 @@ module Yast
         },
         "select_addons_rereg"    => {
           abort:  :abort,
+          skip:   "check",
           cancel: "check",
           next:   "reregister_addons"
         },

--- a/src/clients/inst_scc.rb
+++ b/src/clients/inst_scc.rb
@@ -37,7 +37,8 @@ require "registration/url_helpers"
 require "registration/registration"
 require "registration/registration_ui"
 require "registration/ui/addon_eula_dialog"
-require "registration/ui/addon_selection_dialog"
+require "registration/ui/addon_selection_registration_dialog"
+require "registration/ui/addon_selection_reregistration_dialog"
 require "registration/ui/addon_reg_codes_dialog"
 require "registration/ui/registered_system_dialog"
 require "registration/ui/base_system_registration_dialog"
@@ -138,7 +139,7 @@ module Yast
       @selected_addons = Registration::Addon.selected
       ::Registration::Storage::InstallationOptions.instance.selected_addons = @selected_addons
 
-      Registration::UI::AddonSelectionDialog.run(@registration)
+      Registration::UI::AddonSelectionRegistrationDialog.run(@registration)
     end
 
     # load available addons from SCC server

--- a/src/clients/inst_scc.rb
+++ b/src/clients/inst_scc.rb
@@ -73,7 +73,6 @@ module Yast
       Yast.import "Popup"
       Yast.import "GetInstArgs"
       Yast.import "Wizard"
-      Yast.import "Report"
       Yast.import "Mode"
       Yast.import "Stage"
       Yast.import "Label"
@@ -162,28 +161,12 @@ module Yast
       registration_ui.register_addons(@selected_addons, @known_reg_codes)
     end
 
-    def report_no_base_product
-      # error message
-      msg = _("The base product was not found,\ncheck your system.") + "\n\n"
-
-      if Stage.initial
-        # TRANSLATORS: %s = bugzilla URL
-        msg += _("The installation medium or the installer itself is seriously broken.\n" \
-            "Report a bug at %s.") % "https://bugzilla.suse.com"
-      else
-        msg += _("Make sure a product is installed and /etc/products.d/baseproduct\n" \
-            "is a symlink pointing to the base product .prod file.")
-      end
-
-      Report.Error(msg)
-    end
-
     # do some sanity checks and decide which workflow will be used
     # return [Symbol] :update
     def registration_check
       # check the base product at start to avoid problems later
       if ::Registration::SwMgmt.find_base_product.nil?
-        report_no_base_product
+        ::Registration::Helpers.report_no_base_product
         return Mode.normal ? :abort : :auto
       end
 

--- a/src/lib/registration/helpers.rb
+++ b/src/lib/registration/helpers.rb
@@ -40,6 +40,8 @@ module Registration
     Yast.import "Installation"
     Yast.import "Linuxrc"
     Yast.import "Mode"
+    Yast.import "Stage"
+    Yast.import "Report"
     Yast.import "SlpService"
 
     # reg. code replacement
@@ -222,6 +224,22 @@ module Registration
       end
 
       filtered
+    end
+
+    def self.report_no_base_product
+      # error message
+      msg = _("The base product was not found,\ncheck your system.") + "\n\n"
+
+      if Yast::Stage.initial
+        # TRANSLATORS: %s = bugzilla URL
+        msg += _("The installation medium or the installer itself is seriously broken.\n" \
+            "Report a bug at %s.") % "https://bugzilla.suse.com"
+      else
+        msg += _("Make sure a product is installed and /etc/products.d/baseproduct\n" \
+            "is a symlink pointing to the base product .prod file.")
+      end
+
+      Yast::Report.Error(msg)
     end
   end
 end

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -6,7 +6,7 @@ require "registration/addon_sorter"
 module Registration
   module UI
     # this class displays and runs the dialog with addon selection
-    class AddonSelectionDialog
+    class AddonSelectionBaseDialog
       include Yast::Logger
       include Yast::I18n
       include Yast::UIShortcuts
@@ -20,15 +20,6 @@ module Registration
       Yast.import "Wizard"
       Yast.import "Stage"
 
-      # display and run the dialog with addon selection
-      # @param registration [Registration::Registration] use this Registration object for
-      #   communication with SCC
-      # @return [Symbol] user input symbol
-      def self.run(registration)
-        dialog = AddonSelectionDialog.new(registration)
-        dialog.run
-      end
-
       # constructor
       # @param registration [Registration::Registration] use this Registration object for
       #   communication with SCC
@@ -38,6 +29,8 @@ module Registration
 
         # sort the addons
         @addons.sort!(&::Registration::ADDON_SORTER)
+        
+        @old_selection = Addon.selected.dup
 
         log.info "Available addons: #{@addons}"
       end
@@ -45,39 +38,21 @@ module Registration
       # display the extension selection dialog and wait for a button click
       # @return [Symbol] user input (:import, :cancel)
       def run
-        Wizard.SetContents(
-          # dialog title
-          _("Extension and Module Selection"),
-          content,
-          # help text (1/3)
-          _("<p>Here you can select available extensions and modules for your"\
-              "system.</p>") +
-          # help text (2/3)
-          _("<p>Please note, that some extensions or modules might need "\
-              "specific registration code.</p>") +
-          # help text (3/3)
-          _("<p>If you want to remove any extension or module you need to log"\
-              "into the SUSE Customer Center and remove them manually there.</p>"),
-          # always enable Back/Next, the dialog cannot be the first in workflow
-          true,
-          true
-        )
-
-        @old_selection = Addon.selected.dup
-
-        reactivate_dependencies
-
-        handle_dialog
+        raise "Not implented"
       end
 
       private
+
+      def heading
+        raise "Not implented"
+      end
 
       # create the main dialog definition
       # @return [Yast::Term] the main UI dialog term
       def content
         VBox(
           VStretch(),
-          Left(Heading(_("Available Extensions and Modules"))),
+          Left(Heading(heading)),
           addons_box,
           Left(Label(_("Details"))),
           MinHeight(8,

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -47,6 +47,10 @@ module Registration
         raise "Not implented"
       end
 
+      def addon_selected?(_addon)
+        raise "Not implented"
+      end
+
       # create the main dialog definition
       # @return [Yast::Term] the main UI dialog term
       def content
@@ -128,10 +132,7 @@ module Registration
         # (%s is an extension name)
         label = addon.available? ? addon.label : (_("%s (not available)") % addon.label)
 
-        CheckBox(Id(addon.identifier),
-          Opt(:notify),
-          label,
-          addon.selected? || addon.registered?)
+        CheckBox(Id(addon.identifier), Opt(:notify), label, addon_selected?(addon))
       end
 
       # the main event loop - handle the user in put in the dialog

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -36,20 +36,25 @@ module Registration
         log.info "Available addons: #{@addons}"
       end
 
+      # reimplement this in a subclass
       # display the extension selection dialog and wait for a button click
-      # @return [Symbol] user input (:import, :cancel)
+      # @return [Symbol] user input
       def run
-        raise "Not implented"
+        raise "Not implemented"
       end
 
       private
 
+      # reimplement this in a subclass
+      # @return [String] dialog head
       def heading
-        raise "Not implented"
+        raise "Not implemented"
       end
 
+      # reimplement this in a subclass
+      # @return [Boolean] is the addon selected?
       def addon_selected?(_addon)
-        raise "Not implented"
+        raise "Not implemented"
       end
 
       # create the main dialog definition

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -1,3 +1,4 @@
+# Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
 
 require "yast"
 require "registration/addon"

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -225,6 +225,17 @@ module Registration
 
         true
       end
+
+      # shared part of the help text
+      # @return [String] translated help text
+      def generic_help_text
+        # help text (2/3)
+        _("<p>Please note, that some extensions or modules might need "\
+            "specific registration code.</p>") +
+          # help text (3/3)
+          _("<p>If you want to remove any extension or module you need to log"\
+              "into the SUSE Customer Center and remove them manually there.</p>")
+      end
     end
   end
 end

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -29,7 +29,7 @@ module Registration
 
         # sort the addons
         @addons.sort!(&::Registration::ADDON_SORTER)
-        
+
         @old_selection = Addon.selected.dup
 
         log.info "Available addons: #{@addons}"

--- a/src/lib/registration/ui/addon_selection_registration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_registration_dialog.rb
@@ -1,3 +1,4 @@
+# Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
 
 require "registration/ui/addon_selection_base_dialog"
 
@@ -12,6 +13,14 @@ module Registration
       def self.run(registration)
         dialog = AddonSelectionRegistrationDialog.new(registration)
         dialog.run
+      end
+
+      # constructor
+      # @param registration [Registration::Registration] use this Registration object for
+      #   communication with SCC
+      def initialize(registration)
+        textdomain "registration"
+        super(registration)
       end
 
       # display the extension selection dialog and wait for a button click

--- a/src/lib/registration/ui/addon_selection_registration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_registration_dialog.rb
@@ -5,7 +5,6 @@ module Registration
   module UI
     # this class displays and runs the dialog with addon selection
     class AddonSelectionRegistrationDialog < AddonSelectionBaseDialog
-
       # display and run the dialog with addon selection
       # @param registration [Registration::Registration] use this Registration object for
       #   communication with SCC
@@ -44,10 +43,10 @@ module Registration
       end
 
       private
-      
+
       # @return [String] the main dialog label
       def heading
-          _("Available Extensions and Modules")
+        _("Available Extensions and Modules")
       end
 
       # update the enabled/disabled status in UI for dependent addons
@@ -56,7 +55,6 @@ module Registration
           Yast::UI.ChangeWidget(Id(addon.identifier), :Enabled, addon.selectable?)
         end
       end
-
     end
   end
 end

--- a/src/lib/registration/ui/addon_selection_registration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_registration_dialog.rb
@@ -49,6 +49,10 @@ module Registration
         _("Available Extensions and Modules")
       end
 
+      def addon_selected?(addon)
+        addon.selected? || addon.registered?
+      end
+
       # update the enabled/disabled status in UI for dependent addons
       def reactivate_dependencies
         @addons.each do |addon|

--- a/src/lib/registration/ui/addon_selection_registration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_registration_dialog.rb
@@ -24,7 +24,7 @@ module Registration
       end
 
       # display the extension selection dialog and wait for a button click
-      # @return [Symbol] user input (:import, :cancel)
+      # @return [Symbol] user input
       def run
         Wizard.SetContents(
           # dialog title
@@ -58,6 +58,7 @@ module Registration
         _("Available Extensions and Modules")
       end
 
+      # @return [Boolean] is the addon selected?
       def addon_selected?(addon)
         addon.selected? || addon.registered?
       end

--- a/src/lib/registration/ui/addon_selection_registration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_registration_dialog.rb
@@ -32,13 +32,7 @@ module Registration
           content,
           # help text (1/3)
           _("<p>Here you can select available extensions and modules for your"\
-              "system.</p>") +
-          # help text (2/3)
-          _("<p>Please note, that some extensions or modules might need "\
-              "specific registration code.</p>") +
-          # help text (3/3)
-          _("<p>If you want to remove any extension or module you need to log"\
-              "into the SUSE Customer Center and remove them manually there.</p>"),
+              "system.</p>") + generic_help_text,
           # always enable Back/Next, the dialog cannot be the first in workflow
           true,
           true

--- a/src/lib/registration/ui/addon_selection_registration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_registration_dialog.rb
@@ -1,0 +1,62 @@
+
+require "registration/ui/addon_selection_base_dialog"
+
+module Registration
+  module UI
+    # this class displays and runs the dialog with addon selection
+    class AddonSelectionRegistrationDialog < AddonSelectionBaseDialog
+
+      # display and run the dialog with addon selection
+      # @param registration [Registration::Registration] use this Registration object for
+      #   communication with SCC
+      # @return [Symbol] user input symbol
+      def self.run(registration)
+        dialog = AddonSelectionRegistrationDialog.new(registration)
+        dialog.run
+      end
+
+      # display the extension selection dialog and wait for a button click
+      # @return [Symbol] user input (:import, :cancel)
+      def run
+        Wizard.SetContents(
+          # dialog title
+          _("Extension and Module Selection"),
+          content,
+          # help text (1/3)
+          _("<p>Here you can select available extensions and modules for your"\
+              "system.</p>") +
+          # help text (2/3)
+          _("<p>Please note, that some extensions or modules might need "\
+              "specific registration code.</p>") +
+          # help text (3/3)
+          _("<p>If you want to remove any extension or module you need to log"\
+              "into the SUSE Customer Center and remove them manually there.</p>"),
+          # always enable Back/Next, the dialog cannot be the first in workflow
+          true,
+          true
+        )
+
+        @old_selection = Addon.selected.dup
+
+        reactivate_dependencies
+
+        handle_dialog
+      end
+
+      private
+      
+      # @return [String] the main dialog label
+      def heading
+          _("Available Extensions and Modules")
+      end
+
+      # update the enabled/disabled status in UI for dependent addons
+      def reactivate_dependencies
+        @addons.each do |addon|
+          Yast::UI.ChangeWidget(Id(addon.identifier), :Enabled, addon.selectable?)
+        end
+      end
+
+    end
+  end
+end

--- a/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
@@ -38,13 +38,7 @@ module Registration
           content,
           # help text (1/3)
           _("<p>Here you can select extensions and modules which will be "\
-              "registered again.</p>") +
-          # help text (2/3)
-          _("<p>Please note, that some extensions or modules might need "\
-              "specific registration code.</p>") +
-          # help text (3/3)
-          _("<p>If you want to remove any extension or module you need to log"\
-              "into the SUSE Customer Center and remove them manually there.</p>"),
+              "registered again.</p>") + generic_help_text,
           # always enable Back/Next, the dialog cannot be the first in workflow
           true,
           true

--- a/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
@@ -1,3 +1,4 @@
+# Copyright (c) 2015 SUSE LINUX GmbH, Nuernberg, Germany.
 
 require "registration/ui/addon_selection_base_dialog"
 
@@ -18,6 +19,8 @@ module Registration
       # @param registration [Registration::Registration] use this Registration object for
       #   communication with SCC
       def initialize(registration)
+        textdomain "registration"
+
         super(registration)
 
         # filter out the unregistered addons

--- a/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
@@ -1,0 +1,68 @@
+
+require "registration/ui/addon_selection_base_dialog"
+
+module Registration
+  module UI
+    # this class displays and runs the dialog with addon selection
+    class AddonSelectionReregistrationDialog < AddonSelectionBaseDialog
+
+      # display and run the dialog with addon selection
+      # @param registration [Registration::Registration] use this Registration object for
+      #   communication with SCC
+      # @return [Symbol] user input symbol
+      def self.run(registration)
+        dialog = AddonSelectionReregistrationDialog.new(registration)
+        dialog.run
+      end
+
+      # constructor
+      # @param registration [Registration::Registration] use this Registration object for
+      #   communication with SCC
+      def initialize(registration)
+        super(registration)
+
+        # filter out the unregistered addons
+        @addons.select!(&:registered)
+
+        log.info "Registered addons: #{@addons}"
+      end
+
+      # display the extension selection dialog and wait for a button click
+      # @return [Symbol] user input (:import, :cancel)
+      def run
+        Wizard.SetContents(
+          # dialog title
+          _("Extension and Module Re-registration"),
+          content,
+          # help text (1/3)
+          _("<p>Here you can select extensions and modules which will be "\
+              "registered again.</p>") +
+          # help text (2/3)
+          _("<p>Please note, that some extensions or modules might need "\
+              "specific registration code.</p>") +
+          # help text (3/3)
+          _("<p>If you want to remove any extension or module you need to log"\
+              "into the SUSE Customer Center and remove them manually there.</p>"),
+          # always enable Back/Next, the dialog cannot be the first in workflow
+          true,
+          true
+        )
+
+        handle_dialog
+      end
+
+      private
+      
+      # @return [String] the main dialog label
+      def heading
+          _("Registered Extensions and Modules")
+      end
+
+      # empty implementation, allow reregistration of a dependant addon
+      # without reregistering its parent
+      def reactivate_dependencies
+      end
+
+    end
+  end
+end

--- a/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
@@ -30,7 +30,7 @@ module Registration
       end
 
       # display the extension selection dialog and wait for a button click
-      # @return [Symbol] user input (:import, :cancel)
+      # @return [Symbol] user input
       def run
         Wizard.SetContents(
           # dialog title
@@ -60,6 +60,7 @@ module Registration
         _("Registered Extensions and Modules")
       end
 
+      # @return [Boolean] is the addon selected?
       def addon_selected?(addon)
         addon.selected?
       end

--- a/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
@@ -21,7 +21,7 @@ module Registration
         super(registration)
 
         # filter out the unregistered addons
-        @addons.select!(&:registered)
+        @addons.select!(&:registered?)
 
         log.info "Registered addons: #{@addons}"
       end
@@ -55,6 +55,10 @@ module Registration
       # @return [String] the main dialog label
       def heading
         _("Registered Extensions and Modules")
+      end
+
+      def addon_selected?(addon)
+        addon.selected?
       end
 
       # empty implementation, allow reregistration of a dependant addon

--- a/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
@@ -5,7 +5,6 @@ module Registration
   module UI
     # this class displays and runs the dialog with addon selection
     class AddonSelectionReregistrationDialog < AddonSelectionBaseDialog
-
       # display and run the dialog with addon selection
       # @param registration [Registration::Registration] use this Registration object for
       #   communication with SCC
@@ -52,17 +51,16 @@ module Registration
       end
 
       private
-      
+
       # @return [String] the main dialog label
       def heading
-          _("Registered Extensions and Modules")
+        _("Registered Extensions and Modules")
       end
 
       # empty implementation, allow reregistration of a dependant addon
       # without reregistering its parent
       def reactivate_dependencies
       end
-
     end
   end
 end

--- a/src/lib/registration/ui/autoyast_config_workflow.rb
+++ b/src/lib/registration/ui/autoyast_config_workflow.rb
@@ -6,7 +6,7 @@ require "registration/url_helpers"
 
 require "registration/ui/autoyast_addon_dialog"
 require "registration/ui/autoyast_config_dialog"
-require "registration/ui/addon_selection_dialog"
+require "registration/ui/addon_selection_registration_dialog"
 require "registration/ui/addon_eula_dialog"
 require "registration/ui/addon_reg_codes_dialog"
 
@@ -111,7 +111,7 @@ module Registration
             ::Registration::Addon.find_all(registration).each(&:unregistered)
           end
 
-          ret = AddonSelectionDialog.run(registration)
+          ret = AddonSelectionRegistrationDialog.run(registration)
         end
 
         success ? ret : :addons

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -52,10 +52,7 @@ module Registration
         )
 
         # disable the input fields when already registered
-        if Registration.is_registered? && !Yast::Mode.normal
-          Yast::UI.ChangeWidget(Id(:email), :Enabled, false)
-          Yast::UI.ChangeWidget(Id(:reg_code), :Enabled, false)
-        end
+        disable_widgets if Registration.is_registered? && !Yast::Mode.normal
 
         handle_dialog
       end
@@ -66,6 +63,11 @@ module Registration
 
       # width of reg code input field widget
       REG_CODE_WIDTH = 33
+
+      def disable_widgets
+        Yast::UI.ChangeWidget(Id(:email), :Enabled, false)
+        Yast::UI.ChangeWidget(Id(:reg_code), :Enabled, false)
+      end
 
       # content for the main registration dialog
       # @return [Yast::Term]  UI term

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -47,7 +47,7 @@ module Registration
           _("Registration"),
           content,
           help_text,
-          Yast::GetInstArgs.enable_back,
+          Yast::GetInstArgs.enable_back || (Yast::Mode.normal && Registration.is_registered?),
           Yast::GetInstArgs.enable_next || Yast::Mode.normal
         )
 
@@ -157,7 +157,7 @@ module Registration
           when :next
             ret = handle_registration
           when :abort
-            ret = nil unless Yast::Popup.ConfirmAbort(:painless)
+            ret = nil unless Yast::Mode.normal || Yast::Popup.ConfirmAbort(:painless)
           when :skip
             ret = nil unless confirm_skipping
           end

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -81,6 +81,7 @@ module Registration
           PushButton(Id(:local_server), _("&Local Registration Server...")),
           VSpacing(Yast::UI.TextMode ? 0 : 3),
           skip_button,
+          reregister_extensions_button,
           VStretch()
         )
       end
@@ -91,6 +92,16 @@ module Registration
       def skip_button
         # button label
         Registration.is_registered? ? Empty() : PushButton(Id(:skip), _("&Skip Registration"))
+      end
+
+      def reregister_extensions_button
+        # display the addon re-registration button only in registered installed system
+        return Empty() unless Registration.is_registered? && Yast::Mode.normal
+
+        VBox(
+          VSpacing(Yast::UI.TextMode ? 1 : 4),
+          PushButton(Id(:reregister_addons), _("&Register Extensions or Modules Again"))
+        )
       end
 
       # part of the main dialog definition - the base product details
@@ -133,7 +144,7 @@ module Registration
       # @return [Symbol] the user input
       def handle_dialog
         ret = nil
-        continue_buttons = [:next, :back, :cancel, :abort, :skip]
+        continue_buttons = [:next, :back, :cancel, :abort, :skip, :reregister_addons]
 
         until continue_buttons.include?(ret)
           ret = Yast::UI.UserInput

--- a/src/lib/registration/ui/registered_system_dialog.rb
+++ b/src/lib/registration/ui/registered_system_dialog.rb
@@ -67,10 +67,10 @@ module Registration
           Heading(_("The system is already registered.")),
           VSpacing(2),
           # button label
-          PushButton(Id(:register), _("Register Again")),
+          PushButton(Id(:extensions), _("Select Extensions")),
           VSpacing(1),
           # button label
-          PushButton(Id(:extensions), _("Select Extensions"))
+          PushButton(Id(:register), _("Register Again"))
         )
       end
     end

--- a/test/addon_selection_dialog_test.rb
+++ b/test/addon_selection_dialog_test.rb
@@ -1,7 +1,7 @@
 require_relative "spec_helper"
 
-describe Registration::UI::AddonSelectionDialog do
-  subject { Registration::UI::AddonSelectionDialog }
+describe Registration::UI::AddonSelectionRegistrationDialog do
+  subject { Registration::UI::AddonSelectionRegistrationDialog }
 
   before(:each) do
     # generic UI stubs for the wizard dialog

--- a/test/helpers_spec.rb
+++ b/test/helpers_spec.rb
@@ -243,4 +243,28 @@ describe "Registration::Helpers" do
       expect(test).to eq("addons" => [{ "reg_code" => "foo" }, { "reg_code" => "bar" }])
     end
   end
+
+  describe ".report_no_base_product" do
+    context "in installation" do
+      before do
+        allow(Yast::Stage).to receive(:initial).and_return(true)
+      end
+
+      it "Reports an error about broken medium" do
+        expect(Yast::Report).to receive(:Error).with(/base product was not found/)
+        Registration::Helpers.report_no_base_product
+      end
+    end
+
+    context "in installed system" do
+      before do
+        allow(Yast::Stage).to receive(:initial).and_return(false)
+      end
+
+      it "Reports an error about missing base product" do
+        expect(Yast::Report).to receive(:Error).with(/Make sure a product is installed/)
+        Registration::Helpers.report_no_base_product
+      end
+    end
+  end
 end


### PR DESCRIPTION
Note: There is still one part missing: the old subscription should be "unlinked" before registering an extension again. But this requires an extension in the `connect` gem which won't be ready in this sprint, I'll add it later when it's ready.