### PR TITLE
Restore the *-Update repositories at the end of migration

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -2,6 +2,8 @@
 Tue Sep  2 10:27:28 UTC 2015 - lslezak@suse.cz
 
 - disable "Back" at the initial dialog
+- restore (enable) the Updates repositories at the end of the
+  migration workflow (bsc#943960)
 
 -------------------------------------------------------------------
 Wed Sep  2 05:45:28 UTC 2015 - jsrain@suse.cz

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Sep  2 10:27:28 UTC 2015 - lslezak@suse.cz
+
+- disable "Back" at the initial dialog
+
+-------------------------------------------------------------------
 Wed Sep  2 05:45:28 UTC 2015 - jsrain@suse.cz
 
 - fixed syntax error (bsc#944089)

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -4,6 +4,7 @@ Tue Sep  2 10:27:28 UTC 2015 - lslezak@suse.cz
 - disable "Back" at the initial dialog
 - restore (enable) the Updates repositories at the end of the
   migration workflow (bsc#943960)
+- 3.1.148
 
 -------------------------------------------------------------------
 Wed Sep  2 05:45:28 UTC 2015 - jsrain@suse.cz

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.147
+Version:        3.1.148
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/migration_finish.rb
+++ b/src/clients/migration_finish.rb
@@ -13,10 +13,10 @@
 #
 
 require "yast"
-require "registration/ui/migration_repos_workflow"
+require "registration/ui/migration_finish_workflow"
 
 module Yast
-  class MigrationReposClient < Client
+  class MigrationFinishClient < Client
     Yast.import "Wizard"
 
     def main
@@ -27,12 +27,12 @@ module Yast
       Wizard.CreateDialog unless wizard_present
 
       begin
-        ::Registration::UI::MigrationReposWorkflow.run
+        ::Registration::UI::MigrationFinishWorkflow.run
       ensure
         Wizard.CloseDialog unless wizard_present
       end
     end
-  end unless defined?(YaST::MigrationReposClient)
+  end unless defined?(YaST::MigrationFinishClient)
 end
 
-Yast::MigrationReposClient.new.main
+Yast::MigrationFinishClient.new.main

--- a/src/clients/migration_repos.rb
+++ b/src/clients/migration_repos.rb
@@ -22,12 +22,14 @@ module Yast
     def main
       textdomain "registration"
 
-      Wizard.CreateDialog
+      # create the Wizard dialog if needed
+      wizard_present = Wizard.IsWizardDialog
+      Wizard.CreateDialog unless wizard_present
 
       begin
         ::Registration::UI::MigrationReposWorkflow.run(*Yast::WFM.Args)
       ensure
-        Wizard.CloseDialog
+        Wizard.CloseDialog unless wizard_present
       end
     end
   end unless defined?(YaST::MigrationReposClient)

--- a/src/clients/scc.rb
+++ b/src/clients/scc.rb
@@ -48,10 +48,7 @@ module Yast
         Wizard.CreateDialog
 
         begin
-          if !::Registration::SwMgmt.init
-            Report.Error(Pkg.LastError)
-            return :abort
-          end
+          ::Registration::SwMgmt.init
 
           return WFM.call("inst_scc")
         ensure

--- a/src/lib/registration/finish_dialog.rb
+++ b/src/lib/registration/finish_dialog.rb
@@ -43,7 +43,7 @@ module Registration
         return nil unless Registration.is_registered?
 
         # enable back the update repositories in the installed system
-        revert_repository_changes
+        RepoStateStorage.instance.restore_all
 
         Yast.import "Installation"
 
@@ -62,20 +62,6 @@ module Registration
       else
         raise "Uknown action #{func} passed as first parameter"
       end
-    end
-
-    private
-
-    # revert back the original repository states from the registration server
-    def revert_repository_changes
-      changed_repos = RepoStateStorage.instance.repositories
-      return if changed_repos.empty?
-
-      # activate the original repository states
-      changed_repos.each(&:restore)
-
-      # save all repositories
-      Yast::Pkg.SourceSaveAll
     end
   end
 end

--- a/src/lib/registration/repo_state.rb
+++ b/src/lib/registration/repo_state.rb
@@ -22,6 +22,7 @@
 #
 
 require "singleton"
+require "yaml"
 
 require "yast"
 
@@ -30,13 +31,93 @@ module Registration
 
   # storage for changed repositories
   class RepoStateStorage
+    include Yast::Logger
     include Singleton
 
     # array of RepoState objects
     attr_accessor :repositories
 
+    # location of the persistent storage (to store the data when restarting YaST)
+    REPO_STATE_FILE = "/var/lib/YaST2/migration_repo_state.yml"
+
     def initialize
       @repositories = []
+    end
+
+    # @param [String] repo_id repository ID
+    # @param [Boolean] enabled the repository state to set
+    #   (true = enable the repository, false = disable)
+    def add(repo_id, enabled)
+      repositories << RepoState.new(repo_id, enabled)
+    end
+
+    # restore all saved states
+    def restore_all
+      return if repositories.empty?
+
+      # activate the original repository states
+      repositories.each(&:restore)
+
+      # save all repositories
+      Yast::Pkg.SourceSaveAll
+    end
+
+    # write the current state to the persistent storage (to survive YaST restart)
+    def write
+      data = {}
+
+      # repo_id => alias mapping
+      repo_mapping = repository_mapping
+
+      repositories.each do |repository|
+        data[repo_mapping[repository.repo_id]] = repository.enabled
+      end
+
+      log.info "Exporting repository state: #{data.inspect}"
+      File.write(REPO_STATE_FILE, data.to_yaml)
+    end
+
+    # read the stored state from the persistent storage
+    def read
+      # reset the previous list
+      self.repositories = []
+
+      return unless File.exist?(REPO_STATE_FILE)
+
+      # inverse alias => repo_id mapping
+      repo_mapping = repository_mapping.invert
+
+      data = YAML.load_file(REPO_STATE_FILE)
+      log.info "Importing repository state: #{data}"
+
+      data.each do |repo_alias, enabled|
+        if repo_mapping[repo_alias]
+          add(repo_mapping[repo_alias], enabled)
+        else
+          log.warn "Repository #{repo_alias.inspect} is missing"
+        end
+      end
+    end
+
+    # clean the persistent storage
+    def clean
+      File.unlink(REPO_STATE_FILE) if File.exist?(REPO_STATE_FILE)
+    end
+
+    private
+
+    # create repository mapping repo_id => alias
+    # @return [Hash<Fixnum>,String>] the current repository mapping
+    def repository_mapping
+      ret = {}
+
+      Yast::Pkg.SourceGetCurrent(false).each do |repo|
+        ret[repo] = Yast::Pkg.SourceGeneralData(repo)["alias"]
+      end
+
+      log.info "Current repository setup: #{ret.inspect}"
+
+      ret
     end
   end
 
@@ -46,11 +127,16 @@ module Registration
 
     attr_reader :repo_id, :enabled
 
+    # create repository state status
+    # @param [Fixnum] repo_id repository ID
+    # @param [Boolean] enabled the repository state to set
+    #   (true = enable the repository, false = disable)
     def initialize(repo_id, enabled)
       @repo_id = repo_id
       @enabled = enabled
     end
 
+    # set the saved repository state
     def restore
       log.info "Restoring the original repository state: id: #{repo_id}, enabled: #{enabled}"
       Yast::Pkg.SourceSetEnabled(repo_id, enabled)

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -62,16 +62,16 @@ module Registration
     def self.init(load_packages = false)
       # false = do not allow continuing without the libzypp lock
       lock = PackageLock.Connect(false)
-      raise pkg_exception unless lock["connected"]
+      raise_pkg_exception unless lock["connected"]
 
       # display progress when refreshing repositories
       PackageCallbacks.InitPackageCallbacks
 
-      raise pkg_exception unless Pkg.TargetInitialize(Installation.destdir)
-      raise pkg_exception unless Pkg.TargetLoad
-      raise pkg_exception unless Pkg.SourceRestore
+      raise_pkg_exception unless Pkg.TargetInitialize(Installation.destdir)
+      raise_pkg_exception unless Pkg.TargetLoad
+      raise_pkg_exception unless Pkg.SourceRestore
 
-      raise pkg_exception if load_packages && !Pkg.SourceLoad
+      raise_pkg_exception if load_packages && !Pkg.SourceLoad
     end
 
     # during installation /etc/zypp directory is not writable (mounted on
@@ -473,8 +473,8 @@ module Registration
       product["register_release"]
     end
 
-    def self.pkg_exception
-      PkgError.new(Pkg.LastError)
+    def self.raise_pkg_exception
+      raise PkgError.new, Pkg.LastError
     end
 
     private_class_method :each_repo, :get_release_type

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -57,7 +57,9 @@ module Registration
 
     OEM_DIR = "/var/lib/suseRegister/OEM"
 
-    def self.init
+    # initialize the package management
+    # @param [Boolean] load_packages load also the available packages from the repositories
+    def self.init(load_packages = false)
       # false = do not allow continuing without the libzypp lock
       lock = PackageLock.Connect(false)
       return false unless lock["connected"]
@@ -67,6 +69,7 @@ module Registration
       Pkg.TargetInitialize(Installation.destdir)
       Pkg.TargetLoad
       Pkg.SourceRestore
+      load_packages ? Pkg.SourceLoad : true
     end
 
     # during installation /etc/zypp directory is not writable (mounted on
@@ -295,8 +298,7 @@ module Registration
         next if repo["enabled"] == enabled
 
         # remember the original state
-        repo_state = RepoState.new(repo["SrcId"], repo["enabled"])
-        RepoStateStorage.instance.repositories << repo_state
+        RepoStateStorage.instance.add(repo["SrcId"], repo["enabled"])
 
         log.info "Changing repository state: #{repo["name"]} enabled: #{enabled}"
         Pkg.SourceSetEnabled(repo["SrcId"], enabled)

--- a/src/lib/registration/ui/autoyast_config_workflow.rb
+++ b/src/lib/registration/ui/autoyast_config_workflow.rb
@@ -93,10 +93,7 @@ module Registration
       # download the addons from SCC, let the user select addons to install
       # @return [Symbol] the user input
       def select_remote_addons
-        if !SwMgmt.init
-          Report.Error(Pkg.LastError)
-          return :abort
-        end
+        SwMgmt.init
 
         url = UrlHelpers.registration_url
         registration = ::Registration::Registration.new(url)

--- a/src/lib/registration/ui/media_addon_workflow.rb
+++ b/src/lib/registration/ui/media_addon_workflow.rb
@@ -86,7 +86,15 @@ module Registration
         }
 
         log.info "Starting registering media add-on sequence"
-        Sequencer.Run(aliases, sequence)
+
+        begin
+          Sequencer.Run(aliases, sequence)
+        rescue => e
+          log.error "Caught error: #{e.class}: #{e.message.inspect}, #{e.backtrace}"
+          # TRANSLATORS: error message, %s are details
+          Yast::Report.Error(_("Internal error: %s") % e.message)
+          :abort
+        end
       end
 
       private
@@ -96,10 +104,7 @@ module Registration
       # check if the add-on repository provides a product resolvable
       # @return [Symbol] workflow symbol (:next, :finish or :abort)
       def find_products
-        if !SwMgmt.init(true)
-          Report.Error(Pkg.LastError)
-          return :abort
-        end
+        SwMgmt.init(true)
 
         self.products = SwMgmt.products_from_repo(repo_id)
 

--- a/src/lib/registration/ui/media_addon_workflow.rb
+++ b/src/lib/registration/ui/media_addon_workflow.rb
@@ -96,13 +96,10 @@ module Registration
       # check if the add-on repository provides a product resolvable
       # @return [Symbol] workflow symbol (:next, :finish or :abort)
       def find_products
-        if !SwMgmt.init
+        if !SwMgmt.init(true)
           Report.Error(Pkg.LastError)
           return :abort
         end
-
-        # load the resolvables from the repositories
-        Pkg.SourceLoad
 
         self.products = SwMgmt.products_from_repo(repo_id)
 

--- a/src/lib/registration/ui/migration_finish_workflow.rb
+++ b/src/lib/registration/ui/migration_finish_workflow.rb
@@ -43,17 +43,12 @@ module Registration
       #  - restore the saved repository states (i.e. enable the Updates
       #    repositories when they were disabled during migration)
       def run
-        ret = nil
-        begin
-          ret = run_sequence
-        rescue => e
-          log.error "Caught error: #{e.class}: #{e.message.inspect}, #{e.backtrace}"
-          # TRANSLATORS: error message, %s are details
-          Yast::Report.Error(_("Internal error: %s") % e.message)
-          ret = :abort
-        end
-
-        ret
+        run_sequence
+      rescue => e
+        log.error "Caught error: #{e.class}: #{e.message.inspect}, #{e.backtrace}"
+        # TRANSLATORS: error message, %s are details
+        Yast::Report.Error(_("Internal error: %s") % e.message)
+        return :abort
       end
 
       private
@@ -74,7 +69,7 @@ module Registration
         }
 
         ui = Yast::Sequencer.Run(aliases, WORKFLOW_SEQUENCE)
-        log.info "User input: #{ui}"
+        log.info "Workflow result: #{ui}"
         ui
       end
 

--- a/src/lib/registration/ui/migration_finish_workflow.rb
+++ b/src/lib/registration/ui/migration_finish_workflow.rb
@@ -1,0 +1,91 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2015 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+#
+
+require "yast"
+
+require "registration/repo_state"
+
+module Registration
+  module UI
+    # This class handles the workflow for finishing the online migration
+    class MigrationFinishWorkflow
+      include Yast::Logger
+      include Yast::I18n
+      include Yast::UIShortcuts
+
+      Yast.import "Report"
+      Yast.import "Sequencer"
+
+      # run workflow for adding the migration services
+      # @return [Symbol] the UI symbol
+      def self.run
+        workflow = MigrationFinishWorkflow.new
+        workflow.run
+      end
+
+      # the constructor
+      def initialize
+        textdomain "registration"
+      end
+
+      # The migration finish workflow is:
+      #  - restore the saved repository states (i.e. enable the Updates
+      #    repositories when they were disabled during migration)
+      def run
+        ret = nil
+        begin
+          ret = run_sequence
+        rescue => e
+          log.error "Caught error: #{e.class}: #{e.message.inspect}, #{e.backtrace}"
+          # TRANSLATORS: error message, %s are details
+          Yast::Report.Error(_("Internal error: %s") % e.message)
+          ret = :abort
+        end
+
+        ret
+      end
+
+      private
+
+      WORKFLOW_SEQUENCE = {
+        "ws_start"      => "restore_repos",
+        "restore_repos" => {
+          abort: :abort,
+          next:  :next
+        }
+      }
+
+      # run the workflow
+      # @return [Symbol] the UI symbol
+      def run_sequence
+        aliases = {
+          "restore_repos" => ->() { restore_repos }
+        }
+
+        ui = Yast::Sequencer.Run(aliases, WORKFLOW_SEQUENCE)
+        log.info "User input: #{ui}"
+        ui
+      end
+
+      # restore all saved repository states
+      def restore_repos
+        log.info "Restoring the original repository setup..."
+        repo_state = RepoStateStorage.instance
+        repo_state.read
+        repo_state.restore_all
+        :next
+      end
+    end
+  end
+end

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -157,10 +157,7 @@ module Registration
       def find_products
         log.info "Loading installed products"
 
-        if !SwMgmt.init(true)
-          Yast::Report.Error(Yast::Pkg.LastError)
-          return :abort
-        end
+        SwMgmt.init(true)
 
         self.products = ::Registration::SwMgmt.installed_products.map do |product|
           ::Registration::SwMgmt.remote_product(product)

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -122,12 +122,15 @@ module Registration
           abort:          :abort,
           cancel:         :abort,
           repo_selection: "select_migration_repos",
-          next:           :next
+          next:           "store_repos_state"
         },
         "select_migration_repos"      => {
           abort:  :abort,
           cancel: :abort,
-          next:   :next
+          next:   "store_repos_state"
+        },
+        "store_repos_state"           => {
+          next: :next
         }
       }
 
