### PR TITLE
Removed workaround for making /etc/zypp directory writable (bsc#967828)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug  9 12:59:25 UTC 2016 - lslezak@suse.cz
+
+- Removed workaround for making /etc/zypp directory writable,
+  it has been fixed in the installation-images package (bsc#967828)
+- 3.1.183
+
+-------------------------------------------------------------------
 Fri Aug  5 15:50:59 UTC 2016 - lslezak@suse.cz
 
 - Preselect the add-on products also during installation

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.182
+Version:        3.1.183
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -49,9 +49,6 @@ module Registration
       login, password = SUSE::Connect::YaST.announce_system(settings, distro_target)
       log.info "Global SCC credentials (username): #{login}"
 
-      # ensure the zypp config directories are writable in inst-sys
-      ::Registration::SwMgmt.zypp_config_writable!
-
       # write the global credentials
       SUSE::Connect::YaST.create_credentials_file(login, password)
     end

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -115,25 +115,6 @@ module Registration
       true
     end
 
-    # during installation /etc/zypp directory is not writable (mounted on
-    # a read-only file system), the workaround is to copy the whole directory
-    # structure into a writable temporary directory and override the original
-    # location by "mount -o bind"
-    def self.zypp_config_writable!
-      return if !(Mode.installation || Mode.update) || File.writable?(ZYPP_DIR)
-
-      log.info "Copying libzypp config to a writable place"
-
-      # create writable zypp directory structure in /tmp
-      tmpdir = Dir.mktmpdir
-
-      log.info "Copying #{ZYPP_DIR} to #{tmpdir} ..."
-      ::FileUtils.cp_r ZYPP_DIR, tmpdir
-
-      log.info "Mounting #{tmpdir} to #{ZYPP_DIR}"
-      `mount -o bind #{tmpdir}/zypp #{ZYPP_DIR}`
-    end
-
     def self.find_base_product
       # just for debugging:
       return FAKE_BASE_PRODUCT if ENV["FAKE_BASE_PRODUCT"]
@@ -354,9 +335,6 @@ module Registration
     # installation (in the inst_kickoff.rb client)
     def self.copy_old_credentials(source_dir)
       log.info "Searching registration credentials in #{source_dir}..."
-
-      # ensure the zypp directory is writable in inst-sys
-      zypp_config_writable!
 
       dir = SUSE::Connect::YaST::DEFAULT_CREDENTIALS_DIR
       # create the target directory if missing

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -16,7 +16,6 @@ describe Registration::Registration do
       reg_code = "reg_code"
       target_distro = "sles-12-x86_64"
 
-      expect(Registration::SwMgmt).to receive(:zypp_config_writable!)
       expect_any_instance_of(SUSE::Connect::Credentials).to receive(:write)
       expect(SUSE::Connect::YaST).to(receive(:announce_system)
         .with(hash_including(token: reg_code), target_distro)

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -155,8 +155,6 @@ describe Registration::SwMgmt do
     let(:target_dir) { SUSE::Connect::YaST::DEFAULT_CREDENTIALS_DIR }
 
     before do
-      expect(subject).to receive(:zypp_config_writable!)
-
       expect(File).to receive(:exist?).with(target_dir).and_return(false)
       expect(FileUtils).to receive(:mkdir_p).with(target_dir)
     end
@@ -347,38 +345,6 @@ describe Registration::SwMgmt do
     it "forwards the product renames to the AddOnProduct module" do
       expect(Yast::AddOnProduct).to receive(:add_rename).with("foo", "FOO")
       subject.update_product_renames("foo" => "FOO")
-    end
-  end
-
-  describe ".zypp_config_writable!" do
-    let(:zypp_dir) { Registration::SwMgmt::ZYPP_DIR }
-
-    it "does nothing in running system" do
-      expect(Yast::Mode).to receive(:installation).and_return(false)
-      expect(Yast::Mode).to receive(:update).and_return(false)
-      expect(FileUtils).to_not receive(:cp_r)
-
-      subject.zypp_config_writable!
-    end
-
-    it "does nothing if the target is already writable (not read-only)" do
-      expect(Yast::Mode).to receive(:installation).and_return(true)
-      expect(File).to receive(:writable?).with(zypp_dir).and_return(true)
-      expect(FileUtils).to_not receive(:cp_r)
-
-      subject.zypp_config_writable!
-    end
-
-    it "otherwise it overrides the zypp directory with a writable copy" do
-      tmpdir = "/tmp/foo"
-      expect(Yast::Mode).to receive(:installation).and_return(true)
-      expect(File).to receive(:writable?).with(zypp_dir)
-        .and_return(false)
-      expect(Dir).to receive(:mktmpdir).and_return(tmpdir)
-      expect(FileUtils).to receive(:cp_r).with(zypp_dir, tmpdir)
-      expect(subject).to receive(:`).with("mount -o bind #{tmpdir}/zypp #{zypp_dir}")
-
-      subject.zypp_config_writable!
     end
   end
 


### PR DESCRIPTION
It has been fixed in the installation-images package - see https://github.com/openSUSE/installation-images/pull/126.

The `zypp_config_writable!` method is not needed anymore and can be removed.

- 3.1.183