### PR TITLE
Be explicit about 'Details' box not being localized (bsc#1025846)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 20 12:28:45 UTC 2017 - okurz@suse.com
+
+- Be explicit about 'Details' box not being localized (bsc#1025846)
+- 3.2.6
+
+-------------------------------------------------------------------
 Fri Mar 17 09:23:03 UTC 2017 - gsouzadossantos@suse.com
 
 - Remember the state of the checkbox when leaving the dialog

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.2.5
+Version:        3.2.6
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -102,7 +102,7 @@ module Registration
           Left(CheckBox(Id(:filter_beta), Opt(:notify),
             _("&Hide Beta Versions"), check_filter)),
           addons_box,
-          Left(Label(_("Details"))),
+          Left(Label(_("Details (English only)"))),
           details_widget
         )
       end


### PR DESCRIPTION
By adding a simple notice it should be clarified that the product description
is english and is expected to be so.