### PR TITLE
Make many extensions fit on the screen with a scrollable widget

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jul 25 14:21:00 UTC 2016 - mvidner@suse.com
+
+- Extensions and Modules:
+  - do not show beta versions of products (FATE#319909)
+  - make many items fit by using a scrollable widget (bsc#967387)
+- 3.1.177
+
+-------------------------------------------------------------------
 Fri Jun 17 12:45:21 UTC 2016 - mvidner@suse.com
 
 - For "Register System via local SMT Server" offer a list of servers

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.176
+Version:        3.1.177
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -134,6 +134,15 @@ module Registration
       Addon.selected.delete(self) if selected?
     end
 
+    # toggle the selection state of the add-on
+    def toggle_selected
+      if selected?
+        unselected
+      else
+        selected
+      end
+    end
+
     # has been the add-on registered?
     # @return [Boolean] true if the add-on has been registered
     def registered?

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -108,6 +108,7 @@ module Registration
       :name,
       :product_type,
       :release_type,
+      :release_stage,
       :version
 
     # the constructor
@@ -147,6 +148,10 @@ module Registration
     # just internally mark the addon as NOT registered, not a real unregistration
     def unregistered
       Addon.registered.delete(self) if registered?
+    end
+
+    def beta_release?
+      release_stage == "beta"
     end
 
     # get a product printable name (long name if present, fallbacks to the short name)

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -218,13 +218,8 @@ module Registration
         addon = @addons.find { |a| addon_widget_id(a) == id }
         return unless addon
 
+        addon.toggle_selected
         show_addon_details(addon)
-        new_state = !addon.selected?
-        if new_state
-          addon.selected
-        else
-          addon.unselected
-        end
         reactivate_dependencies
       end
 

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -147,69 +147,6 @@ module Registration
         VWeight(75, MinHeight(12, content))
       end
 
-      # display the addon checkboxes in two columns
-      # @param col1 [Array<Addon>] the addons displayed in the first column
-      # @param col2 [Array<Addon>] the addons displayed in the second column
-      # @return [Yast::Term] the addon cheboxes
-      def two_column_layout(col1, col2)
-        box2 = addon_selection_items(col1)
-        box2.params << VStretch() # just UI tweak
-
-        HBox(
-          addon_selection_items(col2),
-          HSpacing(1),
-          box2
-        )
-      end
-
-      # create a single UI column with addon checkboxes
-      # @return [Yast::Term] addon column
-      def addon_selection_items(addons)
-        box = VBox()
-
-        # whether to add extra spacing in the UI
-        add_extra_spacing = if Yast::UI.TextMode
-          addons.size < 5
-        else
-          true
-        end
-
-        addons.each do |addon|
-          box.params.concat(addon_checkbox(addon, add_extra_spacing))
-        end
-
-        box
-      end
-
-      # create spacing around the addon checkbox so the layout looks better
-      # @param addon [Registration::Addon]
-      # @param extra_spacing [Boolean] add extra spacing (indicates enough space in UI)
-      # @return [Array<Yast::Term>] Return array with one or two elements for VBox
-      def addon_checkbox(addon, extra_spacing)
-        checkbox = Left(addon_checkbox_element(addon))
-
-        # usability help. If addon depends on something, then we get it
-        # immediatelly after parent, so indent it slightly, so it is easier visible
-        checkbox = HBox(HSpacing(2.5), checkbox) if addon.depends_on
-
-        res = [checkbox]
-        # add extra spacing when there are just few addons, in GUI always
-        res << VSpacing(0.7) if extra_spacing
-
-        res
-      end
-
-      # create the UI checkbox element for the addon
-      # @param addon [Registration::Addon] the addon
-      # @return [Yast::Term] checkbox term
-      def addon_checkbox_element(addon)
-        # checkbox label for an unavailable extension
-        # (%s is an extension name)
-        label = addon.available? ? addon.label : (_("%s (not available)") % addon.label)
-
-        CheckBox(Id(addon_widget_id(addon)), Opt(:notify), label, addon_selected?(addon))
-      end
-
       # the main event loop - handle the user in put in the dialog
       # @return [Symbol] the user input
       def handle_dialog

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -98,10 +98,10 @@ module Registration
           # (%s is an extension name)
           label = addon.available? ? addon.label : (_("%s (not available)") % addon.label)
 
-          rt_cb(id: addon_widget_id(addon),
-                label: label,
+          rt_cb(id:       addon_widget_id(addon),
+                label:    label,
                 selected: addon_selected?(addon),
-                enabled: addon.available?,
+                enabled:  addon.available?,
                 indented: addon.depends_on)
         end
         items.join("\n")
@@ -111,11 +111,11 @@ module Registration
       # https://gist.github.com/lslezak/5ed82fe19337bef4807b
 
       # FIXME: adapt to installation theme
-      IMG_ON = "/usr/share/YaST2/theme/current/wizard/checkbox-on.png"
-      IMG_OFF = "/usr/share/YaST2/theme/current/wizard/checkbox-off.png"
+      IMG_ON = "/usr/share/YaST2/theme/current/wizard/checkbox-on.png".freeze
+      IMG_OFF = "/usr/share/YaST2/theme/current/wizard/checkbox-off.png".freeze
 
       def rt_cb(id:, label:, selected:, enabled:,
-                indented: false, text_mode: Yast::UI.TextMode)
+        indented: false, text_mode: Yast::UI.TextMode)
         selected = false unless enabled
         if text_mode
           indent = "&nbsp;" * (indented ? 5 : 1)
@@ -190,7 +190,7 @@ module Registration
         return unless addon
 
         show_addon_details(addon)
-        new_state = ! addon.selected?
+        new_state = !addon.selected?
         if new_state
           addon.selected
         else

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -29,17 +29,19 @@ module Registration
       #   communication with SCC
       def initialize(registration)
         textdomain "registration"
-        @addons = Addon.find_all(registration)
+        @all_addons = Addon.find_all(registration)
 
         # sort the addons
-        @addons.sort!(&::Registration::ADDON_SORTER)
+        @all_addons.sort!(&::Registration::ADDON_SORTER)
+
+        filter_beta_releases(true)
 
         @old_selection = Addon.selected.dup
 
         # activate a workaround on ARM (FATE#320679)
         aarch64_workaround if Arch.aarch64
 
-        log.info "Available addons: #{@addons}"
+        log.info "Available addons: #{@all_addons}"
       end
 
       # reimplement this in a subclass
@@ -56,6 +58,12 @@ module Registration
       # @return [String] widget id
       def addon_widget_id(addon)
         "#{addon.identifier}-#{addon.version}-#{addon.arch}"
+      end
+
+      # Enables or disables beta addons filtering
+      # @param [Boolean] enable true for filtering beta releases
+      def filter_beta_releases(enable)
+        @addons = enable ? @all_addons.reject(&:beta_release?) : @all_addons
       end
 
     private

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -194,7 +194,7 @@ module Registration
             Addon.selected.replace(@old_selection) if ret == :abort
           when :filter_beta
             filter_beta_releases(Yast::UI.QueryWidget(Id(ret), :Value))
-            reactivate_dependencies
+            show_addons
           else
             handle_addon_selection(ret)
           end
@@ -221,7 +221,7 @@ module Registration
 
         addon.toggle_selected
         show_addon_details(addon)
-        reactivate_dependencies
+        show_addons
       end
 
       # update addon details after changing the current addon in the UI
@@ -232,9 +232,8 @@ module Registration
         Yast::UI.ChangeWidget(Id(:details), :Enabled, true)
       end
 
-      # update the enabled/disabled status in UI for dependent addons
-      # FIXME: is this always overriden?
-      def reactivate_dependencies
+      # show the addon list when some are filtered, enabled, selected
+      def show_addons
         Yast::UI.ChangeWidget(Id(:items), :Value, addon_checkboxes)
       end
 

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -114,10 +114,9 @@ module Registration
       IMG_ON = "/usr/share/YaST2/theme/current/wizard/checkbox-on.png".freeze
       IMG_OFF = "/usr/share/YaST2/theme/current/wizard/checkbox-off.png".freeze
 
-      def rt_cb(id:, label:, selected:, enabled:,
-        indented: false, text_mode: Yast::UI.TextMode)
+      def rt_cb(id:, label:, selected:, enabled:, indented: false)
         selected = false unless enabled
-        if text_mode
+        if Yast::UI.TextMode
           indent = "&nbsp;" * (indented ? 5 : 1)
           check = selected ? "[x]" : "[ ]"
           widget = "#{check} #{label}"

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -98,23 +98,36 @@ module Registration
           # (%s is an extension name)
           label = addon.available? ? addon.label : (_("%s (not available)") % addon.label)
 
-          rt_cb(id:       addon_widget_id(addon),
-                label:    label,
-                selected: addon_selected?(addon),
-                enabled:  addon.available?,
-                indented: addon.depends_on)
+          richtext_checkbox(id:       addon_widget_id(addon),
+                            label:    label,
+                            selected: addon_selected?(addon),
+                            enabled:  addon.available?,
+                            indented: addon.depends_on)
         end
         items.join("\n")
       end
 
-      # FIXME: acknowledge Lada's code
-      # https://gist.github.com/lslezak/5ed82fe19337bef4807b
+      IMAGE_DIR = "/usr/share/YaST2/theme/current/wizard".freeze
+      IMAGES = {
+        "normal:on:enabled"   => "checkbox-on.png",
+        "normal:off:enabled"  => "checkbox-off.png",
+        # theme has no special images for disabled checkboxes
+        "normal:on:disabled"  => "checkbox-on.png",
+        "normal:off:disabled" => "checkbox-off.png",
+        "inst:on:enabled"     => "inst_checkbox-on.png",
+        "inst:off:enabled"    => "inst_checkbox-off.png",
+        "inst:on:disabled"    => "inst_checkbox-on-disabled.png",
+        "inst:off:disabled"   => "inst_checkbox-off-disabled.png"
+      }.freeze
 
-      # FIXME: adapt to installation theme
-      IMG_ON = "/usr/share/YaST2/theme/current/wizard/checkbox-on.png".freeze
-      IMG_OFF = "/usr/share/YaST2/theme/current/wizard/checkbox-off.png".freeze
-
-      def rt_cb(id:, label:, selected:, enabled:, indented: false)
+      # Make a simulation of a CheckBox displayed in a RichText
+      # @param id [String]
+      # @param label [String]
+      # @param selected [Boolean]
+      # @param enabled [Boolean]
+      # @param indented [Boolean]
+      # @return [String] a Value for a RichText
+      def richtext_checkbox(id:, label:, selected:, enabled:, indented: false)
         selected = false unless enabled
         if Yast::UI.TextMode
           indent = "&nbsp;" * (indented ? 5 : 1)
@@ -124,12 +137,16 @@ module Registration
           "#{indent}#{enabled_widget}<br>"
         else
           indent = "&nbsp;" * (indented ? 7 : 1)
-          # FIXME: a disabled checkbox?
-          check = "<img src='#{selected ? IMG_ON : IMG_OFF}'></img>"
+
+          installation = !Yast::Mode.normal
+          image = (installation ? "inst:" : "normal:") +
+            (selected ? "on:" : "off:") + (enabled ? "enabled" : "disabled")
+          color = installation ? "white" : "black"
+
+          check = "<img src='#{IMAGE_DIR}/#{IMAGES[image]}'></img>"
           widget = "#{check} #{label}"
           enabled_widget = if enabled
-            # FIXME: adapt to installation theme: find a suitable class?
-            "<a href='#{id}' style='text-decoration:none; color:black'>#{widget}</a>"
+            "<a href='#{id}' style='text-decoration:none; color:#{color}'>#{widget}</a>"
           else
             "<span style='color:grey'>#{widget}</span>"
           end

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -85,6 +85,8 @@ module Registration
       def content
         VBox(
           Left(Heading(heading)),
+          Left(CheckBox(Id(:filter_beta), Opt(:notify),
+            _("&Filter Out Beta Versions"))),
           addons_box,
           Left(Label(_("Details"))),
           details_widget
@@ -189,6 +191,9 @@ module Registration
             ret = Stage.initial && !AbortConfirmation.run ? nil : :abort
             # when canceled switch to old selection
             Addon.selected.replace(@old_selection) if ret == :abort
+          when :filter_beta
+            filter_beta_releases(Yast::UI.QueryWidget(Id(ret), :Value))
+            reactivate_dependencies
           else
             handle_addon_selection(ret)
           end

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -115,7 +115,7 @@ module Registration
         richtext_checkbox(id:       addon_widget_id(addon),
                           label:    label,
                           selected: addon_selected?(addon),
-                          enabled:  addon.available?,
+                          enabled:  addon.selectable?,
                           indented: addon.depends_on)
       end
 
@@ -140,7 +140,6 @@ module Registration
       # @param indented [Boolean]
       # @return [String] a Value for a RichText
       def richtext_checkbox(id:, label:, selected:, enabled:, indented: false)
-        selected = false unless enabled
         if Yast::UI.TextMode
           indent = "&nbsp;" * (indented ? 5 : 1)
           check = selected ? "[x]" : "[ ]"

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -24,6 +24,8 @@ module Registration
       Yast.import "Stage"
       Yast.import "Arch"
 
+      FILTER_BETAS_INITIALLY = true
+
       # constructor
       # @param registration [Registration::Registration] use this Registration object for
       #   communication with SCC
@@ -34,7 +36,7 @@ module Registration
         # sort the addons
         @all_addons.sort!(&::Registration::ADDON_SORTER)
 
-        filter_beta_releases(true)
+        filter_beta_releases(FILTER_BETAS_INITIALLY)
 
         @old_selection = Addon.selected.dup
 
@@ -86,7 +88,7 @@ module Registration
         VBox(
           Left(Heading(heading)),
           Left(CheckBox(Id(:filter_beta), Opt(:notify),
-            _("&Filter Out Beta Versions"))),
+            _("&Filter Out Beta Versions"), FILTER_BETAS_INITIALLY)),
           addons_box,
           Left(Label(_("Details"))),
           details_widget

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -102,19 +102,21 @@ module Registration
       end
 
       # @return [String] a Value for a RichText
-      def richtext_checkboxes(addons)
-        items = addons.map do |addon|
-          # checkbox label for an unavailable extension
-          # (%s is an extension name)
-          label = addon.available? ? addon.label : (_("%s (not available)") % addon.label)
+      def addon_checkboxes
+        @addons.map { |a| addon_checkbox(a) }.join("\n")
+      end
 
-          richtext_checkbox(id:       addon_widget_id(addon),
-                            label:    label,
-                            selected: addon_selected?(addon),
-                            enabled:  addon.available?,
-                            indented: addon.depends_on)
-        end
-        items.join("\n")
+      # @param [<Addon>] addon the addon
+      # @return [String] a Value for a RichText
+      def addon_checkbox(addon)
+        # checkbox label for an unavailable extension
+        # (%s is an extension name)
+        label = addon.available? ? addon.label : (_("%s (not available)") % addon.label)
+        richtext_checkbox(id:       addon_widget_id(addon),
+                          label:    label,
+                          selected: addon_selected?(addon),
+                          enabled:  addon.available?,
+                          indented: addon.depends_on)
       end
 
       IMAGE_DIR = "/usr/share/YaST2/theme/current/wizard".freeze
@@ -164,11 +166,10 @@ module Registration
         end
       end
 
-      # create UI box with addon check boxes, if the number of the addons is too big
-      # the UI uses two column layout
+      # create UI box with addon check boxes
       # @return [Yast::Term] the main UI dialog term
       def addons_box
-        content = RichText(Id(:items), richtext_checkboxes(@addons))
+        content = RichText(Id(:items), addon_checkboxes)
 
         VWeight(75, MinHeight(12, content))
       end
@@ -234,7 +235,7 @@ module Registration
       # update the enabled/disabled status in UI for dependent addons
       # FIXME: is this always overriden?
       def reactivate_dependencies
-        Yast::UI.ChangeWidget(Id(:items), :Value, richtext_checkboxes(@addons))
+        Yast::UI.ChangeWidget(Id(:items), :Value, addon_checkboxes)
       end
 
       # the maximum number of reg. codes displayed vertically,

--- a/src/lib/registration/ui/addon_selection_registration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_registration_dialog.rb
@@ -59,9 +59,7 @@ module Registration
 
       # update the enabled/disabled status in UI for dependent addons
       def reactivate_dependencies
-        @addons.each do |addon|
-          Yast::UI.ChangeWidget(Id(addon_widget_id(addon)), :Enabled, addon.selectable?)
-        end
+        Yast::UI.ChangeWidget(Id(:items), :Value, richtext_checkboxes(@addons))
       end
     end
   end

--- a/src/lib/registration/ui/addon_selection_registration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_registration_dialog.rb
@@ -40,8 +40,6 @@ module Registration
 
         @old_selection = Addon.selected.dup
 
-        reactivate_dependencies
-
         handle_dialog
       end
 
@@ -55,11 +53,6 @@ module Registration
       # @return [Boolean] is the addon selected?
       def addon_selected?(addon)
         addon.selected? || addon.registered?
-      end
-
-      # update the enabled/disabled status in UI for dependent addons
-      def reactivate_dependencies
-        Yast::UI.ChangeWidget(Id(:items), :Value, addon_checkboxes)
       end
     end
   end

--- a/src/lib/registration/ui/addon_selection_registration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_registration_dialog.rb
@@ -59,7 +59,7 @@ module Registration
 
       # update the enabled/disabled status in UI for dependent addons
       def reactivate_dependencies
-        Yast::UI.ChangeWidget(Id(:items), :Value, richtext_checkboxes(@addons))
+        Yast::UI.ChangeWidget(Id(:items), :Value, addon_checkboxes)
       end
     end
   end

--- a/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
@@ -44,6 +44,8 @@ module Registration
           true
         )
 
+        reactivate_dependencies
+
         handle_dialog
       end
 
@@ -62,6 +64,8 @@ module Registration
       # empty implementation, allow reregistration of a dependant addon
       # without reregistering its parent
       def reactivate_dependencies
+        # FIXME: how to test this?
+        Yast::UI.ChangeWidget(Id(:items), :Value, richtext_checkboxes(@addons))
       end
     end
   end

--- a/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
@@ -65,7 +65,7 @@ module Registration
       # without reregistering its parent
       def reactivate_dependencies
         # FIXME: how to test this?
-        Yast::UI.ChangeWidget(Id(:items), :Value, richtext_checkboxes(@addons))
+        Yast::UI.ChangeWidget(Id(:items), :Value, addon_checkboxes)
       end
     end
   end

--- a/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
@@ -24,9 +24,9 @@ module Registration
         super(registration)
 
         # filter out the unregistered addons
-        @addons.select!(&:registered?)
+        @all_addons.select!(&:registered?)
 
-        log.info "Registered addons: #{@addons}"
+        log.info "Registered addons: #{@all_addons}"
       end
 
       # display the extension selection dialog and wait for a button click

--- a/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_reregistration_dialog.rb
@@ -44,8 +44,6 @@ module Registration
           true
         )
 
