### PR TITLE
Migration UI improvements

### DIFF
--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -59,6 +59,8 @@ module Registration
         @selected ||= []
       end
 
+      # return add-ons which are registered but not installed in the system
+      # @return [Array<Addon>] the list of add-ons
       def registered_not_installed
         registered.select do |addon|
           !SwMgmt.installed_products.find do |product|

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -20,6 +20,7 @@
 #
 
 require "forwardable"
+require "registration/sw_mgmt"
 
 module Registration
   # this is a wrapper class around SUSE::Connect::Product object
@@ -56,6 +57,16 @@ module Registration
       # @return [Array<Addon>] selected add-ons
       def selected
         @selected ||= []
+      end
+
+      def registered_not_installed
+        registered.select do |addon|
+          !SwMgmt.installed_products.find do |product|
+            product["name"] == addon.identifier &&
+              product["version_version"] == addon.version &&
+              product["arch"] == addon.arch
+          end
+        end
       end
 
       private

--- a/src/lib/registration/addon_sorter.rb
+++ b/src/lib/registration/addon_sorter.rb
@@ -27,4 +27,16 @@ module Registration
       x.name <=> y.name
     end
   end
+
+  # sort the migration products
+  # first the extensions, then the base product, modules at the end
+  MIGRATION_SORTER = proc do |x, y|
+    if x.base != y.base
+      # base at the end
+      x.base ? 1 : -1
+    else
+      # sort the groups by name
+      x.name <=> y.name
+    end
+  end
 end

--- a/src/lib/registration/addon_sorter.rb
+++ b/src/lib/registration/addon_sorter.rb
@@ -27,16 +27,4 @@ module Registration
       x.name <=> y.name
     end
   end
-
-  # sort the migration products
-  # first the extensions, then the base product, modules at the end
-  MIGRATION_SORTER = proc do |x, y|
-    if x.base != y.base
-      # base at the end
-      x.base ? 1 : -1
-    else
-      # sort the groups by name
-      x.name <=> y.name
-    end
-  end
 end

--- a/src/lib/registration/migration_sorter.rb
+++ b/src/lib/registration/migration_sorter.rb
@@ -1,0 +1,16 @@
+
+module Registration
+  # sort the migration products
+  # first the extensions, then the base product, modules at the end
+  # TODO: merge with ADDON_SORTER when SCC provides "free" and "product_type"
+  # attributes
+  MIGRATION_SORTER = proc do |x, y|
+    if x.base != y.base
+      # base at the end
+      x.base ? 1 : -1
+    else
+      # sort the groups by name
+      x.name <=> y.name
+    end
+  end
+end

--- a/src/lib/registration/registration_ui.rb
+++ b/src/lib/registration/registration_ui.rb
@@ -102,7 +102,7 @@ module Registration
         product_service = Yast::Popup.Feedback(
           _(CONTACTING_MESSAGE),
           # updating base product registration, %s is a new base product name
-          _("Updating to %s ...") % SwMgmt.base_product_label(
+          _("Updating to %s ...") % SwMgmt.product_label(
             SwMgmt.find_base_product)
         ) do
           registration.upgrade_product(base_product)
@@ -233,7 +233,7 @@ module Registration
       base_product = SwMgmt.find_base_product
 
       Yast::Popup.Feedback(_(CONTACTING_MESSAGE),
-        _("Registering %s ...") % SwMgmt.base_product_label(base_product)
+        _("Registering %s ...") % SwMgmt.product_label(base_product)
       ) do
         base_product_data = SwMgmt.base_product_to_register
         base_product_data["reg_code"] = options.reg_code

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -51,7 +51,7 @@ module Registration
     ZYPP_DIR = "/etc/zypp"
 
     FAKE_BASE_PRODUCT = { "name" => "SLES", "arch" => "x86_64", "version" => "12",
-      "release_type" => "DVD" }
+      "release_type" => "DVD", "version_version" => "12" }
 
     def self.init
       # false = do not allow continuing without the libzypp lock

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -137,7 +137,7 @@ module Registration
     # create UI label for a base product
     # @param base_product [Hash] Product (hash from pkg-bindings)
     # @return [String] UI Label
