### PR TITLE
Fixed a crash when EULA download fails (bsc#941232)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 15 08:44:50 UTC 2016 - lslezak@suse.cz
+
+- Fixed a crash when EULA download fails (bsc#941232)
+- 3.1.167
+
+-------------------------------------------------------------------
 Wed Nov 18 11:32:26 UTC 2015 - igonzalezsosa@suse.com
 
 - Fix validation of AutoYaST profiles (bsc#954412)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.166
+Version:        3.1.167
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/addon_eula_dialog.rb
+++ b/src/lib/registration/ui/addon_eula_dialog.rb
@@ -128,7 +128,7 @@ module Registration
       # @return [Symbol] :accepted, :back, :abort, :halt
       def accept_eula(addon)
         Dir.mktmpdir("extension-eula-") do |tmpdir|
-          return false unless download_eula(addon, tmpdir)
+          return :back unless download_eula(addon, tmpdir)
           eula_reader = EulaReader.new(tmpdir)
 
           setup_eula_dialog(addon, eula_reader, tmpdir)


### PR DESCRIPTION
- 3.1.167

Manually tested with this hack which adds a non-existing license file to the list of available licenses (to force a download error for manual testing):

```diff
--- a/src/lib/registration/eula_downloader.rb
+++ b/src/lib/registration/eula_downloader.rb
@@ -86,6 +86,8 @@ module Registration
       licenses.delete(INDEX_FILE)
       log.info "Downloaded license index: #{licenses}"
 
+      licenses << "missing.txt"
+
       licenses
     end
   end
```

*(Interestingly the comment just above the fix lists the expected return values, this error could have been easily spotted...)*