### PR TITLE
Unique widget ID in addon selection dialog

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,3 +1,6 @@
+- Addon selection dialog - avoid possible ID duplicates when
+  an addon with multiple versions is displayed
+
 -------------------------------------------------------------------
 Wed Apr  8 15:31:18 UTC 2015 - lslezak@suse.cz
 

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,5 +1,10 @@
+-------------------------------------------------------------------
+Thu Oct  8 15:51:19 UTC 2015 - lslezak@suse.cz
+
 - Addon selection dialog - avoid possible ID duplicates when
-  an addon with multiple versions is displayed
+  an addon with multiple versions is displayed, fixes the problem
+  when registering SES1.0 or SES2.0 extension (bsc#949424)
+- 3.1.129.2
 
 -------------------------------------------------------------------
 Wed Apr  8 15:31:18 UTC 2015 - lslezak@suse.cz

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.129.1
+Version:        3.1.129.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/addon_selection_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_dialog.rb
@@ -65,6 +65,13 @@ module Registration
 
       private
 
+      # create widget ID for an addon
+      # @param [<Addon>] addon the addon
+      # @return [String] widget id
+      def addon_widget_id(addon)
+        "#{addon.identifier}-#{addon.version}-#{addon.arch}"
+      end
+
       def content
         VBox(
           VStretch(),
@@ -133,7 +140,7 @@ module Registration
         # (%s is an extension name)
         label = addon.available? ? addon.label : (_("%s (not available)") % addon.label)
 
-        CheckBox(Id(addon.identifier),
+        CheckBox(Id(addon_widget_id(addon)),
           Opt(:notify),
           label,
           addon.selected? || addon.registered?)
@@ -169,13 +176,15 @@ module Registration
         Addon.selected.empty? ? :skip : :next
       end
 
+      # handler for changing the addon status in the main loop
+      # @param id [String] addon widget id
       def handle_addon_selection(id)
         # check whether it's an add-on ID (checkbox clicked)
-        addon = @addons.find { |a| a.identifier == id }
+        addon = @addons.find { |a| addon_widget_id(a) == id }
         return unless addon
 
         show_addon_details(addon)
-        if Yast::UI.QueryWidget(Id(addon.identifier), :Value)
+        if Yast::UI.QueryWidget(Id(addon_widget_id(addon)), :Value)
           addon.selected
         else
           addon.unselected
@@ -192,7 +201,7 @@ module Registration
 
       def reactivate_dependencies
         @addons.each do |addon|
-          Yast::UI.ChangeWidget(Id(addon.identifier), :Enabled, addon.selectable?)
+          Yast::UI.ChangeWidget(Id(addon_widget_id(addon)), :Enabled, addon.selectable?)
         end
       end
 

--- a/test/addon_selection_dialog_test.rb
+++ b/test/addon_selection_dialog_test.rb
@@ -29,13 +29,14 @@ describe Registration::UI::AddonSelectionDialog do
     end
 
     it "returns `:next` if some addons are selected and user click next" do
-      test_addon = addon_generator
-      expect(Yast::UI).to receive(:UserInput).and_return(test_addon.identifier, :next)
+      addon = addon_generator
+      widget = "#{addon.identifier}-#{addon.version}-#{addon.arch}"
+      expect(Yast::UI).to receive(:UserInput).and_return(widget, :next)
       # mock that widget is selected
       expect(Yast::UI).to receive(:QueryWidget)
-        .with(Yast::Term.new(:id, test_addon.identifier), :Value)
+        .with(Yast::Term.new(:id, widget), :Value)
         .and_return(true)
-      registration = double(activated_products: [], get_addon_list: [test_addon])
+      registration = double(activated_products: [], get_addon_list: [addon])
       expect(subject.run(registration)).to eq :next
     end
   end


### PR DESCRIPTION
This is a backport of https://github.com/yast/yast-registration/commit/8628c5f0ac0ed4f556a89abdad5f7250f38b61c7 to SLE12-GA.

It is urgently needed to fix the SUSE Enterprise Storage registration (https://bugzilla.suse.com/show_bug.cgi?id=949424).