### PR TITLE
Do not perform SLP discovery when running specs.

### DIFF
--- a/test/inst_scc_test.rb
+++ b/test/inst_scc_test.rb
@@ -12,6 +12,7 @@ describe "inst_scc client" do
     allow(Yast::UI).to receive(:ChangeWidget)
     allow(Yast::UI).to receive(:SetFocus)
     allow(Yast::UI).to receive(:ReplaceWidget)
+    allow(Yast::SlpService).to receive(:all).and_return([])
   end
 
   context "the system is already registered" do

--- a/test/media_addon_workflow_spec.rb
+++ b/test/media_addon_workflow_spec.rb
@@ -21,6 +21,7 @@ describe "Registration::UI::MediaAddonWorkflow" do
       # List of products
       allow(Registration::SwMgmt).to receive(:products_from_repo)
         .and_return(products_from_repo)
+      allow(Yast::SlpService).to receive(:all).and_return([])
     end
 
     context "if package management initialization fails" do


### PR DESCRIPTION
Without this,
if there is a SLP server offering service:registration.suse on the local network,
and it is not blocked by iptables
the tests will loop endlessly.

See https://ci.suse.de/view/YaST/job/yast-registration-master/20/console , or turn off firewall on a machine in the Prague office and try `rake osc:build`, with and without this PR.