### PR TITLE
Display a better error message when registration fails (bsc#952443)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov  2 14:21:16 UTC 2015 - lslezak@suse.cz
+
+- display a better error message when registration fails because
+  of a typo in the URL (bsc#952443)
+- 3.1.164
+
+-------------------------------------------------------------------
 Mon Oct 19 07:21:58 UTC 2015 - lslezak@suse.cz
 
 - Addon upgrade - fixed crash when upgrading installed addon

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.163
+Version:        3.1.164
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
...because of a typo in the URL

- 3.1.164

### Notes:

- When registration failed it was considered as an unconfigured network, but that's not always the case. If you use a SMT registration server and make a typo in the host name you would get the same error and that was confusing (the network really was configured).
- The move to a separate method was required by RuboCop, it started to complain about too long method... :wink: 
- The error message has been reused (because of the text freeze) and should be improved later, but there are also displayed the error details which should make it more clear what has happened...

#### The original state:

![registration_invalid_hostname_bug](https://cloud.githubusercontent.com/assets/907998/10885560/2bbfa358-817e-11e5-954c-7ef2d5806927.png)

#### Fixed version:
![registration_invalid_hostname_fixed](https://cloud.githubusercontent.com/assets/907998/10885589/49cd97ba-817e-11e5-9c26-4f2a008813b6.png)