### PR TITLE
SLE 12 SP2 merge

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -8,7 +8,8 @@ Mon Oct  3 19:11:11 UTC 2016 - lslezak@suse.cz
 -------------------------------------------------------------------
 Mon Oct  3 09:26:28 UTC 2016 - jreidinger@suse.com
 
-- remember value of filter beta checkbox (bnc#996891)
+- Remember the beta filter value and set it when going back
+  (bnc#996891)
 
 -------------------------------------------------------------------
 Wed Aug 31 09:10:41 UTC 2016 - jreidinger@suse.com

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -4,7 +4,6 @@ Mon Oct  3 19:11:11 UTC 2016 - lslezak@suse.cz
 - Better handle invalid credentials at start - start the repository
   manager to allow manually removing the offending service or
   repository (bsc#941427)
-- 3.1.191
 
 -------------------------------------------------------------------
 Mon Oct  3 09:26:28 UTC 2016 - jreidinger@suse.com

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct  3 19:11:11 UTC 2016 - lslezak@suse.cz
+
+- Better handle invalid credentials at start - start the repository
+  manager to allow manually removing the offending service or
+  repository (bsc#941427)
+
+-------------------------------------------------------------------
 Wed Aug 31 09:10:41 UTC 2016 - jreidinger@suse.com
 
 - more robust check for installation dark theme (bnc#996258)

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -4,6 +4,7 @@ Mon Oct  3 19:11:11 UTC 2016 - lslezak@suse.cz
 - Better handle invalid credentials at start - start the repository
   manager to allow manually removing the offending service or
   repository (bsc#941427)
+- 3.1.191
 
 -------------------------------------------------------------------
 Mon Oct  3 09:26:28 UTC 2016 - jreidinger@suse.com

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -11,6 +11,7 @@ Mon Oct  3 09:26:28 UTC 2016 - jreidinger@suse.com
 
 - Remember the beta filter value and set it when going back
   (bnc#996891)
+- 3.1.189
 
 -------------------------------------------------------------------
 Wed Aug 31 09:10:41 UTC 2016 - jreidinger@suse.com

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -6,6 +6,11 @@ Mon Oct  3 19:11:11 UTC 2016 - lslezak@suse.cz
   repository (bsc#941427)
 
 -------------------------------------------------------------------
+Mon Oct  3 09:26:28 UTC 2016 - jreidinger@suse.com
+
+- remember value of filter beta checkbox (bnc#996891)
+
+-------------------------------------------------------------------
 Wed Aug 31 09:10:41 UTC 2016 - jreidinger@suse.com
 
 - more robust check for installation dark theme (bnc#996258)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.191
+Version:        3.1.188
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.188
+Version:        3.1.191
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/scc.rb
+++ b/src/clients/scc.rb
@@ -26,8 +26,13 @@
 require "yast"
 require "registration/sw_mgmt"
 
+# HTML escaping
+require "cgi/util"
+
 module Yast
   class SccClient < Client
+    include Yast::Logger
+
     Yast.import "CommandLine"
     Yast.import "Pkg"
     Yast.import "Report"
@@ -37,13 +42,7 @@ module Yast
       textdomain "registration"
 
       if WFM.Args.include?("help")
-        cmdline_description = {
-          "id"   => "scc",
-          # Command line help text for the repository module, %1 is "SUSEconnect"
-          "help" => _("Use '%s' instead of this YaST module.") % "SUSEconnect"
-        }
-
-        CommandLine.Run(cmdline_description)
+        print_help
       else
         Wizard.CreateDialog
 
@@ -51,10 +50,42 @@ module Yast
           ::Registration::SwMgmt.init
 
           return WFM.call("inst_scc", WFM.Args)
+        rescue Registration::SourceRestoreError => e
+          retry if fix_repositories(e.message)
         ensure
           Wizard.CloseDialog
         end
       end
+    end
+
+  private
+
+    # Print help in command line mode
+    def print_help
+      cmdline_description = {
+        "id"   => "scc",
+        # Command line help text for the repository module, %1 is "SUSEconnect"
+        "help" => _("Use '%s' instead of this YaST module.") % "SUSEconnect"
+      }
+
+      CommandLine.Run(cmdline_description)
+    end
+
+    # Let the user manually fix the broken repositories
+    # @return [Boolean] true if the repository manager was successfuly closed,
+    #   false after pressing [Cancel]
+    def fix_repositories(details)
+      # TRANSLATORS: Error message in RichText format, %s contains the details from libzypp
+      Report.LongError(_("<p>The repository initialization failed. " \
+        "Disable (or remove) the offending service or repository " \
+        "in the repository manager.</p><p>Details:</p><p>%s</p>") % CGI.escapeHTML(details))
+
+      ret = WFM.call("repositories", WFM.Args)
+      log.info "repository manager result: #{ret}"
+
+      # drop all loaded repos, force complete reloading
+      Pkg.SourceFinishAll
+      ret == :next
     end
   end unless defined?(SccClient)
 end

--- a/src/lib/registration/exceptions.rb
+++ b/src/lib/registration/exceptions.rb
@@ -35,6 +35,9 @@ module Registration
     end
   end
 
+  class SourceRestoreError < PkgError
+  end
+
   # generic download error
   class DownloadError < RuntimeError
   end

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -73,7 +73,7 @@ module Registration
 
       raise_pkg_exception unless Pkg.TargetInitialize(Installation.destdir)
       raise_pkg_exception unless Pkg.TargetLoad
-      raise_pkg_exception unless Pkg.SourceRestore
+      raise_pkg_exception(SourceRestoreError) unless Pkg.SourceRestore
 
       raise_pkg_exception if load_packages && !Pkg.SourceLoad
     end
@@ -499,8 +499,8 @@ module Registration
       product["register_release"]
     end
 
-    def self.raise_pkg_exception
-      raise PkgError.new, Pkg.LastError
+    def self.raise_pkg_exception(klass = PkgError)
+      raise klass, Pkg.LastError
     end
 
     private_class_method :each_repo

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -23,6 +23,10 @@ module Registration
       Yast.import "Stage"
       Yast.import "Arch"
 
+      class << self
+        attr_accessor :filter_beta
+      end
+
       FILTER_BETAS_INITIALLY = true
 
       # constructor
@@ -35,7 +39,9 @@ module Registration
         # sort the addons
         @all_addons.sort!(&::Registration::ADDON_SORTER)
 
-        filter_beta_releases(FILTER_BETAS_INITIALLY)
+        self.class.filter_beta = FILTER_BETAS_INITIALLY if self.class.filter_beta.nil?
+
+        filter_beta_releases(self.class.filter_beta)
 
         @old_selection = Addon.selected.dup
 
@@ -64,6 +70,7 @@ module Registration
       # Enables or disables beta addons filtering
       # @param [Boolean] enable true for filtering beta releases
       def filter_beta_releases(enable)
+        self.class.filter_beta = enable
         @addons = enable ? @all_addons.reject(&:beta_release?) : @all_addons
       end
 

--- a/test/addon_selection_dialog_test.rb
+++ b/test/addon_selection_dialog_test.rb
@@ -17,6 +17,17 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
     addon_reset_cache
   end
 
+  describe "#initialize" do
+    it "sets filter beta to previous state" do
+      fake_ref = double.as_null_object
+      res = described_class.new(fake_ref)
+      res.send(:filter_beta_releases, false)
+
+      expect_any_instance_of(described_class).to receive(:filter_beta_releases).with(false)
+      described_class.new(fake_ref)
+    end
+  end
+
   describe ".run" do
     subject { Registration::UI::AddonSelectionRegistrationDialog }
 

--- a/test/addon_selection_dialog_test.rb
+++ b/test/addon_selection_dialog_test.rb
@@ -18,7 +18,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
   end
 
   describe "#initialize" do
-    it "sets filter beta to previous state" do
+    it "sets the beta filter to the previous state" do
       fake_ref = double.as_null_object
       res = described_class.new(fake_ref)
       res.send(:filter_beta_releases, false)

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -56,13 +56,22 @@ describe Registration::SwMgmt do
     context "when the libzypp lock can be obtained" do
       let(:connected) { true }
 
-      it "initializes package management" do
+      before do
         expect(Yast::PackageCallbacks).to receive(:InitPackageCallbacks)
         expect(Yast::Pkg).to receive(:TargetInitialize).and_return(true)
         expect(Yast::Pkg).to receive(:TargetLoad).and_return(true)
+      end
+
+      it "initializes package management" do
         expect(Yast::Pkg).to receive(:SourceRestore).and_return(true)
 
         subject.init
+      end
+
+      it "raises SourceRestoreError exception when the repository restore fails" do
+        expect(Yast::Pkg).to receive(:SourceRestore).and_return(false)
+
+        expect { subject.init }.to raise_exception(Registration::SourceRestoreError)
       end
     end
 


### PR DESCRIPTION
Merge `merge_after_SP2_release` branch into `SLE-12-SP2`. It uses `3.1.191` because `3.1.189` and `3.1.190` already exist in `master` branch. We should bump `master` to `3.2.x`.