@@ -140,7 +143,8 @@ module Registration
           "select_migration_products"   => ->() { select_migration_products },
           "register_migration_products" => [->() { register_migration_products }, true],
           "activate_migration_repos"    => [->() { activate_migration_repos }, true],
-          "select_migration_repos"      => ->() { select_migration_repos }
+          "select_migration_repos"      => ->() { select_migration_repos },
+          "store_repos_state"           => ->() { store_repos_state }
         }
 
         ui = Yast::Sequencer.Run(aliases, WORKFLOW_SEQUENCE)
@@ -153,13 +157,10 @@ module Registration
       def find_products
         log.info "Loading installed products"
 
-        if !SwMgmt.init
+        if !SwMgmt.init(true)
           Yast::Report.Error(Yast::Pkg.LastError)
           return :abort
         end
-
-        # load the resolvables from the repositories
-        Yast::Pkg.SourceLoad
 
         self.products = ::Registration::SwMgmt.installed_products.map do |product|
           ::Registration::SwMgmt.remote_product(product)
@@ -256,8 +257,8 @@ module Registration
         # synchronize the changes done by modifying the services,
         # reinitialize the repositories and reload the available packages
         Yast::Pkg.SourceFinishAll
-        Yast::Pkg.SourceRestore
-        Yast::Pkg.SourceLoad
+        Yast::Pkg.TargetFinish
+        SwMgmt.init(true)
 
         log.info "Registered services: #{registered_services}"
         :next
