### PR TITLE
[RFC] Added Registration Code widget for CaaSP (Fate#322328)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :sle12sp2
+Yast::Tasks.submit_to :casp10
 
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 23 13:21:42 UTC 2017 - kanderssen@suse.com
+
+- Added Registration::Widgets::RegistrationCode (fate#322328).
+- 3.1.191
+
+-------------------------------------------------------------------
 Wed Nov 23 10:01:44 UTC 2016 - jreidinger@suse.com
 
 - do not crash if empty regurl paremeter is passed (bsc#1010387)

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -2,7 +2,7 @@
 Mon Jan 23 13:21:42 UTC 2017 - kanderssen@suse.com
 
 - Added Registration::Widgets::RegistrationCode (fate#322328).
-- 3.1.191
+- 3.1.190.1
 
 -------------------------------------------------------------------
 Wed Nov 23 10:01:44 UTC 2016 - jreidinger@suse.com

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.191
+Version:        3.1.190.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.190
+Version:        3.1.191
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/widgets/registration_code.rb
+++ b/src/lib/registration/widgets/registration_code.rb
@@ -70,7 +70,8 @@ module Registration
         end
 
         if !SwMgmt.find_base_product
-          return error(_("No base product found, skipping registration."))
+          Helpers.report_no_base_product
+          return false
         end
 
         log.info("Registering the system and the base product.")

--- a/src/lib/registration/widgets/registration_code.rb
+++ b/src/lib/registration/widgets/registration_code.rb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
+#
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "cwm/widget"
+
+module Widgets
+  class RegistrationCode < CWM::InputField
+    def initialize
+      textdomain "registration"
+    end
+
+    def label
+      _("Registration Code or SMT Server URL")
+    end
+  end
+end

--- a/src/lib/registration/widgets/registration_code.rb
+++ b/src/lib/registration/widgets/registration_code.rb
@@ -74,10 +74,13 @@ module Registration
           return false
         end
 
+
         log.info("Registering the system and the base product.")
+        # Error reports and logs about the registration are mostly handled
+        # by ConnectHelpers.catch_registration_errors and used by instances
+        # of RegistrationUI.
         return false if !register_system_and_base_product
 
-        log.info("System registered with success.")
         Storage::InstallationOptions.instance.base_registered = true
       end
 

--- a/src/lib/registration/widgets/registration_code.rb
+++ b/src/lib/registration/widgets/registration_code.rb
@@ -70,8 +70,7 @@ module Registration
         end
 
         if !SwMgmt.find_base_product
-          log.info("Not base product found, skipping registration.")
-          return true
+          return error(_("No base product found, skipping registration."))
         end
 
         log.info("Registering the system and the base product.")

--- a/src/lib/registration/widgets/registration_code.rb
+++ b/src/lib/registration/widgets/registration_code.rb
@@ -21,15 +21,106 @@
 
 require "yast"
 require "cwm/widget"
+require "uri"
+require "registration/registration_ui"
 
-module Widgets
-  class RegistrationCode < CWM::InputField
-    def initialize
-      textdomain "registration"
-    end
+module Registration
+  module Widgets
+    class RegistrationCode < CWM::InputField
+      VALID_URL_SCHEMES = ["http", "https"].freeze
 
-    def label
-      _("Registration Code or SMT Server URL")
+      attr_accessor :registration_code, :registration, :reg_options
+
+      def initialize
+        textdomain "registration"
+      end
+
+      def label
+        _("Registration Code or SMT Server URL")
+      end
+
+      # Initialize the widget with stored values
+      def init
+        log.info("Already registered") if registered?
+
+        @options = Storage::InstallationOptions.instance
+        self.value = @options.custom_url
+        self.value = @options.reg_code if !@options.reg_code.to_s.empty?
+      end
+
+      # Set registration options according to the value
+      def store
+        if valid_url?
+          @options.reg_code   = ""
+          @options.custom_url = value
+        else
+          @options.reg_code   = value
+          @options.custom_url = default_url
+        end
+      end
+
+      def registered?
+        Registration.is_registered?
+      end
+
+      def register
+        return true if skip?
+
+        log.info("Registering the system and the base product.")
+        return false if !register_system_and_base_product
+
+        log.info("System registered with success.")
+        Storage::InstallationOptions.instance.base_registered = true
+      end
+
+    private
+
+      def valid_url?
+        return false if value.to_s.empty?
+
+        uri = URI(value)
+        VALID_URL_SCHEMES.include?(uri.scheme)
+      end
+
+      # run the system and the base product registration
+      # @return [Boolean] true on success
+      def register_system_and_base_product
+        url = UrlHelpers.registration_url
+        return false if UrlHelpers.registration_url == :cancel
+
+        registration    = Registration.new(url)
+        registration_ui = RegistrationUI.new(registration)
+
+        success, product_service = registration_ui.register_system_and_base_product
+
+        if product_service && !registration_ui.install_updates?
+          registration_ui.disable_update_repos(product_service)
+        end
+
+        success
+      end
+
+      # Default registration server
+      #
+      # The boot_url takes precedence over the SUSE::Connect default
+      # one.
+      #
+      # @return [String] URL for the registration server
+      def default_url
+        boot_url || SUSE::Connect::Config.new.url
+      end
+
+      # Registration server URL given through Linuxrc
+      #
+      # @return [String,nil] URL for the registration server; nil if not given.
+      def boot_url
+        UrlHelpers.boot_reg_url
+      end
+
+      # Skip registration if the value is empty or nil
+      def skip?
+        value.to_s.empty?
+      end
     end
   end
 end

--- a/src/lib/registration/widgets/registration_code.rb
+++ b/src/lib/registration/widgets/registration_code.rb
@@ -45,7 +45,8 @@ module Registration
         self.value = reg_code.empty? ? (options.custom_url || boot_url) : options.reg_code
       end
 
-      # Set registration options according to the value
+      # Set registration options according to the value and try to register the
+      # system.
       def store
         if valid_url?
           options.reg_code   = ""
@@ -58,6 +59,10 @@ module Registration
         register
       end
 
+      # Try to register the system against SCC or a custom SMT depending on if
+      # the value is an URL or not.
+      #
+      # @return [Boolean] false if not attempted or failed and true if success
       def register
         if skip?
           log.info("Empty value, skipping registration")

--- a/src/lib/registration/widgets/registration_code.rb
+++ b/src/lib/registration/widgets/registration_code.rb
@@ -61,19 +61,18 @@ module Registration
       def register
         if skip?
           log.info("Empty value, skipping registration")
-          return true
+          return false
         end
 
         if Registration.is_registered?
           log.info("The system is already registered so skipped registration.")
-          return true
+          return false
         end
 
         if !SwMgmt.find_base_product
           Helpers.report_no_base_product
           return false
         end
-
 
         log.info("Registering the system and the base product.")
         # Error reports and logs about the registration are mostly handled
@@ -106,6 +105,8 @@ module Registration
       end
 
       def url?
+        return false if value.to_s.empty?
+
         uri = URI(value)
         uri.scheme ? true : false
       rescue URI::InvalidURIError


### PR DESCRIPTION
Just moved the current widget from the main PR: https://github.com/yast/yast-installation/pull/487 (that one uses a built-in fake registration widget)

Using this widget: https://github.com/yast/yast-installation/pull/504

If you want to know more about this:

- https://trello.com/c/XDgl2dj7
- https://fate.suse.com/322328
