### PR TITLE
Rubocop update

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,12 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Max: 25
 
+# FIXME: It seems the cop does not handle this complex case correctly,
+# disable it for now on that file.
+Lint/ShadowedException:
+  Exclude:
+    - 'src/lib/registration/connect_helpers.rb'
+
 # Offense count: 5
 Style/AccessorMethodName:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :test do
   gem "yast-rake", ">= 0.1.9"
   gem "rspec", "~> 3.3.0"
   gem "gettext", require: false
-  gem "rubocop", "~> 0.29.1", require: false
+  gem "rubocop", "~> 0.41.2", require: false
   gem "simplecov", require: false
   gem "coveralls", require: false if ENV["TRAVIS"]
 end

--- a/src/clients/discover_registration_services.rb
+++ b/src/clients/discover_registration_services.rb
@@ -54,8 +54,7 @@ module Yast
           ),
           VSpacing(Opt(:vstretch), 1),
           button_box
-        )
-      )
+        ))
     end
 
     def handle_dialog

--- a/src/clients/inst_scc.rb
+++ b/src/clients/inst_scc.rb
@@ -202,12 +202,10 @@ module Yast
         end
       end
 
-      if Mode.normal && ::Registration::Registration.is_registered?
-        log.info "The system is already registered, displaying registered dialog"
-        return ::Registration::UI::RegisteredSystemDialog.run
-      else
-        return :register
-      end
+      return :register unless Mode.normal && ::Registration::Registration.is_registered?
+
+      log.info "The system is already registered, displaying registered dialog"
+      ::Registration::UI::RegisteredSystemDialog.run
     end
 
     # display EULAs for the selected addons

--- a/src/clients/scc_auto.rb
+++ b/src/clients/scc_auto.rb
@@ -326,7 +326,8 @@ module Yast
       Popup.Feedback(
         _(CONTACTING_MESSAGE),
         # %s is name of given product
-        _("Registering %s ...") % addon["name"]) do
+        _("Registering %s ...") % addon["name"]
+      ) do
         registration.register_product(addon)
       end
     end

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -284,7 +284,8 @@ module Registration
         if Yast::Popup.YesNo(
           # Error popup
           _("Network is not configured, the registration server cannot be reached.\n" \
-              "Do you want to configure the network now?"))
+              "Do you want to configure the network now?")
+        )
 
           Helpers.run_network_configuration
         end

--- a/src/lib/registration/eula_downloader.rb
+++ b/src/lib/registration/eula_downloader.rb
@@ -34,7 +34,7 @@ module Registration
     include Yast::Logger
 
     # name of the directory index file with list of available files
-    INDEX_FILE = "directory.yast"
+    INDEX_FILE = "directory.yast".freeze
 
     # the constructor
     # @param base_url [String] the base URL for EULAs

--- a/src/lib/registration/fingerprint.rb
+++ b/src/lib/registration/fingerprint.rb
@@ -3,8 +3,8 @@ module Registration
   class Fingerprint
     attr_reader :sum, :value
 
-    SHA1 = "SHA1"
-    SHA256 = "SHA256"
+    SHA1 = "SHA1".freeze
+    SHA256 = "SHA256".freeze
 
     def initialize(sum, value)
       @sum = sum

--- a/src/lib/registration/finish_dialog.rb
+++ b/src/lib/registration/finish_dialog.rb
@@ -15,7 +15,7 @@ module Registration
       :live_installation,
       :autoinst,
       :update
-    ]
+    ].freeze
 
     def initialize
       textdomain "registration"

--- a/src/lib/registration/helpers.rb
+++ b/src/lib/registration/helpers.rb
@@ -80,7 +80,7 @@ module Registration
     # @param service [Yast::SlpServiceClass::Service] SLP service
     # @return [String] label
     def self.service_description(service)
-      url  = UrlHelpers.service_url(service.slp_url)
+      url = UrlHelpers.service_url(service.slp_url)
       descr = service.attributes.to_h[:description]
 
       # display URL and the description if it is present

--- a/src/lib/registration/helpers.rb
+++ b/src/lib/registration/helpers.rb
@@ -45,7 +45,7 @@ module Registration
     Yast.import "SlpService"
 
     # reg. code replacement
-    FILTERED = "[FILTERED]"
+    FILTERED = "[FILTERED]".freeze
 
     # Get the current language (without encoding suffix)
     # @return [String,nil] the current language or nil if set to "POSIX" or "C"

