### PR TITLE
Keep the original NCCCredentials file permissions (bsc#943568)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug 28 10:31:56 UTC 2015 - lslezak@suse.cz
+
+- Keep the original NCCCredentials file permissions when upgrading
+  from SLE11 (bsc#943568)
+- 3.1.146
+
+-------------------------------------------------------------------
 Wed Aug 26 07:33:14 UTC 2015 - lslezak@suse.cz
 
 - Better wording in the "install updates" popup (bsc#942843)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.145
+Version:        3.1.146
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -332,7 +332,9 @@ module Registration
       new_file = SUSE::Connect::Credentials::GLOBAL_CREDENTIALS_FILE
       log.info "Copying the old credentials from previous installation"
       log.info "Copying #{file} to #{new_file}"
-      ::FileUtils.cp(file, new_file)
+      # preserve the original file permissions (equivalent to "cp -p")
+      # (SMT uses different permissions than the defaults, make sure it works after upgrade)
+      ::FileUtils.cp(file, new_file, preserve: true)
 
       credentials = SUSE::Connect::Credentials.read(new_file)
       # note: SUSE::Connect::Credentials override #to_s, the password is filtered out

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -25,6 +25,7 @@ require "yast"
 
 require "tmpdir"
 require "fileutils"
+require "shellwords"
 
 require "registration/exceptions"
 require "registration/helpers"
@@ -332,9 +333,11 @@ module Registration
       new_file = SUSE::Connect::Credentials::GLOBAL_CREDENTIALS_FILE
       log.info "Copying the old credentials from previous installation"
       log.info "Copying #{file} to #{new_file}"
-      # preserve the original file permissions (equivalent to "cp -p")
-      # (SMT uses different permissions than the defaults, make sure it works after upgrade)
-      ::FileUtils.cp(file, new_file, preserve: true)
+
+      # SMT uses extra ACL permissions, make sure they are kept in the copied file,
+      # (use "cp -a ", ::FileUtils.cp(..., preserve: true) cannot be used as it preserves only
+      # the traditional Unix file permissions, the extended ACLs are NOT copied!)
+      `cp -a #{Shellwords.escape(file)} #{Shellwords.escape(new_file)}`
 
       credentials = SUSE::Connect::Credentials.read(new_file)
       # note: SUSE::Connect::Credentials override #to_s, the password is filtered out

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -179,7 +179,7 @@ describe Registration::SwMgmt do
         .and_return(false)
 
       expect(FileUtils).to receive(:cp).with(File.join(root_dir, target_dir, "NCCcredentials"),
-        File.join(target_dir, "SCCcredentials"))
+        File.join(target_dir, "SCCcredentials"), preserve: true)
       expect(SUSE::Connect::Credentials).to receive(:read)
 
       expect { subject.copy_old_credentials(root_dir) }.to_not raise_error
@@ -192,7 +192,7 @@ describe Registration::SwMgmt do
         .and_return(true)
 
       expect(FileUtils).to receive(:cp).with(File.join(root_dir, target_dir, "SCCcredentials"),
-        File.join(target_dir, "SCCcredentials"))
+        File.join(target_dir, "SCCcredentials"), preserve: true)
       expect(SUSE::Connect::Credentials).to receive(:read)
 
       expect { subject.copy_old_credentials(root_dir) }.to_not raise_error

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -178,8 +178,8 @@ describe Registration::SwMgmt do
       expect(File).to receive(:exist?).with(File.join(root_dir, target_dir, "SCCcredentials"))
         .and_return(false)
 
-      expect(FileUtils).to receive(:cp).with(File.join(root_dir, target_dir, "NCCcredentials"),
-        File.join(target_dir, "SCCcredentials"), preserve: true)
+      expect(subject).to receive(:`).with("cp -a " + File.join(root_dir, target_dir,
+        "NCCcredentials") + " " + File.join(target_dir, "SCCcredentials"))
       expect(SUSE::Connect::Credentials).to receive(:read)
 
       expect { subject.copy_old_credentials(root_dir) }.to_not raise_error
@@ -191,8 +191,8 @@ describe Registration::SwMgmt do
       expect(File).to receive(:exist?).with(File.join(root_dir, target_dir, "SCCcredentials"))
         .and_return(true)
 
-      expect(FileUtils).to receive(:cp).with(File.join(root_dir, target_dir, "SCCcredentials"),
-        File.join(target_dir, "SCCcredentials"), preserve: true)
+      expect(subject).to receive(:`).with("cp -a " + File.join(root_dir, target_dir,
+        "SCCcredentials") + " " + File.join(target_dir, "SCCcredentials"))
       expect(SUSE::Connect::Credentials).to receive(:read)
 
       expect { subject.copy_old_credentials(root_dir) }.to_not raise_error


### PR DESCRIPTION
...when upgrading from SLE11

- 3.1.146

(See http://ruby-doc.org/stdlib-2.2.0/libdoc/fileutils/rdoc/FileUtils.html#method-c-cp for the details in the documentation.)