### PR TITLE
Use the new Docker image at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: required
-language: ruby
+language: bash
 services:
   - docker
 
 before_install:
   - docker build -t yast-test-image .
 script:
-  # the "yast-travis" script is included in the base yastdevel/ruby-tw image
-  # see https://github.com/yast/docker-yast-ruby-tw/blob/master/yast-travis
-  - docker run -it -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-test-image yast-travis
+  # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
+  # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-test-image yast-travis-ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ services:
   - docker
 
 before_install:
-  - docker build -t yast-test-image .
+  - docker build -t yast-registration-image .
 script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-test-image yast-travis-ruby
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-registration-image yast-travis-ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM yastdevel/ruby-tw
-COPY . /tmp/sources
+FROM yastdevel/ruby
+COPY . /usr/src/app
 


### PR DESCRIPTION
- I found out that Travis supports `generic` language, with `bash`, `sh` and `shell` aliases, which should be less error prone - possibly less issues on the Travis side with a smaller/simpler base image. We do not run any Ruby code out of Docker anyway.
- Use the renamed Docker image - originally I wanted to have a separate image for Head (based on Tumbleweed) and separate images for each maintenance branches, but the common upstream Docker way is to have a single Docker repository based on a single GitHub repo and have separate Docker tags based on the Git branches.
So instead of `cpp-tw` and `cpp-sle12-sp2` (or similar) Docker images and their GitHub repositories we will have `cpp` (which is the same as `cpp:latest`) and `cpp:sle12-sp2` images at Docker and a single GitHub repo.
- Use the `/usr/src/app` directory for storing the sources in the Docker container. The same place is used in the other official Docker images e.g. [Ruby](https://hub.docker.com/_/ruby/), [JRuby](https://hub.docker.com/_/jruby/), [Node,js](https://hub.docker.com/_/node/),... Just be more compatible with the Docker upstream. The new Docker YaST images expects the sources at this place.
- Moved setting `TRAVIS=1` environment here from the common Docker image, avoid sending the coveralls report when using the Docker image locally (outside Travis).