@@ -308,6 +309,11 @@ module Registration
       # @return [Symbol] the UI symbol (:abort, :next)
       def select_migration_repos
         UI::MigrationReposSelectionDialog.run
+      end
+
+      def store_repos_state
+        RepoStateStorage.instance.write
+        :next
       end
     end
   end

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -31,6 +31,7 @@ module Registration
       Yast.import "Wizard"
       Yast.import "Report"
       Yast.import "HTML"
+      Yast.import "GetInstArgs"
 
       attr_accessor :selected_migration, :manual_repo_selection, :installed_products
 
@@ -68,7 +69,7 @@ module Registration
           # TRANSLATORS: help text (3/3), %s is replaced by the (translated) check box label
           (_("<p>Use the <b>%s</b> check box to manually select the migration " \
                 "repositories later.</p>") % _("Manually Select Migration Repositories")),
-          true,
+          Yast::GetInstArgs.enable_back,
           true
         )
 

--- a/test/media_addon_workflow_spec.rb
+++ b/test/media_addon_workflow_spec.rb
@@ -17,14 +17,16 @@ describe "Registration::UI::MediaAddonWorkflow" do
 
     before do
       # SwMgmt initialization
-      allow(Registration::SwMgmt).to receive(:init).and_return swmgmt_init
+      allow(Registration::SwMgmt).to receive(:init)
       # List of products
       allow(Registration::SwMgmt).to receive(:products_from_repo)
         .and_return(products_from_repo)
     end
 
     context "if package management initialization fails" do
