### PR TITLE
Update the Connect version dependency

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -6,6 +6,8 @@ Thu Oct  8 15:51:19 UTC 2015 - lslezak@suse.cz
   when registering SES1.0 or SES2.0 extension (bsc#949424)
 - Addon selection dialog - sort the addons by the displayed label,
   not by the internal name (which might not be unique) (bsc#949424)
+- Require connect >= 0.2.14.42 to allow using a SCC server side
+  workaround for bsc#949424 in the original GA installer
 - 3.1.129.2
 
 -------------------------------------------------------------------

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -31,7 +31,12 @@ Requires:       yast2 >= 3.1.26
 Requires:       yast2-pkg-bindings >= 2.17.20
 # N_() method
 Requires:       yast2-ruby-bindings >= 3.1.12
-Requires:       rubygem(suse-connect) >= 0.2.0
+# Connect in 0.2.14.42 from Updates is the very same as the 0.2.14 version
+# from SLE-12-GA, the version is just used to distinguish between the original
+# unpatched registration from GA and the registration with a fix for
+# bsc#949424. (The Connect version is included in the request header and
+# the SCC server then can handle the GA registration differently).
+Requires:       rubygem(suse-connect) >= 0.2.14.42
 Requires:       yast2-slp >= 3.1.2
 Requires:       yast2-add-on >= 3.1.8
 Requires:       yast2-packager >= 3.1.26


### PR DESCRIPTION
This is a workaround for [bsc#949424](https://bugzilla.suse.com/show_bug.cgi?id=949424) in the original SLE-12-GA installation system. The bug is about conflict between the SES1 and SES2 extensions where only one of them is handled properly.

The connect version is sent in the request header, the workaround is that the SCC server will return only SES2 extension and will hide SES1 when it detects the registration from the SLE-12-GA installer.

The `yast2-registration` maintenance update will be released together with a new Connect where the only difference will be the version number (the other incompatible changes will be released later together with the migration patch). For this Connect version (actually all except the GA version) the SCC server will return both SES1 and SES2 extensions as the fixed YaST package can handle them correctly.