### PR TITLE
Always enable update repositories for modules (bsc#953536)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Nov  6 20:26:06 UTC 2015 - lslezak@suse.cz
+
+- always enable update repositories for modules during online
+  migration (bsc#953536)
+- 3.1.165
+
+-------------------------------------------------------------------
 Mon Nov  2 14:21:16 UTC 2015 - lslezak@suse.cz
 
 - display a better error message when registration fails because

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.164
+Version:        3.1.165
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/migration_repositories_spec.rb
+++ b/test/migration_repositories_spec.rb
@@ -21,7 +21,7 @@ describe Registration::MigrationRepositories do
       expect(Yast::Pkg).to receive(:SourceLoad)
     end
 
-    it "activates the specified sevices for upgrade" do
+    it "activates the specified services for upgrade" do
       subject.services << "test_service"
       allow(Yast::Pkg).to receive(:ResolvablePreselectPatches)
 
@@ -37,7 +37,8 @@ describe Registration::MigrationRepositories do
     end
 
     it "disables update repositories if updates should not be installed" do
-      service = "test_service"
+      product = double("test_product", product_type: "base")
+      service = double("test_service", product: product)
       repo = 42
       subject.install_updates = false
       subject.services << service
@@ -47,6 +48,19 @@ describe Registration::MigrationRepositories do
         .and_return(["SrcId" => repo])
 
       expect(Registration::SwMgmt).to receive(:set_repos_state).with([{ "SrcId" => repo }], false)
+
+      subject.activate_services
+    end
+
+    it "keeps module update repositories enabled eventhough updates should not be installed" do
+      product = double("test_product", product_type: "module")
+      service = double("test_service", product: product)
+
+      subject.install_updates = false
+      subject.services << service
+
+      # empty list of disabled repositories
+      expect(Registration::SwMgmt).to receive(:set_repos_state).with([], false)
 
       subject.activate_services
     end


### PR DESCRIPTION
(during online migration)

- 3.1.165

Fixes [bsc#953536](https://bugzilla.suse.com/show_bug.cgi?id=953536)

### Online Migration Bug

### Bug Prerequisites

- Any module is registered in the system
- User selects to **not** install updates in this dialog:

![migration_disabled_updates_question](https://cloud.githubusercontent.com/assets/907998/11022467/6a28ff4a-8660-11e5-8c04-137407db333c.png)

### The Bug

The result is a dependency conflict in the migration summary:

![migration_disabled_updates_broken_summary](https://cloud.githubusercontent.com/assets/907998/11022481/e2e1d0ce-8660-11e5-80e9-d197fb8c0d23.png)

There is a conflict in the package management:

![migration_disabled_updates_broken_conflict](https://cloud.githubusercontent.com/assets/907998/11022487/06215f28-8661-11e5-9246-bd81455c1b7d.png)

This is caused by bug [bsc#939702](https://bugzilla.suse.com/show_bug.cgi?id=939702).

All update repositories are disabled:

![migration_disabled_updates_broken_repos](https://cloud.githubusercontent.com/assets/907998/11022484/f980dd20-8660-11e5-854e-1cfaed848158.png)

### Bug Fix

This patch fixes the problem:

![migration_disabled_updates_fixed_summary](https://cloud.githubusercontent.com/assets/907998/11022527/6ea4eede-8661-11e5-9ca2-978427153703.png)


It always keeps the update repositories for modules enabled, the update repositories for the other product types (base product, extension) are diabled.

![migration_disabled_updates_fixed_repos](https://cloud.githubusercontent.com/assets/907998/11022528/742a93ae-8661-11e5-9ffc-480e0b9dcd28.png)

