### PR TITLE
Unified shortcut 'alt-w' for network setup button (bsc#974216)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr  6 10:21:38 UTC 2016 - knut.anderssen@suse.com
+
+- Unified shortcut 'alt-w' for network setup button (bsc#974216)
+- 3.1.170
+
+-------------------------------------------------------------------
 Thu Feb 18 08:24:18 UTC 2016 - mvidner@suse.com
 
 - Read registration codes from a USB stick (FATE#316796)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.169
+Version:        3.1.170
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -222,7 +222,7 @@ module Registration
       def network_button
         return Empty() unless Helpers.network_configurable
 
-        Right(PushButton(Id(:network), _("Network Configuration...")))
+        Right(PushButton(Id(:network), _("Net&work Configuration...")))
       end
 
       # handle pressing the "Local Registration Server" button


### PR DESCRIPTION
![registrationnetshortcut](https://cloud.githubusercontent.com/assets/7056681/14313894/2f70f414-fbec-11e5-9fcc-543674e5bb5d.png)
