### PR TITLE
[PoC] Hack - add a trailing space to the addon names (bsc#955156)

### DIFF
--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -132,6 +132,10 @@ module Registration
 
       remote_product = SwMgmt.remote_product(base_product)
       addons = SUSE::Connect::YaST.show_product(remote_product, connect_params).extensions || []
+
+      # hack, the last character is trimmed in ncurses (bsc#955156)
+      addons.each { |a| a.friendly_name += " " }
+
       addons.each { |a| log.info "Found available addon: #{a.inspect}" }
 
       renames = collect_renames(addons)


### PR DESCRIPTION
# Do not merge this! This is just a proof of concept for a possible fix for bsc#955156!

See the [original bug report]( https://bugzilla.suse.com/show_bug.cgi?id=955156) for more details.

# Original State

The last character is lost in the ncurses UI:

![registration_addons_broken](https://cloud.githubusercontent.com/assets/907998/18477242/3b874730-79cd-11e6-8e93-2074692af46c.png)

# Hack

This hack simply adds a trailing space to the displayed label so the ncurses UI eats the extra unused character:

![registration_addons_hacked](https://cloud.githubusercontent.com/assets/907998/18477251/42bab4a6-79cd-11e6-8128-e78560c8f0b7.png)

# Note

I have checked the Qt UI as well and it is still OK, the extra space does not change the layout. (But there might be few pixel difference so it could affect openQA in the end...)