### PR TITLE
Update RSpec config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :test do
   gem "rake"
   gem "yard"
   gem "yast-rake", ">= 0.1.9"
-  gem "rspec", "~> 2.14.0"
+  gem "rspec", "~> 3.3.0"
   gem "gettext", require: false
   gem "rubocop", "~> 0.29.1", require: false
   gem "simplecov", require: false

--- a/test/finish_dialog_test.rb
+++ b/test/finish_dialog_test.rb
@@ -26,7 +26,6 @@ describe ::Registration::FinishDialog do
       it "do nothing if system is not registered" do
         expect(Registration::Registration).to receive(:is_registered?).once
           .and_return(false)
-        expect_any_instance_of(SUSE::Connect::Config).to_not receive(:write)
         expect(Yast::Pkg).to_not receive(:SourceSetEnabled)
 
         subject.run("Write")

--- a/test/registration_ui_test.rb
+++ b/test/registration_ui_test.rb
@@ -98,7 +98,6 @@ describe "Registration::RegistrationUI" do
 
       # stub the registration
       allow(registration).to receive(:register_product)
-      allow(registration).to receive(:select_repositories)
     end
 
     it "does not ask for reg. code if all addons are free" do

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -16,13 +16,11 @@ if ENV["COVERAGE"]
   end
 end
 
-# allow only the new "expect" RSpec syntax
+# configure RSpec
 RSpec.configure do |config|
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
-  end
   config.mock_with :rspec do |c|
-    c.syntax = :expect
+    # https://relishapp.com/rspec/rspec-mocks/v/3-0/docs/verifying-doubles/partial-doubles
+    c.verify_partial_doubles = true
   end
 end
 


### PR DESCRIPTION
- the expect syntax is default in RSpec3 (no need to set it)
- enable verifying doubles, remove the obsolete (invalid) mocks
- use RSpec3 at Travis