### PR TITLE
Allow changing the build target via environment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :sle12sp1
+yast_submit = ENV["YAST_SUBMIT"] || :sle12sp1
+Yast::Tasks.submit_to(yast_submit.to_sym)
 
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now


### PR DESCRIPTION
Use `YAST_SUBMIT` variable to override the build target to [sle12sp1_public](https://github.com/yast/yast-rake/blob/3dc1fc49f9a17211a5c169070d1ae9872c69ee25/data/targets.yml#L16) at Jenkins builds.

See http://ci.opensuse.org/job/yast-registration-github-push/490//console.