-      let(:swmgmt_init) { false }
+      before do
+        allow(Registration::SwMgmt).to receive(:init).and_raise(Registration::PkgError, "error")
+      end
 
       it "aborts" do
         allow(Yast::Pkg).to receive(:LastError)
@@ -34,8 +36,6 @@ describe "Registration::UI::MediaAddonWorkflow" do
     end
 
     context "if package management initialization success" do
-      let(:swmgmt_init) { true }
-
       before do
         # Load source information
         allow(Yast::Pkg).to receive(:SourceLoad)

--- a/test/media_addon_workflow_spec.rb
+++ b/test/media_addon_workflow_spec.rb
@@ -27,6 +27,7 @@ describe "Registration::UI::MediaAddonWorkflow" do
       let(:swmgmt_init) { false }
 
       it "aborts" do
+        allow(Yast::Pkg).to receive(:LastError)
         expect(Yast::Report).to receive(:Error)
         expect(run).to eq(:abort)
       end

--- a/test/migration_finish_workflow_spec.rb
+++ b/test/migration_finish_workflow_spec.rb
@@ -1,0 +1,26 @@
+#! /usr/bin/env rspec
+
+require_relative "spec_helper"
+
+describe Registration::UI::MigrationFinishWorkflow do
+  describe ".run" do
+    subject { Registration::UI::MigrationFinishWorkflow }
+
+    before do
+      allow_any_instance_of(Registration::RepoStateStorage).to receive(:read)
+    end
+
+    it "restores the repository setup and returns :next" do
+      expect_any_instance_of(Registration::RepoStateStorage).to receive(:restore_all)
+      expect(subject.run).to eq(:next)
+    end
+
+    it "returns :abort on an error" do
+      allow_any_instance_of(Registration::RepoStateStorage).to receive(:restore_all)
+      msg = "Something failed..."
+      expect(Yast::Sequencer).to receive(:Run).and_raise(msg)
+      expect(subject.run).to eq(:abort)
+    end
+
+  end
+end