--- a/src/lib/registration/helpers.rb
+++ b/src/lib/registration/helpers.rb
@@ -165,8 +165,11 @@ module Registration
     def self.render_erb_template(file, binding)
       # use erb template for rendering the richtext summary
 
-      erb_file = Pathname.new(file).absolute? ? file :
+      erb_file = if Pathname.new(file).absolute?
+        file
+      else
         File.expand_path(File.join("../../../data/registration", file), __FILE__)
+      end
 
       log.info "Loading ERB template #{erb_file}"
       erb = ERB.new(File.read(erb_file))

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -183,10 +183,10 @@ module Registration
     end
 
     def service_for_product(product, &block)
-      if product.is_a?(Hash)
-        remote_product = SwMgmt.remote_product(product)
+      remote_product = if product.is_a?(Hash)
+        SwMgmt.remote_product(product)
       else
-        remote_product = product
+        product
       end
 
       log.info "Using product: #{remote_product}"

--- a/src/lib/registration/registration_codes_loader.rb
+++ b/src/lib/registration/registration_codes_loader.rb
@@ -37,7 +37,7 @@ module Registration
     REGCODES_NAME_HANDLERS = {
       "regcodes.xml" => :reg_codes_from_xml,
       "regcodes.txt" => :reg_codes_from_txt
-    }
+    }.freeze
 
     # @return [Hash{String => String},nil]
     def reg_codes_from_usb_stick

--- a/src/lib/registration/registration_ui.rb
+++ b/src/lib/registration/registration_ui.rb
@@ -104,7 +104,8 @@ module Registration
           _(CONTACTING_MESSAGE),
           # updating base product registration, %s is a new base product name
           _("Updating to %s ...") % SwMgmt.product_label(
-            SwMgmt.find_base_product)
+            SwMgmt.find_base_product
+          )
         ) do
           registration.upgrade_product(base_product)
         end
@@ -176,7 +177,8 @@ module Registration
     def get_available_addons
       Yast::Popup.Feedback(
         _(CONTACTING_MESSAGE),
-        _("Loading Available Extensions and Modules...")) do
+        _("Loading Available Extensions and Modules...")
+      ) do
         Addon.find_all(registration)
       end
     end
@@ -190,7 +192,8 @@ module Registration
     def migration_products(products)
       Yast::Popup.Feedback(
         _(CONTACTING_MESSAGE),
-        _("Loading Migration Products...")) do
+        _("Loading Migration Products...")
+      ) do
         registration.migration_products(products)
       end
     end
@@ -280,8 +283,7 @@ module Registration
       base_product = SwMgmt.find_base_product
 
       Yast::Popup.Feedback(_(CONTACTING_MESSAGE),
-        _("Registering %s ...") % SwMgmt.product_label(base_product)
-      ) do
+        _("Registering %s ...") % SwMgmt.product_label(base_product)) do
         base_product_data = SwMgmt.base_product_to_register
         base_product_data["reg_code"] = options.reg_code
         registration.register_product(base_product_data, options.email)
@@ -295,9 +297,10 @@ module Registration
 
       product_succeed = registration_order.map do |product|
         registered = ConnectHelpers.catch_registration_errors(
-          message_prefix: "#{product.label}\n") do
-            register_selected_addon(product, known_reg_codes[product.identifier])
-          end
+          message_prefix: "#{product.label}\n"
+        ) do
+          register_selected_addon(product, known_reg_codes[product.identifier])
+        end
 
         # remove from selected after successful registration
         if registered
