### PR TITLE
Preselect addon products at installation (bsc#992304)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug  5 15:50:59 UTC 2016 - lslezak@suse.cz
+
+- Preselect the add-on products also during installation
+  (bsc#992304)
+- 3.1.182
+
+-------------------------------------------------------------------
 Fri Aug  5 10:20:55 UTC 2016 - igonzalezsosa@suse.com
 
 - Fix package building in AArch64 (bsc#992341)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.181
+Version:        3.1.182
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/inst_scc.rb
+++ b/src/clients/inst_scc.rb
@@ -226,18 +226,16 @@ module Yast
       :next
     end
 
-    # preselect the addon products and run the package manager (only in installed system)
+    # preselect the addon products and in installed system run the package manager
     def pkg_manager
-      # during installation the products are installed together with the base
-      # product, run the package manager only in installed system
-      return :next unless Mode.normal
-
-      # skip the package management if no new addon was registered
-      return :next if Registration::Addon.registered == @addons_registered_orig
-
       ::Registration::SwMgmt.select_addon_products
 
-      WFM.call("sw_single")
+      # run the package manager only in installed system and if a new addon was registered
+      if Mode.normal && Registration::Addon.registered != @addons_registered_orig
+        WFM.call("sw_single")
+      else
+        :next
+      end
     end
 
     def registration_ui

--- a/test/base_system_registration_dialog_test.rb
+++ b/test/base_system_registration_dialog_test.rb
@@ -31,6 +31,7 @@ describe Registration::UI::BaseSystemRegistrationDialog do
       allow(Registration::SwMgmt).to receive(:find_base_product).and_return(base_product)
       allow(Yast::Mode).to receive(:mode).and_return(mode)
       allow(Registration::Registration).to receive(:is_registered?).and_return(registered?)
+      allow(Registration::UrlHelpers).to receive(:slp_discovery_feedback).and_return([])
     end
 
     context "when system is not registered" do


### PR DESCRIPTION
### Changes

- Preselect the addon products also during installation - [bsc#992304](https://bugzilla.suse.com/show_bug.cgi?id=992304)
- Do NOT run SLP discovery in a test
- 3.1.182

## Test

The fix has been manually tested in the latest SP2  build.

#### Original State

Registered and added SDK and Legacy module, but none of them is selected to install and displayed in the software proposal:

![addon_products_broken](https://cloud.githubusercontent.com/assets/907998/17443451/0807310a-5b3b-11e6-895b-11b2f55cea32.png)

#### Fixed

Both add-ons are selected and displayed in the software proposal:

![addon_products_fixed](https://cloud.githubusercontent.com/assets/907998/17443460/1081cc64-5b3b-11e6-8315-d2cf5a8ea828.png)
