### PR TITLE
Display more addons in text mode (bsc#1024464)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Mar  2 12:54:20 UTC 2017 - lslezak@suse.cz
 
-- Fixed layout of the "Extension and Module Selection" dialog
+- Fixed the layout of the "Extension and Module Selection" dialog
   in text mode to make all items visible (bsc#1024464)
 - 3.1.166.4
 

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  2 12:54:20 UTC 2017 - lslezak@suse.cz
+
+- Fixed layout of the "Extension and Module Selection" dialog
+  in text mode to make all items visible (bsc#1024464)
+- 3.1.166.4
+
+-------------------------------------------------------------------
 Mon Oct 17 11:21:34 UTC 2016 - lslezak@suse.cz
 
 - Recommend yast2-migration package to install it by default

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.166.3
+Version:        3.1.166.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -83,8 +83,22 @@ module Registration
       # addon description widget
       # @return [Yast::Term] the addon details widget
       def details_widget
-        MinHeight(5,
-          VWeight(15, RichText(Id(:details), Opt(:disabled), "<small>" +
+        vweight =
+          if Yast::UI.TextMode
+            screen_height > 35 ? 25 : 15
+          else
+            25
+          end
+
+        minheight =
+          if Yast::UI.TextMode
+            screen_height > 35 ? 8 : 5
+          else
+            8
+          end
+
+        MinHeight(minheight,
+          VWeight(vweight, RichText(Id(:details), Opt(:disabled), "<small>" +
                 _("Select an extension or a module to show details here") + "</small>"))
         )
       end
@@ -93,14 +107,39 @@ module Registration
       # the UI uses two column layout
       # @return [Yast::Term] the main UI dialog term
       def addons_box
-        lines = Yast::UI.TextMode ? 11 : 14
+        lines = addons_box_lines
         if @addons.size <= lines
           content = addon_selection_items(@addons)
         else
           content = two_column_layout(@addons[lines..(2 * lines - 1)], @addons[0..(lines - 1)])
         end
 
-        VWeight(85, MarginBox(2, 1, content))
+        vweight =
+          if Yast::UI.TextMode
+            screen_height > 35 ? 75 : 85
+          else
+            85
+          end
+
+        VWeight(vweight, MarginBox(2, 1, content))
+      end
+
+      # number of addons displayed in one column
+      def addons_box_lines
+        if Yast::UI.TextMode
+          # experimentally obtained constant - the number of occupied lines
+          # by the other widgets
+          screen_height - 12
+        else
+          14
+        end
+      end
+
+      # height of the screen, in text mode number of lines, in graphical
+      # mode height in pixels
+      # @return [Integer] screen height
+      def screen_height
+        Yast::UI.GetDisplayInfo["Height"]
       end
 
       # display the addon checkboxes in two columns

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -83,8 +83,8 @@ module Registration
       # addon description widget
       # @return [Yast::Term] the addon details widget
       def details_widget
-        MinHeight(8,
-          VWeight(25, RichText(Id(:details), Opt(:disabled), "<small>" +
+        MinHeight(5,
+          VWeight(15, RichText(Id(:details), Opt(:disabled), "<small>" +
                 _("Select an extension or a module to show details here") + "</small>"))
         )
       end
@@ -93,14 +93,14 @@ module Registration
       # the UI uses two column layout
       # @return [Yast::Term] the main UI dialog term
       def addons_box
-        lines = Yast::UI.TextMode ? 9 : 14
+        lines = Yast::UI.TextMode ? 11 : 14
         if @addons.size <= lines
           content = addon_selection_items(@addons)
         else
           content = two_column_layout(@addons[lines..(2 * lines - 1)], @addons[0..(lines - 1)])
         end
 
-        VWeight(75, MarginBox(2, 1, content))
+        VWeight(85, MarginBox(2, 1, content))
       end
 
       # display the addon checkboxes in two columns


### PR DESCRIPTION
See bug https://bugzilla.novell.com/show_bug.cgi?id=1024464

The dialog was originally designed for much less addons, unfortunately the number of addon grew over time and it exceeded the original limit for the text mode UI (18 addons max, currently there are 19 addons).

#### Notes

- The graphical (Qt) version is not affected as the maximum number of displayed addons is much bigger (28 addons).
- That means the graphical layout was kept untouched to avoid possible regressions.
- Only SP1 is affected, in SP2 we use a scrollable `RichText` widget

## Screenshots

### The Original Dialog

![addons_broken](https://cloud.githubusercontent.com/assets/907998/23304046/0689b300-fa98-11e6-9720-c3519a858a83.png)

The dialog looks OK, but actually the *Web and Scripting Module* is missing :hushed: 

## Fix

![addons_80x25](https://cloud.githubusercontent.com/assets/907998/23507508/b8a0018e-ff4d-11e6-8657-ca69859b2abe.png)

- Decreased the size of the *Details* description
- Increased the number of displayed addons from 18 to 22
- The *Web and Scripting Module* is displayed properly
- There is even space for 3 more addons (so hopefully we do not run into the same problem soon...)

### Bigger Screen

The number of addons in one column is now computed dynamically depending on the current screen size.

#### Bigger Screen Size

If the there is enough free space then the dialog might be even switched to one column and the labels are not truncated anymore:

![addons_97x35](https://cloud.githubusercontent.com/assets/907998/23507606/2a1658d6-ff4e-11e6-8562-32615ff4591d.png)

#### Even Bigger Screen Size

For even bigger screens the *Details* description size is increased:

![addons_105x41](https://cloud.githubusercontent.com/assets/907998/23507652/5b9536f2-ff4e-11e6-81ba-66e210bd3520.png)