-    def self.base_product_label(base_product)
+    def self.product_label(base_product)
       base_product["display_name"] ||
         base_product["short_name"] ||
         base_product["name"] ||

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -112,7 +112,7 @@ module Registration
         HSquash(
           VBox(
             VSpacing(1),
-            Left(Heading(SwMgmt.base_product_label(SwMgmt.find_base_product))),
+            Left(Heading(SwMgmt.product_label(SwMgmt.find_base_product))),
             VSpacing(1),
             Registration.is_registered? ? Heading(_("The system is already registered.")) :
               Label(info)

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -187,7 +187,10 @@ module Registration
       # @return [Symbol] workflow symbol (:next or :abort)
       def select_migration_products
         log.info "Displaying migration target selection dialog"
-        dialog = MigrationSelectionDialog.new(migrations)
+        installed_products = SwMgmt.installed_products
+        log.warn "installed_products: #{installed_products.inspect}"
+        log.warn "installed_products: #{installed_products.map { |p| p["name"] }.inspect}"
+        dialog = MigrationSelectionDialog.new(migrations, installed_products)
         ret = dialog.run
 
         if ret == :next

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -52,8 +52,9 @@ module Registration
       # The repositories migration workflow is:
       #
       # - find all installed products
-      # - TODO: add the registered products
+      # - query registered addons from the server
       # - ask the registration server for the available product migrations
+      #   (for both installed and registered products)
       # - user selects the migration target
       # - the registered products are upgraded and new services/repositories
       #   are added to the system
@@ -162,7 +163,21 @@ module Registration
           return :abort
         end
 
+        merge_registered_addons
+        log.info "Products to migrate: #{products}"
+
         :next
+      end
+
+      def merge_registered_addons
+        # load the extensions to merge the registered but not installed extensions
+        Addon.find_all(registration)
+
+        addons = Addon.registered_not_installed.map(&:to_h).map do |addon|
+          SwMgmt.remote_product(addon)
+        end
+
+        products.concat(addons)
       end
 
       # load migration products for the installed products from the registration server
@@ -177,10 +192,6 @@ module Registration
           return :abort
         end
 
-        # FIXME: just to prefill the cache, after upgrading the base product
-        # the addons for the current base product cannot be loaded
-        Addon.find_all(registration)
-
         :next
       end
 
@@ -188,9 +199,7 @@ module Registration
       # @return [Symbol] workflow symbol (:next or :abort)
       def select_migration_products
         log.info "Displaying migration target selection dialog"
-        installed_products = SwMgmt.installed_products
-        log.info "installed_products: #{installed_products}"
-        dialog = MigrationSelectionDialog.new(migrations, installed_products)
+        dialog = MigrationSelectionDialog.new(migrations, products_to_migrate)
         ret = dialog.run
 
         if ret == :next
@@ -200,6 +209,21 @@ module Registration
         end
 
         ret
+      end
+
+      # collect products to migrate
+      # @return [Array<Hash>] installed or registered products
+      def products_to_migrate
+        installed_products = SwMgmt.installed_products
+        log.info "installed_products: #{installed_products}"
+
+        registered_products = Addon.registered_not_installed.map do |addon|
+          ret = addon.to_h
+          ret["display_name"] = addon.friendly_name
+          ret
+        end
+
+        installed_products.concat(registered_products)
       end
 
       # upgrade the services to the new version

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -52,6 +52,7 @@ module Registration
       # The repositories migration workflow is:
       #
       # - find all installed products
+      # - TODO: add the registered products
       # - ask the registration server for the available product migrations
       # - user selects the migration target
       # - the registered products are upgraded and new services/repositories
@@ -188,17 +189,16 @@ module Registration
       def select_migration_products
         log.info "Displaying migration target selection dialog"
         installed_products = SwMgmt.installed_products
-        log.warn "installed_products: #{installed_products.inspect}"
-        log.warn "installed_products: #{installed_products.map { |p| p["name"] }.inspect}"
+        log.info "installed_products: #{installed_products}"
         dialog = MigrationSelectionDialog.new(migrations, installed_products)
         ret = dialog.run
 
         if ret == :next
           self.selected_migration = dialog.selected_migration
           self.manual_repo_selection = dialog.manual_repo_selection
+          log.info "Selected migration: #{selected_migration}"
         end
 
-        log.info "Selected migration: #{selected_migration}"
         ret
       end
 

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -152,8 +152,8 @@ module Registration
           "<li>" + product_summary(product, installed) + "</li>"
         end
 
-        details = "<ul>" + details.join + "</ul>"
-        _("<h3>Migration Summary</h3>%s") % details
+        # TRANSLATORS: RichText header (details for the selected item)
+        "<h3>" + _("Migration Summary") + "</h3><ul>" + details.join + "</ul>"
       end
 
       def product_summary(product, installed_product)

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -84,6 +84,11 @@ module Registration
 
       attr_accessor :migrations
 
+      def add_registered_addons
+        extra = Addon.registered_not_installed.map { |addon| SwMgmt.remote_product(addon) }
+        installed_products.concat(extra)
+      end
+
       # the main dialog content
       # @return [Yast::Term] UI term
       def dialog_content

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -15,6 +15,7 @@
 require "cgi/util"
 
 require "yast"
+require "registration/addon_sorter"
 
 module Registration
   module UI
@@ -27,21 +28,24 @@ module Registration
       Yast.import "UI"
       Yast.import "Wizard"
 
-      attr_accessor :selected_migration, :manual_repo_selection
+      attr_accessor :selected_migration, :manual_repo_selection, :installed_products
 
       # run the dialog
-      # @param [Array<SUSE::Connect::Remote::Product>] the available migration targets
-      def self.run(migrations)
-        dialog = MigrationSelectionDialog.new(migrations)
+      # @param [Array<SUSE::Connect::Remote::Product>] migrations the available migration targets
+      # @param [Array<Hash>] installed_products the currently installed products
+      def self.run(migrations, installed_products)
+        dialog = MigrationSelectionDialog.new(migrations, installed_products)
         dialog.run
       end
 
       # constructor
-      # @param [Array<SUSE::Connect::Remote::Product>] the available migration targets
-      def initialize(migrations)
+      # @param [Array<SUSE::Connect::Remote::Product>] migrations the available migration targets
+      # @param [Array<Hash>] installed_products the currently installed products
+      def initialize(migrations, installed_products)
         textdomain "registration"
 
         @migrations = migrations
+        @installed_products = installed_products
         @manual_repo_selection = false
       end
 
@@ -57,9 +61,9 @@ module Registration
               "server may offer several possible migration to new products.</p>") +
           # TRANSLATORS: help text (2/3)
           _("<p>Only one migration target from the list can be selected.</p>") +
-            # TRANSLATORS: help text (3/3), %s is replaced by the (translated) check box label
-            (_("<p>Use the <b>%s</b> check box to manually select the migration " \
-                  "repositories later.</p>") % _("Manually Select Migration Repositories")),
+          # TRANSLATORS: help text (3/3), %s is replaced by the (translated) check box label
+          (_("<p>Use the <b>%s</b> check box to manually select the migration " \
+                "repositories later.</p>") % _("Manually Select Migration Repositories")),
           true,
           true
         )
