### PR TITLE
Release target fix

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -4,6 +4,7 @@ Fri Aug 21 11:38:22 UTC 2015 - lslezak@suse.cz
 - Fixed registering a product with POOL flavor (bsc#941402)
 - Addon selection dialog - avoid possible ID duplicates when
   an addon with multiple versions is displayed
+- 3.1.143
 
 -------------------------------------------------------------------
 Mon Aug 17 14:40:05 UTC 2015 - igonzalezsosa@suse.com

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -2,6 +2,8 @@
 Fri Aug 21 11:38:22 UTC 2015 - lslezak@suse.cz
 
 - Fixed registering a product with POOL flavor (bsc#941402)
+- Addon selection dialog - avoid possible ID duplicates when
+  an addon with multiple versions is displayed
 
 -------------------------------------------------------------------
 Mon Aug 17 14:40:05 UTC 2015 - igonzalezsosa@suse.com

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Aug 21 11:38:22 UTC 2015 - lslezak@suse.cz
+
+- Fixed registering a product with POOL flavor (bsc#941402)
+
+-------------------------------------------------------------------
 Mon Aug 17 14:40:05 UTC 2015 - igonzalezsosa@suse.com
 
 - Fix AutoYaST crash during registration (bsc#941449)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.142
+Version:        3.1.143
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -44,6 +44,15 @@ module Registration
         raise "Not implemented"
       end
 
+      protected
+
+      # create widget ID for an addon
+      # @param [<Addon>] addon the addon
+      # @return [String] widget id
+      def addon_widget_id(addon)
+        "#{addon.identifier}-#{addon.version}-#{addon.arch}"
+      end
+
       private
 
       # reimplement this in a subclass
@@ -154,7 +163,7 @@ module Registration
         # (%s is an extension name)
         label = addon.available? ? addon.label : (_("%s (not available)") % addon.label)
 
-        CheckBox(Id(addon.identifier), Opt(:notify), label, addon_selected?(addon))
+        CheckBox(Id(addon_widget_id(addon)), Opt(:notify), label, addon_selected?(addon))
       end
 
       # the main event loop - handle the user in put in the dialog
@@ -191,14 +200,14 @@ module Registration
       end
 
       # handler for changing the addon status in the main loop
-      # @param id [String] addon identifier
+      # @param id [String] addon widget id
       def handle_addon_selection(id)
         # check whether it's an add-on ID (checkbox clicked)
-        addon = @addons.find { |a| a.identifier == id }
+        addon = @addons.find { |a| addon_widget_id(a) == id }
         return unless addon
 
         show_addon_details(addon)
-        if Yast::UI.QueryWidget(Id(addon.identifier), :Value)
+        if Yast::UI.QueryWidget(Id(addon_widget_id(addon)), :Value)
           addon.selected
         else
           addon.unselected
@@ -217,7 +226,7 @@ module Registration
       # update the enabled/disabled status in UI for dependent addons
       def reactivate_dependencies
         @addons.each do |addon|
-          Yast::UI.ChangeWidget(Id(addon.identifier), :Enabled, addon.selectable?)
+          Yast::UI.ChangeWidget(Id(addon_widget_id(addon)), :Enabled, addon.selectable?)
         end
       end
 

--- a/src/lib/registration/ui/addon_selection_registration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_registration_dialog.rb
@@ -60,7 +60,7 @@ module Registration
       # update the enabled/disabled status in UI for dependent addons
       def reactivate_dependencies
         @addons.each do |addon|
-          Yast::UI.ChangeWidget(Id(addon.identifier), :Enabled, addon.selectable?)
+          Yast::UI.ChangeWidget(Id(addon_widget_id(addon)), :Enabled, addon.selectable?)
         end
       end
     end

--- a/test/addon_selection_dialog_test.rb
+++ b/test/addon_selection_dialog_test.rb
@@ -29,13 +29,14 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
     end
 
     it "returns `:next` if some addons are selected and user click next" do
-      test_addon = addon_generator
-      expect(Yast::UI).to receive(:UserInput).and_return(test_addon.identifier, :next)
+      addon = addon_generator
+      widget = "#{addon.identifier}-#{addon.version}-#{addon.arch}"
+      expect(Yast::UI).to receive(:UserInput).and_return(widget, :next)
       # mock that widget is selected
       expect(Yast::UI).to receive(:QueryWidget)
-        .with(Yast::Term.new(:id, test_addon.identifier), :Value)
+        .with(Yast::Term.new(:id, widget), :Value)
         .and_return(true)
-      registration = double(activated_products: [], get_addon_list: [test_addon])
+      registration = double(activated_products: [], get_addon_list: [addon])
       expect(subject.run(registration)).to eq :next
     end
   end

--- a/test/registration_ui_test.rb
+++ b/test/registration_ui_test.rb
@@ -9,8 +9,12 @@ describe "Registration::RegistrationUI" do
   let(:target_distro) { "sles-12-x86_64" }
   let(:base_product) do
     {
-      "arch" => "x86_64", "name" => "SLES", "version" => "12",
-      "flavor" => "DVD", "register_target" => target_distro
+      "arch"            => "x86_64",
+      "flavor"          => "DVD",
+      "name"            => "SLES",
+      "version"         => "12-0",
+      "version_version" => "12",
+      "register_target" => target_distro
     }
   end
   let(:base_product_to_register) do
@@ -18,7 +22,7 @@ describe "Registration::RegistrationUI" do
       "arch"         => "x86_64",
       "name"         => "SLES",
       "reg_code"     => "reg_code",
-      "release_type" => "DVD",
+      "release_type" => nil,
       "version"      => "12"
     }
   end

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -101,10 +101,10 @@ describe Registration::SwMgmt do
     it "returns base product base version and release_type" do
       expect(subject).to(receive(:find_base_product)
         .and_return("name" => "SLES", "arch" => "x86_64",
-          "version" => "12.1-1.47", "flavor" => "DVD"))
+          "version" => "12.1-1.47", "version_version" => "12.1", "flavor" => "DVD"))
 
       expect(subject.base_product_to_register).to eq("name" => "SLES",
-        "arch" => "x86_64", "version" => "12.1", "release_type" => "DVD")
+        "arch" => "x86_64", "version" => "12.1", "release_type" => nil)
     end
   end
 


### PR DESCRIPTION
- Tested registering the SLES-SP1 POOL product against SCC and SMT - both OK.
- It's the same as the SUSEConnect implementation: https://github.com/SUSE/connect/blob/master/lib/suse/connect/zypper/product.rb#L18.
- Fixed a small issue in the addon selection dialog, using just `addon.identifier` as a widget ID is not enough, there might be the same addon in more versions. In that case the ID is not unique and that makes troubles (found in the SMT testcase).