@@ -313,7 +316,8 @@ module Registration
       product_service = Yast::Popup.Feedback(
         _(CONTACTING_MESSAGE),
         # %s is name of given product
-        _("Registering %s ...") % product.label) do
+        _("Registering %s ...") % product.label
+      ) do
         product_data = {
           "name"     => product.identifier,
           "reg_code" => reg_code,

--- a/src/lib/registration/releasever.rb
+++ b/src/lib/registration/releasever.rb
@@ -25,7 +25,7 @@ module Registration
     include Yast::Logger
 
     # the environment variable which overrides the system default in libzpp
-    RELEASEVER_ENV = "ZYPP_REPO_RELEASEVER"
+    RELEASEVER_ENV = "ZYPP_REPO_RELEASEVER".freeze
 
     Yast.import "Pkg"
 

--- a/src/lib/registration/repo_state.rb
+++ b/src/lib/registration/repo_state.rb
@@ -38,7 +38,7 @@ module Registration
     attr_accessor :repositories
 
     # location of the persistent storage (to store the data when restarting YaST)
-    REPO_STATE_FILE = "/var/lib/YaST2/migration_repo_state.yml"
+    REPO_STATE_FILE = "/var/lib/YaST2/migration_repo_state.yml".freeze
 
     def initialize
       @repositories = []

--- a/src/lib/registration/ssl_certificate_details.rb
+++ b/src/lib/registration/ssl_certificate_details.rb
@@ -37,11 +37,11 @@ module Registration
         _("SHA256 Fingerprint: ") + "\n"
 
       sha256 = certificate.fingerprint(Fingerprint::SHA256).value
-      if small_space
+      summary += if small_space
         # split the long SHA256 digest to two lines in small text mode UI
-        summary += INDENT + sha256[0..59] + "\n" + INDENT + sha256[60..-1]
+        INDENT + sha256[0..59] + "\n" + INDENT + sha256[60..-1]
       else
-        summary += INDENT + sha256
+        INDENT + sha256
       end
 
       summary

--- a/src/lib/registration/ssl_certificate_details.rb
+++ b/src/lib/registration/ssl_certificate_details.rb
@@ -32,9 +32,9 @@ module Registration
 
     def summary(small_space: false)
       summary = _("Certificate:") + "\n" + _("Issued To") + "\n" + subject +
-        "\n" + _("Issued By")  + "\n" + issuer + "\n" + _("SHA1 Fingerprint: ") +
+        "\n" + _("Issued By") + "\n" + issuer + "\n" + _("SHA1 Fingerprint: ") +
         "\n" + INDENT + certificate.fingerprint(Fingerprint::SHA1).value + "\n" +
-        _("SHA256 Fingerprint: ")  + "\n"
+        _("SHA256 Fingerprint: ") + "\n"
 
       sha256 = certificate.fingerprint(Fingerprint::SHA256).value
       if small_space

--- a/src/lib/registration/storage.rb
+++ b/src/lib/registration/storage.rb
@@ -36,10 +36,10 @@ module Registration
       include RegistrationCodesLoader
 
       def initialize
-        if Stage.initial
-          self.reg_codes = reg_codes_from_usb_stick || {}
+        self.reg_codes = if Stage.initial
+          reg_codes_from_usb_stick || {}
         else
-          self.reg_codes = {}
+          {}
         end
       end
     end

--- a/src/lib/registration/suse_register.rb
+++ b/src/lib/registration/suse_register.rb
@@ -3,8 +3,8 @@ require "uri"
 module Registration
   # class to read and query old suse register configuration file
   class SuseRegister
-    PATH = "/etc/suseRegister.conf"
-    NCC_HOST = "secure-www.novell.com"
+    PATH = "/etc/suseRegister.conf".freeze
+    NCC_HOST = "secure-www.novell.com".freeze
 
     def initialize(root)
       @found = read_conf(root)

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -53,13 +53,13 @@ module Registration
 
     textdomain "registration"
 
-    ZYPP_DIR = "/etc/zypp"
+    ZYPP_DIR = "/etc/zypp".freeze
 
     FAKE_BASE_PRODUCT = { "name" => "SLES", "arch" => "x86_64", "version" => "12-0",
       "flavor" => "DVD", "version_version" => "12", "register_release" => "",
-      "register_target" => "sle-12-x86_64" }
+      "register_target" => "sle-12-x86_64" }.freeze
 
-    OEM_DIR = "/var/lib/suseRegister/OEM"
+    OEM_DIR = "/var/lib/suseRegister/OEM".freeze
 
     # initialize the package management
     # @param [Boolean] load_packages load also the available packages from the repositories

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -251,8 +251,7 @@ module Registration
           "name"        => service_name,
           "url"         => product_service.url.to_s,
           "enabled"     => true,
-          "autorefresh" => true
-          )
+          "autorefresh" => true)
 
           ## error message
           raise ::Registration::ServiceError.new(N_("Updating service '%s' failed."), service_name)
