### PR TITLE
Preselect the Toolchain module on ARM64

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,10 @@ Yast::Tasks.configuration do |conf|
   # lets ignore license check for now
   conf.skip_license_check << /.*/
 end
+
+task "test:unit" => "test:unit:env"
+
+task "test:unit:env" do
+  # run tests in English locale (to avoid problems with translations)
+  ENV["LC_ALL"] = "en_US.UTF-8"
+end

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun 13 17:08:26 UTC 2016 - lslezak@suse.cz
+
+- Automatically preselect the Toolchain module on ARM in SLES12-SP2
+  (FATE#320679)
+- 3.1.175
+
+-------------------------------------------------------------------
 Fri Jun  3 09:53:50 UTC 2016 - igonzalezsosa@suse.com
 
 - regurl parameter overwrites default SCC registration URL

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.174
+Version:        3.1.175
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -268,6 +268,7 @@ module Registration
 
       # workaround for FATE#320679 - preselect the Toolchain module on ARM
       # in SLES12-SP2
+      # FIXME: remove this hack in SLES12-SP3, use a proper solution instead
       def aarch64_workaround
         # SLES12-SP2 base?
         product = SwMgmt.base_product_to_register

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -4,6 +4,7 @@ require "yast"
 require "registration/ui/abort_confirmation"
 require "registration/addon"
 require "registration/addon_sorter"
+require "registration/sw_mgmt"
 
 module Registration
   module UI
@@ -21,6 +22,7 @@ module Registration
       Yast.import "UI"
       Yast.import "Wizard"
       Yast.import "Stage"
+      Yast.import "Arch"
 
       # constructor
       # @param registration [Registration::Registration] use this Registration object for
@@ -33,6 +35,9 @@ module Registration
         @addons.sort!(&::Registration::ADDON_SORTER)
 
         @old_selection = Addon.selected.dup
+
+        # activate a workaround on ARM (FATE#320679)
+        aarch64_workaround if Arch.aarch64
 
         log.info "Available addons: #{@addons}"
       end
@@ -259,6 +264,25 @@ module Registration
           # help text (3/3)
           _("<p>If you want to remove any extension or module you need to log"\
               "into the SUSE Customer Center and remove them manually there.</p>")
+      end
+
+      # workaround for FATE#320679 - preselect the Toolchain module on ARM
+      # in SLES12-SP2
+      def aarch64_workaround
+        # SLES12-SP2 base?
+        product = SwMgmt.base_product_to_register
+        return unless product["name"] == "SLES" && product["version"] == "12.2"
+
+        # is the Toolchain module available?
+        toolchain = @addons.find do |addon|
+          addon.identifier == "sle-module-toolchain" && addon.version == "12" \
+            && addon.arch == "aarch64"
+        end
+        return unless toolchain
+
+        # then pre-select it!
+        log.info "Activating the ARM64 workaround, preselecting addon: #{toolchain}"
+        toolchain.selected
       end
     end
   end

--- a/test/base_system_registration_dialog_test.rb
+++ b/test/base_system_registration_dialog_test.rb
@@ -38,6 +38,7 @@ describe Registration::UI::BaseSystemRegistrationDialog do
       before do
         allow(Registration::UrlHelpers).to receive(:registration_url).and_return(nil)
         allow(Registration::RegistrationUI).to receive(:new).and_return(registration_ui)
+        allow(Registration::Helpers).to receive(:reset_registration_status)
       end
 
       context "when user enters a correct regcode" do


### PR DESCRIPTION
## Details

- See [FATE320679](https://fate.suse.com/320679)
- There are also few test suite improvelemnts
- The workaround is limited to SP2, in SP3 we will need a proper solution

## Testing

- Added unit tests
- Tested in a patched SLES installation (the latest build)
- I have manually adjusted the patch with simple `s/aarch64/x86_64/g` so it could be tested on x86_64 without need for special ARM64 hardware:

# Screencast
*(Adjusted and tested on x86_64 to be easier to test, in reality the module is not pre-selected on x86_64.)*

![preselect_toolchain6](https://cloud.githubusercontent.com/assets/907998/16060447/0ec57a28-3288-11e6-9a23-a66c9b4b178f.gif)
