### PR TITLE
Get update list errors

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Feb 14 10:00:41 UTC 2017 - igonzalezsosa@suse.com
+
+- Registration#get_updates_list won't catch errors anymore because
+  that's something tightly coupled to the user interface. They
+  should be handled outside that method (bsc#1025251)
+- 3.2.3
+
+-------------------------------------------------------------------
 Mon Jan 30 20:05:56 UTC 2017 - mfilka@suse.com
 
 - fate#321044

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.2.2
+Version:        3.2.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -176,12 +176,8 @@ module Registration
       product ||= SwMgmt.base_product_to_register
 
       log.info "Reading available updates for product: #{product["name"]}"
-      updates = []
-
-      ConnectHelpers.catch_registration_errors do
-        remote_product = SwMgmt.remote_product(product)
-        updates = SUSE::Connect::YaST.list_installer_updates(remote_product, connect_params)
-      end
+      remote_product = SwMgmt.remote_product(product)
+      updates = SUSE::Connect::YaST.list_installer_updates(remote_product, connect_params)
 
       log.info "Updates for '#{product["name"]}' are available at '#{updates}'"
       updates


### PR DESCRIPTION
* `Registration#get_updates_list` won't catch errors anymore. I think this method should be responsible for just asking the API.
* Other option could be just adding a new argument (`handle_errors` or something like that) which determines whether error handling should be performed or not.

The error is handled in the [UpdateRepositoryFinder class](https://github.com/yast/yast-installation/pull/522/commits/65860510f385bacb027fd6e928262be8881d3f81#diff-bf4d34fcdb7355d3d66880e4bf99d1c4R284).