@@ -495,8 +494,7 @@ module Registration
 
           # TRANSLATORS: %s is a product name
           Report.Error(_("Cannot find remote product %s.\n" \
-                "The product cannot be registered.") % product_label
-          )
+                "The product cannot be registered.") % product_label)
         end
       end
     end

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -90,8 +90,7 @@ module Registration
       def details_widget
         MinHeight(8,
           VWeight(25, RichText(Id(:details), Opt(:disabled), "<small>" +
-                _("Select an extension or a module to show details here") + "</small>"))
-        )
+                _("Select an extension or a module to show details here") + "</small>")))
       end
 
       # create UI box with addon check boxes, if the number of the addons is too big
@@ -129,10 +128,10 @@ module Registration
         box = VBox()
 
         # whether to add extra spacing in the UI
-        if Yast::UI.TextMode
-          add_extra_spacing = addons.size < 5
+        add_extra_spacing = if Yast::UI.TextMode
+          addons.size < 5
         else
-          add_extra_spacing = true
+          true
         end
 
         addons.each do |addon|

--- a/src/lib/registration/ui/autoyast_addon_dialog.rb
+++ b/src/lib/registration/ui/autoyast_addon_dialog.rb
@@ -69,7 +69,7 @@ module Registration
             PushButton(Id(:delete), Label.DeleteButton),
             HSpacing(0.5),
             # button label
-            PushButton(Id(:download),  _("Download Available Extensions...")
+            PushButton(Id(:download), _("Download Available Extensions...")
             )
           )
         )
@@ -171,7 +171,7 @@ module Registration
       def set_addon_table_content(current = nil)
         content = addons.map do |a|
           Item(Id(a["name"]), a["name"], a["version"], a["arch"],
-            a["release_type"],  a["reg_code"])
+            a["release_type"], a["reg_code"])
         end
 
         Yast::UI.ChangeWidget(Id(:addons_table), :Items, content)

--- a/src/lib/registration/ui/autoyast_addon_dialog.rb
+++ b/src/lib/registration/ui/autoyast_addon_dialog.rb
@@ -69,8 +69,7 @@ module Registration
             PushButton(Id(:delete), Label.DeleteButton),
             HSpacing(0.5),
             # button label
-            PushButton(Id(:download), _("Download Available Extensions...")
-            )
+            PushButton(Id(:download), _("Download Available Extensions..."))
           )
         )
       end

--- a/src/lib/registration/ui/autoyast_config_dialog.rb
+++ b/src/lib/registration/ui/autoyast_config_dialog.rb
@@ -111,8 +111,7 @@ module Registration
               Left(CheckBox(Id(:install_updates),
                 _("Install Available Updates from Update Repositories"),
                 config.install_updates))
-            )
-          )
+            ))
         )
       end
 
@@ -166,8 +165,7 @@ module Registration
                 _("SSL Certificate Fingerprint"),
                 config.reg_server_cert_fingerprint
               )
-            )
-          )
+            ))
         )
       end
 

--- a/src/lib/registration/ui/autoyast_config_dialog.rb
+++ b/src/lib/registration/ui/autoyast_config_dialog.rb
@@ -23,7 +23,7 @@ module Registration
         :addons, :do_registration, :email, :install_updates,
         :reg_code, :reg_server, :reg_server_cert, :reg_server_cert_fingerprint,
         :reg_server_cert_fingerprint_type, :slp_discovery
-      ]
+      ].freeze
 
       # widgets containing data (serialized to the exported Hash)
       # (:addons belongs to a push button, it does not contain any data)

--- a/src/lib/registration/ui/autoyast_config_workflow.rb
+++ b/src/lib/registration/ui/autoyast_config_workflow.rb
@@ -103,7 +103,8 @@ module Registration
         success = ConnectHelpers.catch_registration_errors do
           Popup.Feedback(
             SccAutoClient::CONTACTING_MESSAGE,
-            _("Loading Available Extensions and Modules...")) do
+            _("Loading Available Extensions and Modules...")
+          ) do
             # reset registration status to allow selecting all addons
             ::Registration::Addon.find_all(registration).each(&:unregistered)
           end

--- a/src/lib/registration/ui/autoyast_config_workflow.rb
+++ b/src/lib/registration/ui/autoyast_config_workflow.rb
@@ -145,7 +145,7 @@ module Registration
       # @return [Hash, nil] found addon or nil
       def find_addon(addon)
         config.addons.find do |a|