@@ -112,9 +116,9 @@ module Registration
       # list of items for the main widget
       # @return [Array<Yast::Term>] widget content
       def migration_items
-        migrations.map.with_index do |arr, idx|
+        sorted_migrations.map.with_index do |arr, idx|
           products = arr.map do |product|
-            "#{product.identifier}-#{product.version}-#{product.arch}"
+            "#{product.identifier}-#{product.version}"
           end
 
           Item(Id(idx), products.join(", "))
@@ -134,14 +138,53 @@ module Registration
       # @param [Integer] migration index
       # @return [String] user friendly description (in RichText format)
       def migration_details(idx)
-        # TODO: display some more user friendly details
-        details = migrations[idx].map do |product|
-          "<li>" + CGI.escapeHTML("#{product.identifier}-#{product.version}-#{product.arch}") +
-            "</li>"
+        details = sorted_migrations[idx].map do |product|
+          installed = installed_products.find do |installed_product|
+            installed_product["name"] == product.identifier
+          end
+
+          "<li>" + product_summary(product, installed) + "</li>"
         end
 
         details = "<ul>" + details.join + "</ul>"
-        _("<h3>Migration Products Details</h3>%s") % details
+        _("<h3>Migration Summary</h3>%s") % details
+      end
+
+      def product_summary(product, installed_product)
+        log.info "creating summary for: #{product}, installed_product: #{installed_product}"
+
+        product_name = CGI.escapeHTML(product.friendly_name)
+
+        if !installed_product
+          # this is rather a theoretical case, but anyway....
+          # TRANSLATORS: Summary message, rich text format
+          # %s is a product name, e.g. "SUSE Linux Enterprise Server 12 SP1 x86_64"
+          return _("%s <b>will be installed.</b>") % product_name
+        end
+
+        if installed_product["version_version"] == product.version
+          # TRANSLATORS: Summary message, rich text format
+          # %s is a product name, e.g. "SUSE Linux Enterprise Server 12"
+          return _("%s <b>stays unchanged.</b>") % product_name
+        end
+
+        installed_version = Gem::Version.new(installed_product["version_version"])
+        migrated_version = Gem::Version.new(product.version)
+        old_product_name = installed_product["display_name"] || installed_product["summary"] ||
+          installed_product["short_name"] || installed_product["name"]
+
+        if installed_version < migrated_version
+          # TRANSLATORS: Summary message, rich text format
+          # %{old_product} is a product name, e.g. "SUSE Linux Enterprise Server 12"
+          # %{new_product} is a product name, e.g. "SUSE Linux Enterprise Server 12 SP1 x86_64"
+          return _("%{old_product} <b>will be upgraded to</b> %{new_product}.") \
+            % { old_product: old_product_name, new_product: product_name }
+        else
+          # TRANSLATORS: Summary message, rich text format
+          # %{old_product} and %{new_product} are product names
+          return _("%{old_product} <b>will be downgraded to</b> %{new_product}.") \
+            % { old_product: old_product_name, new_product: product_name }
+        end
       end
 
       # store the current UI values
