### PR TITLE
[WIP] Free flag on smt (bsc#970990)

### DIFF
--- a/src/lib/registration/registration_ui.rb
+++ b/src/lib/registration/registration_ui.rb
@@ -205,9 +205,10 @@ module Registration
     #   user entered values
     # @return [Symbol]
     def register_addons(selected_addons, known_reg_codes)
-      # if registering only add-ons which do not need a reg. code (like SDK)
-      # then simply start the registration
-      if selected_addons.all?(&:free)
+      # if using an SMT server for registration (bsc#970990)
+      # or registering only add-ons which do not need a reg. code (like SDK)
+      # then simply start the registration without asking for the reg. codes
+      if !UrlHelpers.scc_url? || selected_addons.all?(&:free)
         Yast::Wizard.SetContents(
           # dialog title
           _("Register Extensions and Modules"),

--- a/src/lib/registration/url_helpers.rb
+++ b/src/lib/registration/url_helpers.rb
@@ -182,6 +182,15 @@ module Registration
       slp_service_url
     end
 
+    # Is an SCC server used for registration?
+    # @note It checks only the URL which is used, if the server is just a proxy
+    #   which forwards the requests to the real SCC server then it cannot
+    #   detect it and the code considers it as a non-SCC registration.
+    # @return [Boolean] true when SCC is used, false otherwise
+    def self.scc_url?
+      registration_url.nil? || registration_url == SUSE::Connect::YaST::DEFAULT_URL
+    end
+
     # @return [String,nil] the boot command line parameter
     def self.boot_reg_url
       reg_url = Yast::Linuxrc.InstallInf("regurl")

--- a/test/registration_ui_test.rb
+++ b/test/registration_ui_test.rb
@@ -99,6 +99,9 @@ describe "Registration::RegistrationUI" do
 
       # stub the registration
       allow(registration).to receive(:register_product)
+
+      # set the default URL
+      allow(Registration::UrlHelpers).to receive(:registration_url)
     end
 
     context "when the addons are free" do
@@ -147,6 +150,16 @@ describe "Registration::RegistrationUI" do
         registration_ui.register_addons(selected_addons, {})
       end
 
+      it "does not ask for the reg. codes when using an SMT server" do
+        allow(Registration::UrlHelpers).to receive(:registration_url)
+          .and_return("https://smt.example.com")
+        allow(registration_ui).to receive(:register_selected_addons).with(any_args).and_return(true)
+        # do NOT ask for the reg. codes
+        expect(Registration::UI::AddonRegCodesDialog).to_not receive(:run)
+
+        # Register the HA-GEO addon, it requires a reg. code
+        registration_ui.register_addons([addon_HA_GEO], {})
+      end
     end
 
   end

--- a/test/url_helpers_spec.rb
+++ b/test/url_helpers_spec.rb
@@ -193,6 +193,28 @@ describe "Registration::UrlHelpers" do
     end
   end
 
+  describe ".scc_url?" do
+    it "returns true if the URL is set to the default (nil)" do
+      allow(Registration::UrlHelpers).to receive(:registration_url)
+
+      expect(Registration::UrlHelpers.scc_url?).to eq(true)
+    end
+
+    it "returns true if the URL is set to the SCC URL" do
+      allow(Registration::UrlHelpers).to receive(:registration_url)
+        .and_return("https://scc.suse.com")
+
+      expect(Registration::UrlHelpers.scc_url?).to eq(true)
+    end
+
+    it "returns false if the URL is set to a different URL" do
+      allow(Registration::UrlHelpers).to receive(:registration_url)
+        .and_return("https://smt.example.com")
+
+      expect(Registration::UrlHelpers.scc_url?).to eq(false)
+    end
+  end
+
   describe ".service_url" do
     it "converts a SLP service to plain URL" do
       url = "https://example.com/registration"


### PR DESCRIPTION
See bug https://bugzilla.suse.com/show_bug.cgi?id=970990

Unfortunately this won't work correctly in all cases. The SCC vs. SMT detection is currently done via the registration server URL.

This will work correctly with the SCC or an SMT server. However, this will break when using the SCC Proxy. In that case the URL is different than the SCC server but the specified server (the proxy) just forwards the registration to the real SCC. And SCC (in contrast to SMT) will require registration codes.

Unfortunately the SCC Proxy is used in openQA so we cannot ignore this use case.

The proposed solutions:

- Add a new flag in the server response. In addition to `free`, which defines whether the addon is paid, we could add a new flag (e.g. `regcode_required`) which would tell that the server requires a reg. code for this addon.  
*Unfortunately this would need a change on the SMT and SCC side. (Or at least on the SCC side, we could use default `false` for SMT when the value is missing in the response.)*
- Detect SMT via some API call which returns different value on SCC or SMT (or returns an different error). Or check the HTTP header?  
*The question is whether this is possible and how reliable it is...*
- Change the registration workflow - first try registering without any reg. code if it fails with "No reg. code" error ask user for the reg. code and try again.  
*Trying blindly registering an addon sounds a bit strange, we would need carefully check for the errors, esp. finding that it's just because of a missing reg. code would be tricky and likely fragile.*

Any other opinions, suggestions?