-          a["name"] == addon["name"] &&  a["version"] == addon["version"] &&
+          a["name"] == addon["name"] && a["version"] == addon["version"] &&
             a["arch"] == addon["arch"] && a["release_type"] == addon["release_type"]
         end
       end

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -305,8 +305,7 @@ module Registration
               VBox(
                 MinWidth(REG_CODE_WIDTH,
                   ComboBox(Id(:custom_url), Opt(:editable),
-                    _("&Local Registration Server URL"), urls)
-                )
+                    _("&Local Registration Server URL"), urls))
               )
             )
           ),
@@ -339,13 +338,18 @@ module Registration
       # part of the main dialog definition - the base product details
       # @return [Yast::Term]  UI term
       def product_details_widgets
+        label = if Registration.is_registered?
+          Heading(_("The system is already registered."))
+        else
+          Label(_("Please select your preferred method of registration."))
+        end
+
         HSquash(
           VBox(
             VSpacing(1),
             Left(Heading(SwMgmt.product_label(SwMgmt.find_base_product))),
             VSpacing(1),
-            Registration.is_registered? ? Heading(_("The system is already registered.")) :
-              Label(_("Please select your preferred method of registration."))
+            label
           )
         )
       end

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -36,7 +36,7 @@ module Registration
         register_scc:      [:email, :reg_code],
         register_local:    [:custom_url],
         skip_registration: []
-      }
+      }.freeze
       private_constant :WIDGETS
 
       # create and run the dialog for registering the base system
@@ -273,7 +273,7 @@ module Registration
       end
 
       # Example URL to be used in the :register_local UI
-      EXAMPLE_SMT_URL = "https://smt.example.com"
+      EXAMPLE_SMT_URL = "https://smt.example.com".freeze
 
       # Widgets for :register_local action
       #
@@ -542,7 +542,7 @@ module Registration
         end
       end
 
-      VALID_CUSTOM_URL_SCHEMES = ["http", "https"]
+      VALID_CUSTOM_URL_SCHEMES = ["http", "https"].freeze
 
       # Determine whether an URL is valid and suitable to be used as local SMT server
       #

--- a/src/lib/registration/ui/import_certificate_dialog.rb
+++ b/src/lib/registration/ui/import_certificate_dialog.rb
@@ -25,7 +25,7 @@ module Registration
         18 => N_("Self signed certificate"),
         # SSL error message
         19 => N_("Self signed certificate in certificate chain")
-      }
+      }.freeze
 
       Yast.import "UI"
       Yast.import "Label"

--- a/src/lib/registration/ui/migration_repos_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_repos_selection_dialog.rb
@@ -82,8 +82,7 @@ module Registration
         VBox(
           VWeight(75, MultiSelectionBox(Id(:repos), Opt(:vstretch, :notify),
             # TRANSLATORS: Multiselection widget label
-            _("Select the Repositories used for Migration"), repo_items
-          )),
+            _("Select the Repositories used for Migration"), repo_items)),
           MinHeight(6, VWeight(25, RichText(Id(:details), ""))),
           # TRANSLATORS: Push button label, starts the repository management module
           PushButton(Id(:repo_mgmt), _("Manage Repositories..."))

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -110,7 +110,7 @@ module Registration
           next:   "update_releasever"
         },
         "update_releasever"           => {
-          next:   "register_migration_products"
+          next: "register_migration_products"
         },
         "register_migration_products" => {
           abort:  :rollback,

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -131,7 +131,7 @@ module Registration
         "store_repos_state"           => {
           next: :next
         }
-      }
+      }.freeze
 
       # check whether the system is registered, ask the user to register it
       # if the system is not registered

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -130,8 +130,7 @@ module Registration
           VSpacing(1),
           migration_selection_widget,
           VWeight(15,
-            RichText(Id(:details), Opt(:vstretch), "")
-          ),
+            RichText(Id(:details), Opt(:vstretch), "")),
 
           VSpacing(Yast::UI.TextMode ? 0 : 1),
           # TRANSLATORS: check button label
@@ -150,8 +149,7 @@ module Registration
         VWeight(weight,
           # TRANSLATORS: selection box label
           SelectionBox(Id(:migration_targets), Opt(:vstretch, :notify),
-            _("Possible Migration Targets"), migration_items)
-        )
+            _("Possible Migration Targets"), migration_items))
       end
 
       # list of items for the main widget
@@ -215,7 +213,8 @@ module Registration
                 "registration server (%{url}). Make the product available " \
                 "to allow using this migration.") %
             { product: product_name, url: url },
