### PR TITLE
Offer a list of found local SMT servers

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 17 12:45:21 UTC 2016 - mvidner@suse.com
+
+- For "Register System via local SMT Server" offer a list of servers
+  found with SLP (bsc#981633).
+- 3.1.176
+
+-------------------------------------------------------------------
 Mon Jun 13 17:08:26 UTC 2016 - lslezak@suse.cz
 
 - Automatically preselect the Toolchain module on ARM in SLES12-SP2

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.175
+Version:        3.1.176
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -279,8 +279,15 @@ module Registration
       #
       # @return [Yast::Term] UI terms
       def register_local_option
-        # If not special URL is used, show an example one.
-        url = using_default_url? ? EXAMPLE_SMT_URL : reg_options[:custom_url]
+        # If not special URL is used, probe with SLP
+        if using_default_url?
+          services = UrlHelpers.slp_discovery_feedback
+          urls = services.map { |svc| UrlHelpers.service_url(svc.slp_url) }
+          urls = [EXAMPLE_SMT_URL] if urls.empty?
+        else
+          urls = [reg_options[:custom_url]]
+        end
+
         VBox(
           Left(
             RadioButton(
@@ -296,8 +303,10 @@ module Registration
             HBox(
               HSpacing(5),
               VBox(
-                MinWidth(REG_CODE_WIDTH, InputField(Id(:custom_url),
-                  _("&Local Registration Server URL"), url))
+                MinWidth(REG_CODE_WIDTH,
+                  ComboBox(Id(:custom_url), Opt(:editable),
+                    _("&Local Registration Server URL"), urls)
+                )
               )
             )
           ),

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -204,7 +204,7 @@ module Registration
       # Read registration options from Storage::InstallationOptions
       # and, if needed, from Storage::RegCodes.
       #
-      # @retun [Hash] Hash containing values for :reg_code,
+      # @return [Hash] Hash containing values for :reg_code,
       #               :email and :custom_url.
       def reg_options
         return @reg_options unless @reg_options.nil?
@@ -512,7 +512,8 @@ module Registration
 
       # This method check whether the input is valid
       #
-      # It relies in methods "validate_#{action}". For example, #validate_register_local.
+      # It relies on methods "validate_#!{action}".
+      # For example, {#validate_register_local}.
       # It's intended to be used when the user clicks "Next" button.
       #
       # @return [Boolean] True if input is valid; false otherwise.

--- a/src/lib/registration/url_helpers.rb
+++ b/src/lib/registration/url_helpers.rb
@@ -48,7 +48,6 @@ module Registration
     # SLP service name
     SLP_SERVICE = "registration.suse"
 
-    # Get the language for using in HTTP requests (in "Accept-Language" header)
     # Evaluate the registration URL to use
     # @see https://github.com/yast/yast-registration/wiki/Changing-the-Registration-Server
     # for details
@@ -85,6 +84,7 @@ module Registration
       url
     end
 
+    # @return [void]
     def self.reset_registration_url
       ::Registration::Storage::Cache.instance.reg_url = nil
       ::Registration::Storage::Cache.instance.reg_url_cached = false
@@ -93,12 +93,14 @@ module Registration
     # convert service URL to plain URL, remove the SLP service prefix
     # "service:registration.suse:smt:https://scc.suse.com/connect" ->
     # "https://scc.suse.com/connect"
+    # @param service [String]
+    # @return [String]
     def self.service_url(service)
       service.sub(/\Aservice:#{Regexp.escape(SLP_SERVICE)}:[^:]+:/, "")
     end
 
-    # return "credentials" parameter from URL
-    # raises URI::InvalidURIError if URL is invalid
+    # @return [String] "credentials" parameter from URL
+    # @raise [URI::InvalidURIError] if URL is invalid
     # @param url [String] URL as string
     def self.credentials_from_url(url)
       parsed_url = URI(url)
@@ -108,6 +110,7 @@ module Registration
     end
 
     # get registration URL in installation mode
+    # @return (see registration_url)
     def self.reg_url_at_installation
       custom_url = ::Registration::Storage::InstallationOptions.instance.custom_url
       return custom_url if custom_url && !custom_url.empty?
@@ -121,6 +124,7 @@ module Registration
     end
 
     # get registration URL from AutoYaST configuration file
+    # @return (see registration_url)
     def self.reg_url_from_autoyast_config
       server = ::Registration::Storage::Config.instance.reg_server
       return server if server && !server.empty?
@@ -128,6 +132,7 @@ module Registration
     end
 
     # get registration URL in upgrade mode
+    # @return (see registration_url)
     def self.reg_url_at_upgrade
       # in online upgrade mode behave like in installed system
       return reg_url_at_running_system if Yast::Installation.destdir == "/"
@@ -162,6 +167,7 @@ module Registration
     end
 
     # get registration URL in running system
+    # @return (see registration_url)
     def self.reg_url_at_running_system
       custom_url = ::Registration::Storage::InstallationOptions.instance.custom_url
       return custom_url if custom_url && !custom_url.empty?
@@ -176,7 +182,7 @@ module Registration
       slp_service_url
     end
 
-    # return the boot command line parameter
+    # @return [String,nil] the boot command line parameter
     def self.boot_reg_url
       reg_url = Yast::Linuxrc.InstallInf("regurl")
       log.info "Boot regurl option: #{reg_url.inspect}"
@@ -187,6 +193,7 @@ module Registration
     private_class_method :reg_url_at_running_system, :reg_url_at_upgrade,
       :reg_url_at_installation
 
+    # @return (see registration_url)
     def self.slp_service_url
       log.info "Starting SLP discovery..."
       url = Yast::WFM.call("discover_registration_services")
@@ -195,6 +202,7 @@ module Registration
       url
     end
 
+    # @return [Array<Yast::SlpServiceClass::Service>]
     def self.slp_discovery
       log.info "Searching for #{SLP_SERVICE} SLP services"
       services = Yast::SlpService.all(SLP_SERVICE)
@@ -207,6 +215,7 @@ module Registration
       services
     end
 
+    # @return [Array<Yast::SlpServiceClass::Service>]
     def self.slp_discovery_feedback
       Yast::Popup.Feedback(_("Searching..."), _("Looking up local registration servers...")) do
         slp_discovery


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=981633
(internal tracking: https://trello.com/c/vwuEhHKZ)

Before, the widget was a single text field and a little helpful `smt.example.com` was always shown (no matter what your actual domain was).
![local-smt-server-1-before](https://cloud.githubusercontent.com/assets/102056/16152080/50519e9e-34a0-11e6-93f1-6402aa1be0d4.png)

Now, if your local [SMT](https://www.suse.com/documentation/smt11/) servers are advertised via [SLP](https://en.wikipedia.org/wiki/Service_Location_Protocol) they will be offered as choices . (Here `acme.com` stands for your domain)
![local-smt-server-2-after](https://cloud.githubusercontent.com/assets/102056/16152092/58652218-34a0-11e6-9754-a4181ec2ea20.png)

