### PR TITLE
Workaround for missing trailing characters (bsc#955156)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 19 12:08:54 UTC 2016 - lslezak@suse.cz
+
+- Added a workaround for missing last characters in the addon
+  selection dialog in text mode (bsc#955156)
+
+-------------------------------------------------------------------
 Wed Apr  6 16:10:58 CEST 2016 - schubi@suse.de
 
 - Force refreshing while adding a service (bnc#967828).

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -163,6 +163,9 @@ module Registration
         # (%s is an extension name)
         label = addon.available? ? addon.label : (_("%s (not available)") % addon.label)
 
+        # workaround for an ncurses UI bug (the last character is lost)(bsc#955156)
+        label += " " if Yast::UI.TextMode
+
         CheckBox(Id(addon_widget_id(addon)), Opt(:notify), label, addon_selected?(addon))
       end
 


### PR DESCRIPTION
This is a workaround for an ncurses UI bug, the Qt UI displays the labels correctly.
See https://bugzilla.suse.com/show_bug.cgi?id=955156

### Notes

- This is for SP1 only as in SP2 we use a different UI layout and the bug does not happen there anymore.
- It's without a version update as this will be released later together with some other maintenance update (it is not urgent, it is just a cosmetic issue).

## The Original State

![addon_selection_broken](https://cloud.githubusercontent.com/assets/907998/18631890/d1e708ea-7e74-11e6-9380-20ef350cb46b.png)

## With the Workaround

![addon_selection_fixed](https://cloud.githubusercontent.com/assets/907998/18631891/dca3a784-7e74-11e6-93bb-39661b682107.png)