-            "red")
+            "red"
+          )
         end
 
         if !installed_product

--- a/src/lib/registration/url_helpers.rb
+++ b/src/lib/registration/url_helpers.rb
@@ -43,10 +43,10 @@ module Registration
     Yast.import "SlpService"
 
     # name of the boot parameter
-    BOOT_PARAM = "reg_url"
+    BOOT_PARAM = "reg_url".freeze
 
     # SLP service name
-    SLP_SERVICE = "registration.suse"
+    SLP_SERVICE = "registration.suse".freeze
 
     # Evaluate the registration URL to use
     # @see https://github.com/yast/yast-registration/wiki/Changing-the-Registration-Server

--- a/test/base_system_registration_dialog_test.rb
+++ b/test/base_system_registration_dialog_test.rb
@@ -160,7 +160,7 @@ describe Registration::UI::BaseSystemRegistrationDialog do
       end
     end
 
-    context "when system is already registered"  do
+    context "when system is already registered" do
       let(:registered?) { true }
 
       context "in installation mode" do

--- a/test/downloader_spec.rb
+++ b/test/downloader_spec.rb
@@ -44,7 +44,8 @@ describe "Registration::Downloader" do
       expect_any_instance_of(Net::HTTP).to receive(:proxy?).and_return(false)
 
       expect { Registration::Downloader.download(url) }.to raise_error(
-        Registration::DownloadError, "Downloading #{url} failed: Not Found")
+        Registration::DownloadError, "Downloading #{url} failed: Not Found"
+      )
     end
 
     it "handles HTTP redirection" do

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -7,9 +7,9 @@ def suse_connect_product_generator(attrs = {})
   params["name"] = attrs["name"] || "Product#{rand(100_000)}"
   params["friendly_name"] = attrs["friendly_name"] || "The best cool #{params["name"]}"
   params["description"] = attrs["description"] || "Bla bla bla bla!"
-  params["id"] = attrs["id"] || "#{rand(10_000)}"
+  params["id"] = attrs["id"] || rand(10_000).to_s
   params["identifier"] = attrs["zypper_name"] || "prod#{rand(100_000)}"
-  params["version"] = attrs["version"] || "#{rand(13)}"
+  params["version"] = attrs["version"] || rand(13).to_s
   params["arch"] = attrs["arch"] || "x86_64"
   params["free"] = attrs.fetch("free", true)
   params["eula_url"] = attrs["eula_url"]
@@ -26,7 +26,8 @@ end
 def addon_with_child_generator(parent_params = {})
   prod_child = suse_connect_product_generator
   SUSE::Connect::Remote::Product.new(
-    suse_connect_product_generator(parent_params.merge("extensions" => [prod_child])))
+    suse_connect_product_generator(parent_params.merge("extensions" => [prod_child]))
+  )
 end
 
 # add cache reset, which is not needed in runtime, but for test it is critical

--- a/test/helpers_spec.rb
+++ b/test/helpers_spec.rb
@@ -207,7 +207,8 @@ describe "Registration::Helpers" do
         "install_updates"                  => true,
         "addons"                           => [{
           "name" => "sle-sdk", "arch" => "x86_64", "version" => "12",
-            "release_type" => "nil", "reg_code" => "" }],
+            "release_type" => "nil", "reg_code" => ""
+        }],
         "reg_server_cert_fingerprint"      => "AB:CD:EF",
         "reg_server_cert_fingerprint_type" => "SHA256"
       )
@@ -233,7 +234,8 @@ describe "Registration::Helpers" do
     it "it replaces \"reg_code\" also in nested \"addons\" list" do
       test = { "addons" => [{ "reg_code" => "foo" }, { "reg_code" => "bar" }] }
       expect(Registration::Helpers.hide_reg_codes(test)).to eq(
-        "addons" => [{ "reg_code" => "[FILTERED]" }, { "reg_code" => "[FILTERED]" }])
+        "addons" => [{ "reg_code" => "[FILTERED]" }, { "reg_code" => "[FILTERED]" }]
+      )
     end
 
     it "it does not modify the original input value" do