@@ -151,6 +194,13 @@ module Registration
         log.info "Selected migration: #{selected_migration}"
 
         self.manual_repo_selection = Yast::UI.QueryWidget(:manual_repos, :Value)
+      end
+
+      def sorted_migrations
+        # sort the products in each migration
+        migrations.map do |migration|
+          migration.sort(&::Registration::MIGRATION_SORTER)
+        end
       end
     end
   end

--- a/test/fixtures/migration_to_sles12_sp1.yml
+++ b/test/fixtures/migration_to_sles12_sp1.yml
@@ -5,3 +5,4 @@
       :version: '12.1'
       :arch: x86_64
       :release_type: 
+      :friendly_name: SUSE Linux Enterprise Server SP1 x86_64

--- a/test/migration_repos_selection_dialog_test.rb
+++ b/test/migration_repos_selection_dialog_test.rb
@@ -12,13 +12,14 @@ describe Registration::UI::MigrationReposSelectionDialog do
         "name" => "name", "url" => "https://example.com", "enabled" => false)
       allow(Yast::Pkg).to receive(:SourceGeneralData).with(1).and_return(
         "name" => "name2", "url" => "https://example2.com", "enabled" => true)
+      allow(Yast::UI).to receive(:QueryWidget).with(:repos, :CurrentItem).and_return(0)
 
       # check the displayed content
       expect(Yast::Wizard).to receive(:SetContents) do |_title, content, _help, _back, _next|
         term = content.nested_find do |t|
           t.respond_to?(:value) && t.value == :MultiSelectionBox &&