--- a/test/migration_repos_workflow_spec.rb
+++ b/test/migration_repos_workflow_spec.rb
@@ -19,8 +19,7 @@ describe Registration::UI::MigrationReposWorkflow do
 
     it "aborts if package management initialization fails" do
       msg = "Initialization failed"
-      expect(Registration::SwMgmt).to receive(:init).and_return(false)
-      expect(Yast::Pkg).to receive(:LastError).and_return(msg)
+      expect(Registration::SwMgmt).to receive(:init).and_raise(Registration::PkgError, msg)
 
       expect(subject.run).to eq(:abort)
     end
@@ -37,7 +36,7 @@ describe Registration::UI::MigrationReposWorkflow do
       let(:migration_service) { load_yaml_fixture("migration_service.yml") }
 
       before do
-        expect(Registration::SwMgmt).to receive(:init).at_least(1).and_return(true)
+        expect(Registration::SwMgmt).to receive(:init).at_least(1)
         allow_any_instance_of(Registration::RepoStateStorage).to receive(:write)
       end
 

--- a/test/migration_repos_workflow_spec.rb
+++ b/test/migration_repos_workflow_spec.rb
@@ -12,6 +12,9 @@ describe Registration::UI::MigrationReposWorkflow do
       allow(Registration::Addon).to receive(:find_all)
       # Load source information
       allow(Yast::Pkg).to receive(:SourceLoad)