--- a/test/inst_scc_test.rb
+++ b/test/inst_scc_test.rb
@@ -68,7 +68,8 @@ describe "inst_scc client" do
     it "switchs to manual registration when aborting selection of url" do
       # User cancels the selection of registration url
       expect_any_instance_of(Registration::UI::RegistrationUpdateDialog).to receive(
-        :init_registration).and_return(:cancel)
+        :init_registration
+      ).and_return(:cancel)
       # So manual registration dialog is displayed
       expect_any_instance_of(Yast::InstSccClient).to receive(:register_base_system)
         .and_return(:cancel)

--- a/test/migration_repos_selection_dialog_test.rb
+++ b/test/migration_repos_selection_dialog_test.rb
@@ -9,9 +9,11 @@ describe Registration::UI::MigrationReposSelectionDialog do
     before do
       allow(Yast::Pkg).to receive(:SourceGetCurrent).and_return([0, 1])
       allow(Yast::Pkg).to receive(:SourceGeneralData).with(0).and_return(
-        "name" => "name", "url" => "https://example.com", "enabled" => false)
+        "name" => "name", "url" => "https://example.com", "enabled" => false
+      )
       allow(Yast::Pkg).to receive(:SourceGeneralData).with(1).and_return(
-        "name" => "name2", "url" => "https://example2.com", "enabled" => true)
+        "name" => "name2", "url" => "https://example2.com", "enabled" => true
+      )
       allow(Yast::UI).to receive(:QueryWidget).with(:repos, :CurrentItem).and_return(0)
 
       # check the displayed content

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -20,8 +20,7 @@ describe Registration::Registration do
       expect_any_instance_of(SUSE::Connect::Credentials).to receive(:write)
       expect(SUSE::Connect::YaST).to(receive(:announce_system)
         .with(hash_including(token: reg_code), target_distro)
-        .and_return([username, password])
-      )
+        .and_return([username, password]))
 
       Registration::Registration.new.register("email", reg_code, target_distro)
     end
@@ -63,10 +62,13 @@ describe Registration::Registration do
         .with("SUSE_SLES_SAP" => "SLES_SAP")
 
       allow(File).to receive(:exist?).with(
-        SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE).and_return(true)
+        SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE
+      ).and_return(true)
       allow(File).to receive(:read).with(
-        SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE).and_return(
-          "username=SCC_foo\npassword=bar")
+        SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE
+      ).and_return(
+        "username=SCC_foo\npassword=bar"
+      )
 
       registered_service = Registration::Registration.new.send(yast_method, product)
       expect(registered_service).to eq(service)
@@ -157,7 +159,8 @@ describe Registration::Registration do
       expect(logger).to receive(:error).with(/SSL verification failed:/)
       # the exception is logged
       expect(logger).to receive(:error).with(
-        /Exception in SSL verify callback: OpenSSL::X509::CertificateError/)
+        /Exception in SSL verify callback: OpenSSL::X509::CertificateError/
+      )
 
       allow(registration).to receive(:log).and_return(logger)
 
@@ -183,12 +186,13 @@ describe Registration::Registration do
     it "synchronizes the local products with the server" do
       expect(SUSE::Connect::YaST).to receive(:synchronize)
         .with([
-          OpenStruct.new(
-            arch:         "x86_64",
-            identifier:   "SLES",
-            version:      "12",
-            release_type: nil
-          )])
+                OpenStruct.new(
+                  arch:         "x86_64",
+                  identifier:   "SLES",
+                  version:      "12",
+                  release_type: nil
+                )
+              ])
 
       subject.synchronize_products([installed_sles])
     end
@@ -204,7 +208,8 @@ describe Registration::Registration do
             version:      "12-0",
             release_type: nil
           ),
-          anything)
+          anything
+        )
 
       expect(subject.downgrade_product(installed_sles))
     end

--- a/test/registration_update_dialog_test.rb
+++ b/test/registration_update_dialog_test.rb
@@ -13,18 +13,25 @@ describe Registration::UI::RegistrationUpdateDialog do
 
     it "updates system registration, base and add-on products" do
       expect_any_instance_of(Registration::RegistrationUI).to receive(
-        :update_system).and_return(true)
+        :update_system
+      ).and_return(true)
       allow_any_instance_of(Registration::RegistrationUI).to receive(
-        :update_base_product).and_return(
-          [true, load_yaml_fixture("remote_product.yml")])
+        :update_base_product
+      ).and_return(
+        [true, load_yaml_fixture("remote_product.yml")]
+      )
       allow_any_instance_of(Registration::RegistrationUI).to receive(
-        :install_updates?).and_return(false)
+        :install_updates?
+      ).and_return(false)
       allow_any_instance_of(Registration::RegistrationUI).to receive(
-        :disable_update_repos).and_return(true)
+        :disable_update_repos
+      ).and_return(true)
       allow_any_instance_of(Registration::RegistrationUI).to receive(
-        :get_available_addons).and_return([])
+        :get_available_addons
+      ).and_return([])
       allow_any_instance_of(Registration::RegistrationUI).to receive(
-        :update_addons).and_return([])
+        :update_addons
+      ).and_return([])
 
       expect(subject.run).to eq(:next)
     end

