### PR TITLE
Catch exceptions also when loading the available extensions (bsc#941491)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug 14 10:45:56 UTC 2015 - lslezak@suse.cz
+
+- Catch exceptions also when loading the available extensions
+  (bsc#941491)
+- 3.1.141
+
+-------------------------------------------------------------------
 Fri Aug 14 08:20:21 UTC 2015 - lslezak@suse.cz
 
 - Reload the packages after modifying the repository setup

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.140
+Version:        3.1.141
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_scc.rb
+++ b/src/clients/inst_scc.rb
@@ -154,7 +154,11 @@ module Yast
       # cache the available addons
       return :cancel if init_registration == :cancel
 
-      registration_ui.get_available_addons
+      addons_loaded = Registration::ConnectHelpers.catch_registration_errors do
+        registration_ui.get_available_addons
+      end
+
+      return :cancel unless addons_loaded
 
       @addons_registered_orig = Registration::Addon.registered.dup
     end

--- a/test/inst_scc_test.rb
+++ b/test/inst_scc_test.rb
@@ -28,6 +28,16 @@ describe "inst_scc client" do
       expect(Yast::WFM.call("inst_scc")).to eq(:abort)
     end
 
+    it "displays an error when loading the available extensions fails" do
+      # click installing extensions, close the error message and abort the workflow
+      expect(Yast::UI).to receive(:UserInput).and_return(:extensions, :ok, :abort)
+
+      expect_any_instance_of(Registration::RegistrationUI).to receive(:get_available_addons)
+        .and_raise("Invalid system credentials")
+
+      expect(Yast::WFM.call("inst_scc")).to eq(:abort)
+    end
+
     it "goes back to initial screen when aborting selection of url" do
       # User clicks on 'select extensions' first time the initial screen is
       # displayed and 'finish' the second time

--- a/test/inst_scc_test.rb
+++ b/test/inst_scc_test.rb
@@ -29,11 +29,17 @@ describe "inst_scc client" do
     end
 
     it "displays an error when loading the available extensions fails" do
-      # click installing extensions, close the error message and abort the workflow
-      expect(Yast::UI).to receive(:UserInput).and_return(:extensions, :ok, :abort)
+      error = "Invalid system credentials"
+      # click installing extensions, abort the workflow
+      expect(Yast::UI).to receive(:UserInput).and_return(:extensions, :abort)
+
+      expect(Yast::Report).to receive(:Error) do |msg|
+        # make sure the propoer error is displayed
+        expect(msg).to include(error)
+      end
 
       expect_any_instance_of(Registration::RegistrationUI).to receive(:get_available_addons)
-        .and_raise("Invalid system credentials")
+        .and_raise(error)
 
       expect(Yast::WFM.call("inst_scc")).to eq(:abort)
     end


### PR DESCRIPTION
- 3.1.141

Do not crash when an exception is raised.

(Note: An error popup is displayed internally inside the `ConnectHelpers.catch_registration_errors` it's enough to just check the return value).