+      allow(Yast::Pkg).to receive(:SourceFinishAll)
+      allow(Yast::Pkg).to receive(:SourceRestore)
+      allow(Yast::Pkg).to receive(:SourceGetCurrent).and_return([])
     end
 
     it "aborts if package management initialization fails" do
@@ -34,7 +37,8 @@ describe Registration::UI::MigrationReposWorkflow do
       let(:migration_service) { load_yaml_fixture("migration_service.yml") }
 
       before do
-        expect(Registration::SwMgmt).to receive(:init).and_return(true)
+        expect(Registration::SwMgmt).to receive(:init).at_least(1).and_return(true)
+        allow_any_instance_of(Registration::RepoStateStorage).to receive(:write)
       end
 
       let(:set_success_expectations) do

--- a/test/migration_repositories_spec.rb
+++ b/test/migration_repositories_spec.rb
@@ -23,6 +23,7 @@ describe Registration::MigrationRepositories do
 
     it "activates the specified sevices for upgrade" do
       subject.services << "test_service"
+      allow(Yast::Pkg).to receive(:ResolvablePreselectPatches)
 
       subject.activate_services
     end
@@ -41,6 +42,7 @@ describe Registration::MigrationRepositories do
       subject.install_updates = false
       subject.services << service
 
+      expect(Yast::Pkg).to_not receive(:ResolvablePreselectPatches)
       expect(Registration::SwMgmt).to receive(:service_repos).with(service, only_updates: true)
         .and_return(["SrcId" => repo])
 
@@ -57,6 +59,9 @@ describe Registration::MigrationRepositories do
       expect(Yast::Pkg).to receive(:PkgSolve)
       expect(Yast::Pkg).to receive(:PkgUpdateAll)
       expect(Yast::Pkg).to receive(:SourceLoad)
+
+      allow(Yast::Pkg).to receive(:ResolvablePreselectPatches)
+      allow(Yast::Pkg).to receive(:SourceGetCurrent).and_return([])
     end
 
     it "activates the specified repositories and disables the rest" do

--- a/test/registration_ui_test.rb
+++ b/test/registration_ui_test.rb
@@ -94,6 +94,7 @@ describe "Registration::RegistrationUI" do
       allow(Yast::UI).to receive(:OpenDialog)
       allow(Yast::UI).to receive(:CloseDialog)
       allow(Yast::Wizard).to receive(:SetContents)
+      allow(Yast::Pkg).to receive(:SourceGetCurrent).and_return([])
 
       # stub the registration
       allow(registration).to receive(:register_product)