--- a/test/releasever_spec.rb
+++ b/test/releasever_spec.rb
@@ -41,8 +41,10 @@ describe Registration::Releasever do
     # some complex test case (see bsc#944505#c0):
     # SLE_${releasever_major}${releasever_minor:+_SP$releasever_minor}
     it "refreshes the repositories containing an expression in the URL" do
-      allow(Yast::Pkg).to receive(:SourceGeneralData).with(repo).and_return("raw_url" =>
-          "https://example.com/SLE_${releasever_major}${releasever_minor:+_SP$releasever_minor}")
+      allow(Yast::Pkg).to receive(:SourceGeneralData).with(repo).and_return(
+        "raw_url" => "https://example.com/SLE_${releasever_major}" \
+        "${releasever_minor:+_SP$releasever_minor}"
+      )
       expect(Yast::Pkg).to receive(:SourceForceRefreshNow).with(repo)
       subject.activate
     end

--- a/test/ssl_certificate_details_spec.rb
+++ b/test/ssl_certificate_details_spec.rb
@@ -5,7 +5,8 @@ require_relative "spec_helper"
 describe "Registration::SslCertificateDetails" do
   subject do
     Registration::SslCertificateDetails.new(
-      Registration::SslCertificate.load_file(fixtures_file("test.pem")))
+      Registration::SslCertificate.load_file(fixtures_file("test.pem"))
+    )
   end
 
   let(:identity) do
@@ -48,7 +49,7 @@ SHA1 Fingerprint:
 SHA256 Fingerprint: 
    #{sha256sum}
 EOS
-      # rubocop:enable Style/TrailingWhitespace
+        # rubocop:enable Style/TrailingWhitespace
       )
     end
 

--- a/test/storage_spec.rb
+++ b/test/storage_spec.rb
@@ -17,7 +17,8 @@ describe Registration::Storage::Config do
     {
       "addons"                           => [{
         "arch" => "x86_64", "name" => "sle-module-legacy", "reg_code" => "",
-          "release_type" => "nil", "version" => "12" }],
+          "release_type" => "nil", "version" => "12"
+      }],
       "do_registration"                  => true,
       "email"                            => "foo@example.com",
       "install_updates"                  => false,

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -136,14 +136,16 @@ describe Registration::SwMgmt do
       expect(Yast::Pkg).to receive(:ServiceAliases).and_return([])
       expect(Yast::Pkg).to receive(:ServiceAdd).with(service_name, service_url).and_return(true)
       expect(Yast::Pkg).to receive(:ServiceSet).with(
-        service_name, hash_including("autorefresh" => true)).and_return(true)
+        service_name, hash_including("autorefresh" => true)
+      ).and_return(true)
       expect { subject.add_service(product_service, credentials) }.to_not raise_error
     end
 
     it "updates the existing service if the service already exists" do
       expect(Yast::Pkg).to receive(:ServiceAliases).and_return([service_name])
       expect(Yast::Pkg).to receive(:ServiceSet).with(
-        service_name, hash_including("url" => service_url)).and_return(true)
+        service_name, hash_including("url" => service_url)
+      ).and_return(true)
       expect { subject.add_service(product_service, credentials) }.to_not raise_error
     end
   end


### PR DESCRIPTION
Notes:

- *Lint/ShadowedException* has been disabled as it cannot handle [this complex case](https://github.com/yast/yast-registration/blob/cde3fb50db6d2b70cac7b9a203151b49e61b9bf8/src/lib/registration/connect_helpers.rb#L70) correctly. I'll investigate it later.
- Jenkins fails because the `rubygem-rubocop.rpm` has not been updated in YaST:Head yet (I'll do it, I have added a task to the Trello card). Let's ignore this failure for now, Travis passes.