-        reactivate_dependencies
-
         handle_dialog
       end
 
@@ -59,13 +57,6 @@ module Registration
       # @return [Boolean] is the addon selected?
       def addon_selected?(addon)
         addon.selected?
-      end
-
-      # empty implementation, allow reregistration of a dependant addon
-      # without reregistering its parent
-      def reactivate_dependencies
-        # FIXME: how to test this?
-        Yast::UI.ChangeWidget(Id(:items), :Value, addon_checkboxes)
       end
     end
   end

--- a/test/addon_selection_dialog_test.rb
+++ b/test/addon_selection_dialog_test.rb
@@ -45,12 +45,12 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       addon = addon_generator
       widget = "#{addon.identifier}-#{addon.version}-#{addon.arch}"
       expect(Yast::UI).to receive(:UserInput).and_return(widget, :next)
-      # mock that widget is selected
-      expect(Yast::UI).to receive(:QueryWidget)
-        .with(Yast::Term.new(:id, widget), :Value)
-        .and_return(true)
       registration = double(activated_products: [], get_addon_list: [addon])
       expect(subject.run(registration)).to eq :next
+
+      addons = Registration::Addon.find_all(registration)
+      wrapped_addon = addons.first
+      expect(wrapped_addon.selected?).to eq true
     end
 
     context "in SLES12-SP2" do

