### PR TITLE
Select the default product patterns (FATE#320199)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May  4 12:58:57 UTC 2016 - lslezak@suse.cz
+
+- Select the default product patterns for the registered modules
+  and extensions (FATE#320199)
+- 3.1.172
+
+-------------------------------------------------------------------
 Wed Apr  6 16:10:58 CEST 2016 - schubi@suse.de
 
 - Force refreshing while adding a service (bnc#967828).

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.171
+Version:        3.1.172
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -43,7 +43,8 @@ Requires:       SUSEConnect
 
 Requires:       yast2-slp >= 3.1.2
 Requires:       yast2-add-on >= 3.1.8
-Requires:       yast2-packager >= 3.1.26
+# packager/product_patterns.rb
+Requires:       yast2-packager >= 3.1.95
 Requires:       yast2-update >= 3.1.36
 
 BuildRequires:  yast2 >= 3.1.26
@@ -53,7 +54,8 @@ BuildRequires:  rubygem(yast-rake) >= 0.2.5
 BuildRequires:  rubygem(rspec)
 BuildRequires:  rubygem(suse-connect) >= 0.2.22
 BuildRequires:  yast2-slp >= 3.1.2
-BuildRequires:  yast2-packager >= 3.1.26
+# packager/product_patterns.rb
+BuildRequires:  yast2-packager >= 3.1.95
 BuildRequires:  yast2-update >= 3.1.36
 
 BuildArch:      noarch

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -33,6 +33,8 @@ require "registration/helpers"
 require "registration/url_helpers"
 require "registration/repo_state"
 
+require "packager/product_patterns"
+
 module Registration
   Yast.import "AddOnProduct"
   Yast.import "Mode"
@@ -460,7 +462,15 @@ module Registration
 
       log.info "Products to install: #{products}"
 
-      products.all? { |product| Pkg.ResolvableInstall(product, :product) }
+      ret = products.all? { |product| Pkg.ResolvableInstall(product, :product) }
+
+      # preselect the default product patterns (FATE#320199)
+      # note: must be called *after* selecting the products
+      product_patterns = ProductPatterns.new
+      log.info "Selecting the default product patterns: #{product_patterns.names}"
+      product_patterns.select
+
+      ret
     end
 
     # select remote addons matching the product resolvables

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -215,16 +215,28 @@ describe Registration::SwMgmt do
   end
 
   describe ".select_addon_products" do
-    it "selects new addon products for installation" do
-      legacy_services = load_yaml_fixture("legacy_module_services.yml")
+    before do
+      allow_any_instance_of(Yast::ProductPatterns).to receive(:names).and_return([])
+      allow_any_instance_of(Yast::ProductPatterns).to receive(:select)
 
-      expect(::Registration::Storage::Cache).to receive(:instance)
+      legacy_services = load_yaml_fixture("legacy_module_services.yml")
+      allow(::Registration::Storage::Cache).to receive(:instance)
         .and_return(double("addon_services" => legacy_services))
-      expect(subject).to receive(:service_repos).with(legacy_services.first)
+      allow(subject).to receive(:service_repos).with(legacy_services.first)
         .and_return(load_yaml_fixture("legacy_module_repositories.yml"))
-      expect(Yast::Pkg).to receive(:ResolvableProperties)
+      allow(Yast::Pkg).to receive(:ResolvableProperties)
         .and_return(load_yaml_fixture("products_legacy_installation.yml"))
+      allow(Yast::Pkg).to receive(:ResolvableInstall).with("sle-module-legacy", :product)
+    end
+
+    it "selects new addon products for installation" do
       expect(Yast::Pkg).to receive(:ResolvableInstall).with("sle-module-legacy", :product)
+
+      subject.select_addon_products
+    end
+
+    it "selects the default patterns for the selected products" do
+      expect_any_instance_of(Yast::ProductPatterns).to receive(:select)
 
       subject.select_addon_products
     end


### PR DESCRIPTION
[FATE#320199](https://fate.suse.com/320199) - Select the default product patterns, this part is for the registered modules and extensions in an installed system.

- 3.1.172

### Testing

The code has been tested in a patched SP1 installation as SP2 builds cannot be registered yet.

Here is a snippet from `y2log` showing that the code was called as expected after registering the *Web and Scripting* module:

```
packager/product_patterns.rb:54 Found selected products: ["sle-module-web-scripting"]
packager/product_patterns.rb:140 Found default patterns: []
packager/product_patterns.rb:57 Default patterns for the selected products: []
registration/sw_mgmt.rb:469 Selecting the default product patterns: []
```

*Note: No product was selected as the new `defaultpattern()` tags are not used in SP1 products, this just proves that the pattern selection code was executed.*