### PR TITLE
Ask again after wrong registration code (bsc#958521)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Feb 12 12:42:19 UTC 2016 - knut.anderssen@suse.com
+
+- Continue asking for registration codes also after failed
+  registration. you should go back to unselect some of not wanted
+  modules (bsc#958521)
+- 3.1.168
+
+-------------------------------------------------------------------
 Fri Jan 15 08:44:50 UTC 2016 - lslezak@suse.cz
 
 - Fixed a crash when EULA download fails (bsc#941232)

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,9 +1,7 @@
 -------------------------------------------------------------------
 Fri Feb 12 12:42:19 UTC 2016 - knut.anderssen@suse.com
 
-- Continue asking for registration codes also after failed
-  registration. you should go back to unselect some of not wanted
-  modules (bsc#958521)
+- Ask again after some provided registration code failed (bsc#958521)
 - 3.1.168
 
 -------------------------------------------------------------------

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.167
+Version:        3.1.168
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_scc.rb
+++ b/src/clients/inst_scc.rb
@@ -164,9 +164,11 @@ module Yast
     end
 
     # register all selected addons
+    # back returns directly to the extensions selection
     def register_addons
       return false if init_registration == :cancel
-      registration_ui.register_addons(@selected_addons, @known_reg_codes)
+      ret = registration_ui.register_addons(@selected_addons, @known_reg_codes)
+      (ret == :back) ? :extensions : ret
     end
 
     # do some sanity checks and decide which workflow will be used
@@ -304,12 +306,14 @@ module Yast
           next:  "register_addons"
         },
         "register_addons"        => {
-          abort: :abort,
-          next:  "update_autoyast_config"
+          abort:      :abort,
+          extensions: "select_addons",
+          next:       "update_autoyast_config"
         },
         "reregister_addons"      => {
-          abort: :abort,
-          next:  "check"
+          abort:      :abort,
+          extensions: "select_addons",
+          next:       "check"
         },
         "update_autoyast_config" => {
           abort: :abort,

--- a/src/clients/inst_scc.rb
+++ b/src/clients/inst_scc.rb
@@ -168,7 +168,8 @@ module Yast
     def register_addons
       return false if init_registration == :cancel
       ret = registration_ui.register_addons(@selected_addons, @known_reg_codes)
-      (ret == :back) ? :extensions : ret
+      ret = :extensions if ret == :back
+      ret
     end
 
     # do some sanity checks and decide which workflow will be used
@@ -312,7 +313,7 @@ module Yast
         },
         "reregister_addons"      => {
           abort:      :abort,
-          extensions: "select_addons",
+          extensions: "select_addons_rereg",
           next:       "check"
         },
         "update_autoyast_config" => {

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -133,7 +133,7 @@ module Registration
       Addon.selected.delete(self) if selected?
     end
 
-    # has beem the add-on registered?
+    # has been the add-on registered?
     # @return [Boolean] true if the add-on has been registered
     def registered?
       Addon.registered.include?(self)

--- a/src/lib/registration/registration_ui.rb
+++ b/src/lib/registration/registration_ui.rb
@@ -294,13 +294,16 @@ module Registration
       registration_order = selected_addons.clone
 
       product_succeed = registration_order.map do |product|
-        ConnectHelpers.catch_registration_errors(
+        registered = ConnectHelpers.catch_registration_errors(
           message_prefix: "#{product.label}\n") do
-          register_selected_addon(product, known_reg_codes[product.identifier])
-        end
+            register_selected_addon(product, known_reg_codes[product.identifier])
+          end
 
         # remove from selected after successful registration
-        selected_addons.reject! { |selected| selected.identifier == product.identifier }
+        if registered
+          selected_addons.reject! { |selected| selected.identifier == product.identifier }
+        end
+        registered
       end
 
       !product_succeed.include?(false) # succeed only if noone failed

--- a/test/registration_ui_test.rb
+++ b/test/registration_ui_test.rb
@@ -128,6 +128,7 @@ describe "Registration::RegistrationUI" do
 
       # All selected addons are marked as registered
       expect(selected_addons.all?(&:registered?)).to eq(true)
+      expect(selected_addons.size).to eq (0)
     end
 
     it "returns :next if everything goes fine" do


### PR DESCRIPTION
- We will register all valid addons and will continue asking for register codes for the missing ones. You can go back and disable the extension in case you decide to not install it.