### PR TITLE
Use "zypper dup --no-vendor-change" equivalent

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul  7 13:02:23 UTC 2015 - lslezak@suse.cz
+
+- Use "zypper dup --no-vendor-change" equivalent for online
+  migration (FATE#319138)
+- 3.1.136
+
+-------------------------------------------------------------------
 Tue Jun 30 14:28:43 UTC 2015 - lslezak@suse.cz
 
 - added support for online migration, the registration part handles

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -28,8 +28,8 @@ License:        GPL-2.0
 
 # Popup.Feedback
 Requires:       yast2 >= 3.1.26
-# fixed service removal
-Requires:       yast2-pkg-bindings >= 3.1.25
+# "allowVendorChange" option in Pkg.SetSolverFlags()
+Requires:       yast2-pkg-bindings >= 3.1.26
 # N_() method
 Requires:       yast2-ruby-bindings >= 3.1.12
 Requires:       rubygem(suse-connect) >= 0.2.18

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.135
+Version:        3.1.136
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/migration_repositories.rb
+++ b/src/lib/registration/migration_repositories.rb
@@ -71,9 +71,10 @@ module Registration
         # the status if it is different than expected
         next if repositories.include?(repo) == repo_data["enabled"]
 
-        new_state_msg = repo_data["enabled"] ? "Disabling" : "Enabling"
-        log.info "#{new_state_msg} repository #{repo_data["alias"]}"
-        Yast::Pkg.SourceSetEnabled(repo, !repo_data["enabled"])
+        # switch the repository state
+        new_state = !repo_data["enabled"]
+        log.info "#{new_state ? "Enabling" : "Disabling"} repository #{repo_data["alias"]}"
+        Yast::Pkg.SourceSetEnabled(repo, new_state)
       end
 
       activate_solver

--- a/src/lib/registration/migration_repositories.rb
+++ b/src/lib/registration/migration_repositories.rb
@@ -44,7 +44,7 @@ module Registration
     # does any configured service contain an update repo?
     # @return [Boolean] true if at least one service repository is an update
     #   repository
-    def service_update_repo?
+    def service_with_update_repo?
       services_repositories.any? { |repo| repo["is_update_repo"] }
     end
 

--- a/src/lib/registration/migration_repositories.rb
+++ b/src/lib/registration/migration_repositories.rb
@@ -74,10 +74,12 @@ module Registration
 
     private
 
-    # set some solver flags to be compatible with "zypper dup --from"
+    # set the solver flags for online migration
+    # @see https://fate.suse.com/319138
     def set_solver
-      log.info "Disabling recommended packages for already installed packages"
-      Yast::Pkg.SetSolverFlags("ignoreAlreadyRecommended" => true)
+      log.info "Setting the solver flag for online migration"
+      Yast::Pkg.SetSolverFlags("ignoreAlreadyRecommended" => true,
+                               "allowVendorChange"        => false)
     end
 
     # preselect all applicable patches (except optional ones)

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -254,7 +254,7 @@ module Registration
           migration_repos.services << service
         end
 
-        if migration_repos.service_update_repo?
+        if migration_repos.service_with_update_repo?
           migration_repos.install_updates = registration_ui.install_updates?
         end
 

--- a/test/migration_repos_workflow_spec.rb
+++ b/test/migration_repos_workflow_spec.rb
@@ -79,7 +79,7 @@ describe Registration::UI::MigrationReposWorkflow do
 
         # an update available
         expect_any_instance_of(Registration::MigrationRepositories).to \
-          receive(:service_update_repo?).and_return(true)
+          receive(:service_with_update_repo?).and_return(true)
         # user requestes skipping updates
         expect_any_instance_of(Registration::RegistrationUI).to receive(:install_updates?)
           .and_return(false)

--- a/test/migration_repos_workflow_spec.rb
+++ b/test/migration_repos_workflow_spec.rb
@@ -54,7 +54,7 @@ describe Registration::UI::MigrationReposWorkflow do
         expect_any_instance_of(Registration::Registration).to receive(:upgrade_product)
           .and_return(migration_service)
 
-        expect_any_instance_of(Registration::MigrationRepositories).to receive(:activate)
+        expect_any_instance_of(Registration::MigrationRepositories).to receive(:activate_services)
       end
 
       it "registers the selected migration products" do
@@ -74,12 +74,12 @@ describe Registration::UI::MigrationReposWorkflow do
         expect(subject.run).to eq(:next)
       end
 
-      it "does not install updates if required" do
+      it "does not install updates if not required" do
         set_success_expectations
 
         # an update available
         expect_any_instance_of(Registration::MigrationRepositories).to \
-          receive(:has_update_repo?).and_return(true)
+          receive(:service_update_repo?).and_return(true)
         # user requestes skipping updates
         expect_any_instance_of(Registration::RegistrationUI).to receive(:install_updates?)
           .and_return(false)
@@ -105,6 +105,26 @@ describe Registration::UI::MigrationReposWorkflow do
         expect_any_instance_of(Registration::RegistrationUI).to receive(:migration_products)
           .and_return([])
         expect(Yast::Report).to receive(:Error)
+
+        expect(subject.run).to eq(:abort)
+      end
+
+      it "reports error and aborts when registering the migration products fails" do
+        # installed SLES12
+        expect(Registration::SwMgmt).to receive(:installed_products)
+          .and_return([load_yaml_fixture("products_legacy_installation.yml")[1]])
+
+        expect_any_instance_of(Registration::RegistrationUI).to receive(:migration_products)
+          .and_return(migrations)
+
+        # user selected a migration and pressed [Next]
+        expect_any_instance_of(Registration::UI::MigrationSelectionDialog).to receive(:run)
+          .and_return(:next)
+        expect_any_instance_of(Registration::UI::MigrationSelectionDialog).to \
+          receive(:selected_migration).and_return(migrations.first)
+
+        expect_any_instance_of(Registration::Registration).to receive(:upgrade_product)
+          .and_raise("Registration failed")
 
         expect(subject.run).to eq(:abort)
       end

--- a/test/migration_repositories_spec.rb
+++ b/test/migration_repositories_spec.rb
@@ -31,7 +31,8 @@ describe Registration::MigrationRepositories do
     before do
       subject.repositories << { "SrcId" => 42 }
 
-      allow(Yast::Pkg).to receive(:SetSolverFlags)
+      expect(Yast::Pkg).to receive(:SetSolverFlags).with("ignoreAlreadyRecommended" => true,
+                                                         "allowVendorChange"        => false)
       allow(Yast::Pkg).to receive(:PkgSolve)
       expect(Yast::Pkg).to receive(:AddUpgradeRepo).with(42)
     end

--- a/test/migration_repositories_spec.rb
+++ b/test/migration_repositories_spec.rb
@@ -3,42 +3,28 @@
 require_relative "spec_helper"
 
 describe Registration::MigrationRepositories do
-  subject { Registration::MigrationRepositories.new }
-
   describe ".reset" do
-    it "resets the distribution upgrade flags and package statuses" do
-      expect(Yast::Pkg).to receive(:GetUpgradeRepos).and_return([99])
-      expect(Yast::Pkg).to receive(:RemoveUpgradeRepo).with(99)
+    it "resets the selected packages" do
       expect(Yast::Pkg).to receive(:PkgReset)
+      expect(Yast::Pkg).to receive(:SetSolverFlags).with("reset" => true)
 
       Registration::MigrationRepositories.reset
     end
   end
 
-  describe "#add_service" do
-    it "adds repositories belonging to a service" do
-      subject.repositories << { "SrcId" => 42 }
-
-      expect(Registration::SwMgmt).to receive(:service_repos).with("service")
-        .and_return(["SrcId" => 99])
-
-      subject.add_service("service")
-      expect(subject.repositories).to eq([{ "SrcId" => 42 }, { "SrcId" => 99 }])
-    end
-  end
-
-  describe "#activate" do
+  describe "#activate_services" do
     before do
-      subject.repositories << { "SrcId" => 42 }
-
       expect(Yast::Pkg).to receive(:SetSolverFlags).with("ignoreAlreadyRecommended" => true,
                                                          "allowVendorChange"        => false)
-      allow(Yast::Pkg).to receive(:PkgSolve)
-      expect(Yast::Pkg).to receive(:AddUpgradeRepo).with(42)
+      expect(Yast::Pkg).to receive(:PkgSolve)
+      expect(Yast::Pkg).to receive(:PkgUpdateAll)
+      expect(Yast::Pkg).to receive(:SourceLoad)
     end
 
-    it "activates upgrade from the specified repositories" do
-      subject.activate
+    it "activates the specified sevices for upgrade" do
+      subject.services << "test_service"
+
+      subject.activate_services
     end
 
     it "preselects patches if configured to install them" do
@@ -46,15 +32,60 @@ describe Registration::MigrationRepositories do
 
       expect(Yast::Pkg).to receive(:ResolvablePreselectPatches)
 
-      subject.activate
+      subject.activate_services
     end
 
-    it "skips update repositories if updates should not be installed" do
+    it "disables update repositories if updates should not be installed" do
+      service = "test_service"
+      repo = 42
       subject.install_updates = false
-      subject.repositories << { "SrcId" => 44, "is_update_repo" => true }
-      expect(Yast::Pkg).to_not receive(:AddUpgradeRepo).with(44)
+      subject.services << service
 
-      subject.activate
+      expect(Registration::SwMgmt).to receive(:service_repos).with(service, only_updates: true)
+        .and_return(["SrcId" => repo])
+
+      expect(Registration::SwMgmt).to receive(:set_repos_state).with([{ "SrcId" => repo }], false)
+
+      subject.activate_services
+    end
+  end
+
+  describe "#activate_repositories" do
+    before do
+      expect(Yast::Pkg).to receive(:SetSolverFlags).with("ignoreAlreadyRecommended" => true,
+                                                         "allowVendorChange"        => false)
+      expect(Yast::Pkg).to receive(:PkgSolve)
+      expect(Yast::Pkg).to receive(:PkgUpdateAll)
+      expect(Yast::Pkg).to receive(:SourceLoad)
+    end
+
+    it "activates the specified repositories and disables the rest" do
+      subject.repositories << 42
+      subject.repositories << 43
+
+      expect(Yast::Pkg).to receive(:SourceGetCurrent).with(false).and_return([41, 42, 43, 44])
+
+      expect(Yast::Pkg).to receive(:SourceGeneralData).with(41).and_return("enabled" => true)
+      expect(Yast::Pkg).to receive(:SourceGeneralData).with(42).and_return("enabled" => true)
+      expect(Yast::Pkg).to receive(:SourceGeneralData).with(43).and_return("enabled" => false)
+      expect(Yast::Pkg).to receive(:SourceGeneralData).with(44).and_return("enabled" => false)
+
+      expect(Yast::Pkg).to receive(:SourceSetEnabled).with(41, false)
+      expect(Yast::Pkg).to receive(:SourceSetEnabled).with(43, true)
+
+      subject.activate_repositories
+    end
+
+    it "preselects patches if configured to install them" do
+      subject.install_updates = true
+      expect(Yast::Pkg).to receive(:ResolvablePreselectPatches)
+      subject.activate_repositories
+    end
+
+    it "does not preselect patches if configured to skip them" do
+      subject.install_updates = false
+      expect(Yast::Pkg).to_not receive(:ResolvablePreselectPatches)
+      subject.activate_repositories
     end
   end
 end


### PR DESCRIPTION
- Use `Pkg.PkgUpdateAll()` instead of `Pkg.AddUpgradeRepo()`
- Disable the vendor change solver flag
- 3.1.136