--- a/test/addon_selection_dialog_test.rb
+++ b/test/addon_selection_dialog_test.rb
@@ -2,8 +2,6 @@ require_relative "spec_helper"
 require "registration/addon"
 
 describe Registration::UI::AddonSelectionRegistrationDialog do
-  subject { Registration::UI::AddonSelectionRegistrationDialog }
-
   before(:each) do
     # generic UI stubs for the wizard dialog
     allow(Yast::UI).to receive(:WizardCommand)
@@ -17,6 +15,8 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
   end
 
   describe ".run" do
+    subject { Registration::UI::AddonSelectionRegistrationDialog }
+
     let(:toolchain) do
       Registration::Addon.new(
         addon_generator("zypper_name" => "sle-module-toolchain",
@@ -108,6 +108,24 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
           subject.run(registration)
         end
       end
+    end
+  end
+
+  describe "#handle_dialog" do
+    subject do
+      registration = double(activated_products: [], get_addon_list: [])
+      Registration::UI::AddonSelectionRegistrationDialog.new(registration)
+    end
+
+    it "filters beta releases" do
+      expect(Yast::UI).to receive(:UserInput).and_return(:filter_beta, :next)
+
+      expect(Yast::UI).to receive(:QueryWidget)
+        .with(Yast::Term.new(:id, :filter_beta), :Value)
+        .and_return(true)
+      expect(subject).to receive(:filter_beta_releases).with(true)
+
+      expect(subject.send(:handle_dialog)).to_not eq :back
     end
   end
 end

--- a/test/addon_spec.rb
+++ b/test/addon_spec.rb
@@ -146,6 +146,22 @@ describe Registration::Addon do
     end
   end
 
+  describe "#beta_release?" do
+    it "returns true if addon is beta release" do
+      product = addon_generator("release_stage" => "beta")
+      addon = Registration::Addon.new(product)
+
+      expect(addon.beta_release?).to eq(true)
+    end
+
+    it "returns false if addon is not beta release" do
+      product = addon_generator("release_stage" => "production")
+      addon = Registration::Addon.new(product)
+
+      expect(addon.beta_release?).to eq(false)
+    end
+  end
+
   describe "#label" do
     it "returns short name when the long name is nil" do
       product = addon_generator

--- a/test/addon_spec.rb
+++ b/test/addon_spec.rb
@@ -138,6 +138,21 @@ describe Registration::Addon do
     end
   end
 
+  describe "#toggle_selected" do
+    it "marks an unselected addon as selected" do
+      expect(Registration::Addon.selected.include?(addon)).to eq(false)
+      addon.toggle_selected
+      expect(Registration::Addon.selected.include?(addon)).to eq(true)
+    end
+
+    it "marks a selected addon as unselected" do
+      Registration::Addon.selected << addon
+      expect(Registration::Addon.selected.include?(addon)).to eq(true)
+      addon.toggle_selected
+      expect(Registration::Addon.selected.include?(addon)).to eq(false)
+    end
+  end
+
   describe "#registered?" do
     it "returns if addon is already registered" do
       expect(addon.registered?).to eq(false)

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -15,6 +15,7 @@ def suse_connect_product_generator(attrs = {})
   params["eula_url"] = attrs["eula_url"]
   params["extensions"] = attrs["extensions"] || []
   params["former_identifier"] = attrs["former_identifier"]
+  params["release_stage"] = attrs["release_stage"]
 
   params
 end


### PR DESCRIPTION
References:
Scrum: https://trello.com/c/L7i4X9kv
Bug: [bsc#967387](https://bugzilla.suse.com/show_bug.cgi?id=967387)
Also includes [FATE#319909](https://fate.suse.com/319909) - Do not show beta versions of products in YaST extension listing