--- a/test/repo_state_spec.rb
+++ b/test/repo_state_spec.rb
@@ -1,0 +1,97 @@
+#! /usr/bin/env rspec
+
+require_relative "spec_helper"
+
+describe Registration::RepoState do
+  subject { Registration::RepoState.new(42, true) }
+  describe "#restore" do
+    it "restores the original repository state" do
+      expect(Yast::Pkg).to receive(:SourceSetEnabled).with(42, true)
+
+      subject.restore
+    end
+  end
+end
+
+describe Registration::RepoStateStorage do
+  # create a new anonymous instance for each test to avoid test dependencies
+  # see http://stackoverflow.com/a/26172556/633234
+  subject { Class.new(Registration::RepoStateStorage).instance }
+  let(:file) { Registration::RepoStateStorage::REPO_STATE_FILE }
+
+  before do
+    allow(Yast::Pkg).to receive(:SourceGetCurrent).and_return([42])
+    allow(Yast::Pkg).to receive(:SourceGeneralData).with(42)
+      .and_return("alias" => "foo")
+  end
+
+  describe "#add" do
+    it "adds a new repository to the storage" do
+      expect { subject.add(42, true) }.to change { subject.repositories.size }.by(1)
+    end
+  end
+
+  describe "#restore_all" do
+    it "calls 'restore' for all repositories" do
+      subject.add(42, true)
+      expect_any_instance_of(Registration::RepoState).to receive(:restore)
+      subject.restore_all
+    end
+  end
+
+  describe "#write" do
+    it "writes the current staus to disk" do
+      subject.add(42, true)
+      expect(File).to receive(:write).with(file, anything)
+      subject.write
+    end
+  end
+
+  describe "#read" do
+    context "the storage file exists" do
+      before do
+        expect(File).to receive(:exist?).with(file).and_return(true)
+        allow(YAML).to receive(:load_file).with(file).and_return("foo" => true)
+      end
+
+      it "reads the stored file" do
+        expect { subject.read }.to change { subject.repositories.size }.from(0).to(1)
+      end
+
+      it "remaps the stored aliases to repository ID" do
+        subject.read
+        expect(subject.repositories.first.repo_id).to eq(42)
+        expect(subject.repositories.first.enabled).to eq(true)
+      end
+
+      it "ignores unknown repository aliases" do
+        expect(YAML).to receive(:load_file).with(file).and_return("FOO" => true)
+        subject.read
+        expect(subject.repositories).to be_empty
+      end
+    end
+
+    context "the storage file does not exist" do
+      it "does not fail if the file does not exist" do
+        expect(File).to receive(:exist?).with(file).and_return(false)
+        expect { subject.read }.to_not raise_error
+      end
+    end
+  end
+
+  describe "#clean" do
+    it "removes the storage file if it exists" do
+      expect(File).to receive(:exist?).with(file).and_return(true)
+      expect(File).to receive(:unlink).with(file)
+
+      subject.clean
+    end
+
+    it "does not try removing the file when it does not exist" do
+      expect(File).to receive(:exist?).with(file).and_return(false)
+      expect(File).to_not receive(:unlink).with(file)
+
+      subject.clean
+    end
+  end
+end

--- a/test/scc_test.rb
+++ b/test/scc_test.rb
@@ -16,7 +16,7 @@ describe "scc client" do
     expect(Yast::Wizard).to receive(:CreateDialog)
     expect(Yast::Wizard).to receive(:CloseDialog)
 
-    expect(Registration::SwMgmt).to receive(:init).and_return(true)
+    expect(Registration::SwMgmt).to receive(:init)
     expect(Registration::SwMgmt).to receive(:find_base_product).and_return("name" => "SLES")
   end
 

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -55,23 +55,22 @@ describe Registration::SwMgmt do
 
     context "when the libzypp lock can be obtained" do
       let(:connected) { true }
-      let(:source_restore_result) { true }
 
-      it "initializes package management and returns Pkg.:SourceRestore result" do
+      it "initializes package management" do
         expect(Yast::PackageCallbacks).to receive(:InitPackageCallbacks)
-        expect(Yast::Pkg).to receive(:TargetInitialize)
-        expect(Yast::Pkg).to receive(:TargetLoad)
-        expect(Yast::Pkg).to receive(:SourceRestore).and_return(source_restore_result)
+        expect(Yast::Pkg).to receive(:TargetInitialize).and_return(true)
+        expect(Yast::Pkg).to receive(:TargetLoad).and_return(true)
+        expect(Yast::Pkg).to receive(:SourceRestore).and_return(true)
 
-        expect(subject.init).to eq(source_restore_result)
+        subject.init
       end
     end
 
     context "when the libzypp lock cannot be obtained" do
       let(:connected) { false }
 
-      it "returns false" do
-        expect(subject.init).to eq(false)
+      it "raises an PkgError exception" do
+        expect { subject.init }.to raise_error(Registration::PkgError)
       end
     end
   end


### PR DESCRIPTION
After migration with disabled updates (migrating to the original SP release) the Update repositories need to be re-enabled.

https://bugzilla.suse.com/show_bug.cgi?id=943960