-            t.params[3].include?(Item(Id(0), "name (https://example.com)", false)) &&
-            t.params[3].include?(Item(Id(1), "name2 (https://example2.com)", true))
+            t.params[3].include?(Item(Id(0), "name", false)) &&
+            t.params[3].include?(Item(Id(1), "name2", true))
         end
 
         expect(term).to_not eq(nil)
@@ -49,7 +50,7 @@ describe Registration::UI::MigrationReposSelectionDialog do
       expect(Yast::WFM).to receive(:call).with("repositories", ["refresh-enabled"])
         .and_return(:next)
 
-      expect(Yast::UI).to receive(:ChangeWidget)
+      expect(Yast::UI).to receive(:ChangeWidget).twice
 
       expect(subject.run).to eq(:abort)
     end

--- a/test/migration_repos_workflow_spec.rb
+++ b/test/migration_repos_workflow_spec.rb
@@ -39,7 +39,7 @@ describe Registration::UI::MigrationReposWorkflow do
 
       let(:set_success_expectations) do
         # installed SLES12
-        expect(Registration::SwMgmt).to receive(:installed_products)
+        allow(Registration::SwMgmt).to receive(:installed_products)
           .and_return([load_yaml_fixture("products_legacy_installation.yml")[1]])
 
         expect_any_instance_of(Registration::RegistrationUI).to receive(:migration_products)
@@ -111,7 +111,7 @@ describe Registration::UI::MigrationReposWorkflow do
 
       it "reports error and aborts when registering the migration products fails" do
         # installed SLES12
-        expect(Registration::SwMgmt).to receive(:installed_products)
+        allow(Registration::SwMgmt).to receive(:installed_products)
           .and_return([load_yaml_fixture("products_legacy_installation.yml")[1]])
 
         expect_any_instance_of(Registration::RegistrationUI).to receive(:migration_products)

--- a/test/migration_selection_dialog_test.rb
+++ b/test/migration_selection_dialog_test.rb
@@ -14,7 +14,7 @@ describe Registration::UI::MigrationSelectionDialog do
 
       # check the displayed content
       expect(Yast::Wizard).to receive(:SetContents) do |_title, content, _help, _back, _next|
-        expected_list_item = Item(Id(0), "SLES-12.1-x86_64")
+        expected_list_item = Item(Id(0), "SLES-12.1")
 
         term = content.nested_find do |t|
           t.respond_to?(:value) && t.value == :MinHeight &&
@@ -25,7 +25,7 @@ describe Registration::UI::MigrationSelectionDialog do
         expect(term).to_not eq(nil)
       end
 
-      expect(subject.run(migration_products)).to eq(:abort)
+      expect(subject.run(migration_products, [])).to eq(:abort)
     end
 
     it "saves the entered values when clicking Next" do
@@ -35,7 +35,7 @@ describe Registration::UI::MigrationSelectionDialog do
         .and_return(0).twice
       expect(Yast::UI).to receive(:QueryWidget).with(:manual_repos, :Value).and_return(true)
 
-      dialog = subject.new(migration_products)
+      dialog = subject.new(migration_products, [])
       expect(dialog.run).to eq(:next)
 
       # check the saved values


### PR DESCRIPTION
This is the result after discussing the UI with Ken. The changes include:

### The migration selection dialog:

- Sort the products in the displayed migration (the base product is at the end)
- Hide architecture in product name (not useful, architecture cannot be changed during migration anyway)
- Display user-friendly status

### Manual repository selection:

- Hide the repository URL in the `SelectionBox` (too long...)
- Display it in the details below (with some more data like the repository priority)

### Other changes:

- Query the registered extensions/modules and add them to the migration
  (to migrate also the registrations for the uninstalled products), this was required by the SCC team