### PR TITLE
Better handle invalid credentials (bsc#941427)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Oct  3 19:11:11 UTC 2016 - lslezak@suse.cz
+
+- Better handle invalid credentials at start - start the repository
+  manager to allow manually removing the offending service or
+  repository (bsc#941427)
+- 3.1.190
+
+-------------------------------------------------------------------
 Mon Oct  3 09:26:28 UTC 2016 - jreidinger@suse.com
 
 - Remember the beta filter value and set it when going back

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.189
+Version:        3.1.190
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/scc.rb
+++ b/src/clients/scc.rb
@@ -58,6 +58,8 @@ module Yast
       end
     end
 
+  private
+
     # Print help in command line mode
     def print_help
       cmdline_description = {

--- a/src/lib/registration/exceptions.rb
+++ b/src/lib/registration/exceptions.rb
@@ -35,6 +35,9 @@ module Registration
     end
   end
 
+  class SourceRestoreError < PkgError
+  end
+
   # generic download error
   class DownloadError < RuntimeError
   end

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -73,7 +73,7 @@ module Registration
 
       raise_pkg_exception unless Pkg.TargetInitialize(Installation.destdir)
       raise_pkg_exception unless Pkg.TargetLoad
-      raise_pkg_exception unless Pkg.SourceRestore
+      raise_pkg_exception(SourceRestoreError) unless Pkg.SourceRestore
 
       raise_pkg_exception if load_packages && !Pkg.SourceLoad
     end
@@ -499,8 +499,8 @@ module Registration
       product["register_release"]
     end
 
-    def self.raise_pkg_exception
-      raise PkgError.new, Pkg.LastError
+    def self.raise_pkg_exception(klass = PkgError)
+      raise klass, Pkg.LastError
     end
 
     private_class_method :each_repo

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -56,13 +56,22 @@ describe Registration::SwMgmt do
     context "when the libzypp lock can be obtained" do
       let(:connected) { true }
 
-      it "initializes package management" do
+      before do
         expect(Yast::PackageCallbacks).to receive(:InitPackageCallbacks)
         expect(Yast::Pkg).to receive(:TargetInitialize).and_return(true)
         expect(Yast::Pkg).to receive(:TargetLoad).and_return(true)
+      end
+
+      it "initializes package management" do
         expect(Yast::Pkg).to receive(:SourceRestore).and_return(true)
 
         subject.init
+      end
+
+      it "raises SourceRestoreError exception when the repository restore fails" do
+        expect(Yast::Pkg).to receive(:SourceRestore).and_return(false)
+
+        expect { subject.init }.to raise_exception(Registration::SourceRestoreError)
       end
     end
 


### PR DESCRIPTION
- Start the repository manager to remove the offending service/repository.
- Fixes [bsc#941427](https://bugzilla.suse.com/show_bug.cgi?id=941427)

### Notes

The debugging was a bit tricky, I was not able to reproduce the problem after manually invalidating (changing) the credentials stored in a *.service* file and clearing the libzypp cache with `zypper clear -a`.

It turned out that the service cache time stamp is stored directly in the *.service* file (`lrf_dat` key) and is not touched by that `zypper clear` call. By default the service cache is valid for 24 hours, so the invalid credentials might take effect after (up to) 24 hours!

### The Original Bug

When the credentials are not valid anymore and the service is refreshed when starting the registration module you will see this error:

![yast2-failed_auth](https://cloud.githubusercontent.com/assets/907998/19050704/1e36d6b2-89b0-11e6-97c0-72b03f7faec3.png)

Then whatever button you press you will see the generic exception handler:

![yast2-original_failure](https://cloud.githubusercontent.com/assets/907998/19050633/c51a8ee8-89af-11e6-92c3-621908bfbce3.png)

That's not user friendly.

### Initial Fix

At first I thought I could have added a new button (*Disable the Service*) into the authentication popup which would automatically disable the problematic service and user could continue in the workflow.

Unfortunately there are two issues:

- The [Authentication callback](https://github.com/yast/yast-yast2/blob/master/library/packages/src/modules/PackageCallbacks.rb#L2182) can be called not only from the service refresh, but also during package installation. In that context the *Disable the Service* button would not make sense. Unfortunately the context is not known for the callback code, we would need to track what is being called from the outside code. And that's fragile...
- The URL passed to the callback contains the real URL which failed (e.g. https://scc.suse.com/access/services/1106?cookies=0&credentials=SUSE_Linux_Enterprise_Server_12_x86_64), not the service URL (e.g. https://scc.suse.com/access/services/1106?credentials=SUSE_Linux_Enterprise_Server_12_x86_64). Matching the service URL and the failure URL would be tricky and again fragile (libzypp might add some more URL options or use different path in the future).

Therefore I implemented a simpler fix - when the repository initialization fails display the details about the failure and start the repository manager so the user could **manually** remove (disable) the offending service/repository.

### The Fix

After pressing any button in the authentication popup

![yast2-failed_auth](https://cloud.githubusercontent.com/assets/907998/19050704/1e36d6b2-89b0-11e6-97c0-72b03f7faec3.png)

you will see this new error popup with details:

![yast2-failed_repos](https://cloud.githubusercontent.com/assets/907998/19050834/96203f88-89b0-11e6-98eb-cf793e6862ab.png)

After pressing *OK* the repository manager is started. Here you have to manually remove (or disable) the offending service/repository. After pressing *OK* there the registration module tries the repository initialization again. After pressing *Cancel* in the repository manager the registration module exits.
