### PR TITLE
Added migration warnings when not installed but registered (Fate#320534).

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,17 @@
 -------------------------------------------------------------------
+Mon Apr 10 07:38:45 WEST 2017 - knut.anderssen@suse.com
+
+- Online Migration (fate#320534)
+  - Added step for check registered but not installed addons to the
+    migration workflow. In case of existence, allow the user to
+    install the release package or deactivate the products.
+  - In case of abort, only registered products are downgraded and
+    synced.
+  - Added to the migration summary information about products not
+    offering migrations (third party addons).
+- 3.1.129.18
+
+-------------------------------------------------------------------
 Tue Jan  5 12:02:31 UTC 2016 - ancor@suse.com
 
 - Another fix (wrong backport) in the user messages when

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.129.17
+Version:        3.1.129.18
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -43,6 +43,11 @@ module Registration
         end
       end
 
+      def reset!
+        @cached_addons = nil
+        @registered    = nil
+      end
+
       def registered
         @registered ||= []
       end

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -102,7 +102,8 @@ module Registration
       :name,
       :product_type,
       :release_type,
-      :version
+      :version,
+      :repositories
 
     def initialize(pure_addon)
       @pure_addon = pure_addon

--- a/src/lib/registration/registration_ui.rb
+++ b/src/lib/registration/registration_ui.rb
@@ -287,6 +287,27 @@ module Registration
       options.install_updates
     end
 
+    # Ask the user if wants to also rollback the registered but not
+    # installed addons, in case of accept, it returns the addons list.
+    #
+    # @return [Array<OpenStruct>] registered but not installed addons if
+    #   accept or an empty array if not.
+    def registered_addons_to_rollback
+      get_available_addons
+
+      addon_names = Addon.registered_not_installed.map(&:friendly_name)
+
+      return [] if addon_names.empty?
+
+      msg = _("The addons listed below are registered but not installed: \n\n%s\n\n" \
+              "Would you like to rollback also them? If not, they will be deactivated. ")
+      if Yast::Popup.YesNo(msg % addon_names.join("\n"))
+        Addon.registered_not_installed
+      else
+        []
+      end
+    end
+
     private
 
     attr_accessor :registration

--- a/src/lib/registration/registration_ui.rb
+++ b/src/lib/registration/registration_ui.rb
@@ -305,7 +305,7 @@ module Registration
 
       return [] if addons.empty?
 
-      addon_names = addons.map {|a| a["display_name"] }
+      addon_names = addons.map { |a| a["display_name"] }
 
       msg = _("The addons listed below are registered but not installed: \n\n%s\n\n" \
               "Would you like to downgrade also them in the registration server? \n" \

--- a/src/lib/registration/registration_ui.rb
+++ b/src/lib/registration/registration_ui.rb
@@ -295,14 +295,23 @@ module Registration
     def registered_addons_to_rollback
       get_available_addons
 
-      addon_names = Addon.registered_not_installed.map(&:friendly_name)
+      addons =
+        Addon.registered_not_installed.map do |addon|
+          ret = addon.to_h
+          ret["display_name"]    = addon.friendly_name
+          ret["version_version"] = addon.version
+          ret
+        end
 
-      return [] if addon_names.empty?
+      return [] if addons.empty?
+
+      addon_names = addons.map {|a| a["display_name"] }
 
       msg = _("The addons listed below are registered but not installed: \n\n%s\n\n" \
-              "Would you like to rollback also them? If not, they will be deactivated. ")
+              "Would you like to downgrade also them in the registration server? \n" \
+              "If not they will be deactivated. ")
       if Yast::Popup.YesNo(msg % addon_names.join("\n"))
-        Addon.registered_not_installed
+        addons
       else
         []
       end

--- a/src/lib/registration/registration_ui.rb
+++ b/src/lib/registration/registration_ui.rb
@@ -307,14 +307,15 @@ module Registration
 
       addon_names = addons.map { |a| a["display_name"] }
 
+      # TRANSLATORS: Popup question, add registered but not installed addons to
+      # the list of products that will be downgraded.
+      # %s are all the product names splited by '\n' e.g
+      # "SUSE Linux Enterprise Server 12\nSUSE Enterprise Storage 1 x86_64"
       msg = _("The addons listed below are registered but not installed: \n\n%s\n\n" \
               "Would you like to downgrade also them in the registration server? \n" \
-              "If not they will be deactivated. ")
-      if Yast::Popup.YesNo(msg % addon_names.join("\n"))
-        addons
-      else
-        []
-      end
+              "If not they will be deactivated. ") % addon_names.join("\n")
+
+      Yast::Popup.YesNo(msg) ? addons : []
     end
 
     private

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -169,6 +169,20 @@ module Registration
       products
     end
 
+    def self.installed_products_not_registered(addons)
+      addons.each do |addon|
+        log.info "Found remote addon: #{addon.identifier}-#{addon.version}-#{addon.arch}"
+      end
+
+      installed_products.select do |product|
+        (product["type"] != "base") && addons.find do |addon|
+          product["name"] == addon.identifier &&
+            product["version_version"] == addon.version &&
+            product["arch"] == addon.arch
+        end
+      end
+    end
+
     # convert a libzypp Product Hash to a SUSE::Connect::Remote::Product object
     # @param product [Hash] product Hash obtained from pkg-bindings
     # @return [SUSE::Connect::Remote::Product] the remote product

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -169,20 +169,6 @@ module Registration
       products
     end
 
-    def self.installed_products_not_registered(addons)
-      addons.each do |addon|
-        log.info "Found remote addon: #{addon.identifier}-#{addon.version}-#{addon.arch}"
-      end
-
-      installed_products.select do |product|
-        (product["type"] != "base") && addons.find do |addon|
-          product["name"] == addon.identifier &&
-            product["version_version"] == addon.version &&
-            product["arch"] == addon.arch
-        end
-      end
-    end
-
     # convert a libzypp Product Hash to a SUSE::Connect::Remote::Product object
     # @param product [Hash] product Hash obtained from pkg-bindings
     # @return [SUSE::Connect::Remote::Product] the remote product

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -224,14 +224,14 @@ module Registration
         # TRANSLATORS: Popup question, merge this addon that are registered but not
         # installed to the current migration products list.
         # %s is an addon friendly name, e.g 'SUSE Enterprise Storage 2 x86_64'
-        msg = "The '%s' extension is registered but not installed.\n" \
+        msg = _("The '%s' extension is registered but not installed.\n" \
               "If you accept it will be added for be installed, in other case " \
               "it will be unregistered at the end of the migration.\n\n" \
-              "Do you want to add it?"
+              "Do you want to add it?")
 
         addons =
           Addon.registered_not_installed.each_with_object([]) do |addon, result|
-            if Yast::Popup.YesNoHeadline(addon.friendly_name, _(msg % addon.friendly_name))
+            if Yast::Popup.YesNoHeadline(addon.friendly_name, (msg % addon.friendly_name))
               result << SwMgmt.remote_product(addon.to_h)
             end
           end

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -221,6 +221,9 @@ module Registration
         # load the extensions to merge the registered but not installed extensions
         Addon.find_all(registration)
 
+        # TRANSLATORS: Popup question, merge this addon that are registered but not
+        # installed to the current migration products list.
+        # %s is an addon friendly name, e.g 'SUSE Enterprise Storage 2 x86_64'
         msg = "The '%s' extension is registered but not installed.\n" \
               "If you accept it will be added for be installed, in other case " \
               "it will be unregistered at the end of the migration.\n\n" \

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -214,14 +214,17 @@ module Registration
         :next
       end
 
+      # ask the user about adding not installed addons to the current products
+      #
+      # @return [Array<Hash>] installed products and addons selected to be installed
       def merge_registered_addons
         # load the extensions to merge the registered but not installed extensions
         Addon.find_all(registration)
 
         msg = "The '%s' extension is registered but not installed.\n" \
-              "If you accept it will be added for be upgraded, in other case " \
-              "it will be unregistered after the migration.\n\n" \
-              "Do you want to upgrade it?"
+              "If you accept it will be added for be installed, in other case " \
+              "it will be unregistered at the end of the migration.\n\n" \
+              "Do you want to add it?"
 
         addons =
           Addon.registered_not_installed.each_with_object([]) do |addon, result|

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -211,7 +211,7 @@ module Registration
           # TRANSLATORS: Summary message in rich text format
           # %s is a product name, e.g. "SUSE Linux Enterprise Server 12 SP1 x86_64"
           return _("The registration server does not offer migrations for Product " \
-                   "<b>%s</b> so it will <b>stay unchanged</b> . We recommend you " \
+                   "<b>%s</b> so it will <b>stay unchanged</b>. We recommend you " \
                    "to check if it's correct and to configure the repositories " \
                    "manually in case of needed.") % product_name
 

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -78,7 +78,7 @@ module Registration
         handle_user_input
       end
 
-      private
+    private
 
       attr_accessor :migrations
 
@@ -179,12 +179,22 @@ module Registration
       # @param [Integer] idx migration index
       # @return [String] user friendly description (in RichText format)
       def migration_details(idx)
+        products_to_migrate = []
+
         details = sorted_migrations[idx].map do |product|
           installed = installed_products.find do |installed_product|
             installed_product["name"] == product.identifier
           end
 
+          products_to_migrate << installed if installed
+
           "<li>" + product_summary(product, installed) + "</li>"
+        end
+
+        installed_products.each do |installed_product|
+          next if products_to_migrate.include?(installed_product)
+
+          details << "<li>" + product_summary(nil, installed_product) + "</li>"
         end
 
         # TRANSLATORS: RichText header (details for the selected item)
@@ -194,8 +204,16 @@ module Registration
       # create a product summary for the details widget
       # @return [String] product summary
       def product_summary(product, installed_product)
-        product_name = CGI.escapeHTML(product.friendly_name)
         log.info "creating summary for #{product} and #{installed_product}"
+
+        if !product
+          product_name = CGI.escapeHTML(SwMgmt.product_label(installed_product))
+          return _("The registration server does not offer migrations for Product " \
+                   "<b>%s</b>. <b> The product stays unchanged.</b>") % product_name
+
+        end
+
+        product_name = CGI.escapeHTML(product.friendly_name)
 
         # explicitly check for false, the flag is not returned by SCC, this is
         # a SMT specific check (in SCC all products are implicitly available)

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -209,7 +209,9 @@ module Registration
         if !product
           product_name = CGI.escapeHTML(SwMgmt.product_label(installed_product))
           return _("The registration server does not offer migrations for Product " \
-                   "<b>%s</b>. <b> The product stays unchanged.</b>") % product_name
+                   "<b>%s</b> so it will <b>stay unchanged</b> . We recommend you " \
+                   "to check if it's correct and to configure the repositories " \
+                   "manually in case of needed.") % product_name
 
         end
 

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -208,6 +208,8 @@ module Registration
 
         if !product
           product_name = CGI.escapeHTML(SwMgmt.product_label(installed_product))
+          # TRANSLATORS: Summary message in rich text format
+          # %s is a product name, e.g. "SUSE Linux Enterprise Server 12 SP1 x86_64"
           return _("The registration server does not offer migrations for Product " \
                    "<b>%s</b> so it will <b>stay unchanged</b> . We recommend you " \
                    "to check if it's correct and to configure the repositories " \

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -78,7 +78,7 @@ module Registration
         handle_user_input
       end
 
-    private
+      private
 
       attr_accessor :migrations
 

--- a/src/lib/registration/ui/not_installed_products_dialog.rb
+++ b/src/lib/registration/ui/not_installed_products_dialog.rb
@@ -1,0 +1,163 @@
+# encoding: utf-8
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
+#
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "registration/sw_mgmt"
+require "registration/helpers"
+
+module Registration
+  module UI
+    # this class displays and runs the dialog which check all the installed
+    # but not registered products warning the user about it and allowing him
+    # to take some actions over them.
+    class NotInstalledProductsDialog
+      include Yast::Logger
+      include Yast::I18n
+      include Yast::UIShortcuts
+      include Yast
+
+      attr_accessor :registration, :registration_ui
+
+      def self.run
+        dialog = NotInstalledProductsDialog.new
+        dialog.run
+      end
+
+      def initialize
+        textdomain "registration"
+
+        self.registration = Registration.new(UrlHelpers.registration_url)
+        self.registration_ui = RegistrationUI.new(registration)
+      end
+
+      def run
+        Yast::Popup.Feedback(RegistrationUI::CONTACTING_MESSAGE, _("Checking product conflicts")) do
+          return :next if !registered_not_installed_addons?
+        end
+
+        Yast::UI.OpenDialog(Opt(:decorated), content)
+
+        begin
+          handle_dialog
+        ensure
+          Yast::UI.CloseDialog
+        end
+      end
+
+    private
+
+      def content
+        VBox(
+          MinWidth(80,
+            MinHeight(15,
+              VWeight(25, RichText(Id(:summary), not_installed_addons_summary))
+            )
+          ),
+          ButtonBox(
+            PushButton(Id(:cancel), Opt(:key_F9, :cancelButton), Yast::Label.AbortButton),
+            # FIXME: Maybe we could remove this option and just warn the user
+            PushButton(Id(:install), _("Ins&tall Release Package")),
+            PushButton(Id(:sync), _("&Synchronize")),
+            PushButton(Id(:next), Opt(:okButton, :key_F10, :default), _("Continue"))
+          )
+        )
+      end
+
+      def handle_dialog
+        loop do
+          Yast::UI.SetFocus(:next)
+          ui = Yast::UI.UserInput
+          log.info "User input: #{ui}"
+          case ui
+          when :install
+            not_installed = []
+            Addon.registered_not_installed.map do |addon|
+              begin
+                Yast::Popup.Feedback(RegistrationUI::CONTACTING_MESSAGE,
+                  _("Installing %s release package") % addon.identifier) do
+
+                  Yast::Pkg.ResolvableInstall(addon.identifier, :product)
+                  Yast::Pkg.PkgSolve(true)
+                  Yast::Pkg.PkgCommit(0)
+                end
+              rescue
+                not_installed << addon.identifier
+              end
+            end
+            Yast::Popup.Error(_("These addons were not installed:\n\n%s") %
+                              not_installed.join("\n")) unless not_installed.empty?
+            update_summary
+          when :sync
+            registration_ui.synchronize_products(SwMgmt.installed_products)
+            update_summary
+            return :next if !registered_not_installed_addons?
+          when :next, :cancel
+            return ui
+          end
+        end
+      end
+
+    private
+
+      # RichText summary of the installed but not registered products.
+      #
+      # @return [String]
+      def not_installed_addons_summary
+        # TRANSLATORS: A RichText warning about all the products registered but
+        #   not installed. (1/2)
+        summary = _("<p>The addons listed below are registered but not installed: </p>")
+
+        summary << "<ul>#{not_installed_addon_names.map { |a| "<li>#{a}</li>" }.join("")}</ul>"
+
+        # TRANSLATORS: A RichText warning about all the products registered but
+        #   not installed. (2/2)
+        summary << _("<p><b>Synchronize</b> your products if you want to <b>deactive</b> " \
+                     "them at your registration server.</p>")
+
+        summary
+      end
+
+      # It updates the summary of registered but not installed products
+      # updating also Addon cache.
+      def update_summary
+        log.info "Updating summary"
+        Yast::Popup.Feedback(RegistrationUI::CONTACTING_MESSAGE, _("Updating summary")) do
+          Addon.reset!
+          Addon.find_all(registration)
+        end
+
+        Yast::UI.ChangeWidget(Id(:summary), :Value, not_installed_addons_summary)
+      end
+
+      # @return [Boolean] true if in the registration server exists some
+      # registered but not installed addon; false otherwise
+      def registered_not_installed_addons?
+        !Addon.registered_not_installed.empty?
+      end
+
+      # @return [Array<String>] return an array with all the registered but not
+      #   installed addon names.
+      def not_installed_addon_names
+        Addon.registered_not_installed.map(&:name)
+      end
+    end
+  end
+end

--- a/src/lib/registration/ui/not_installed_products_dialog.rb
+++ b/src/lib/registration/ui/not_installed_products_dialog.rb
@@ -74,7 +74,7 @@ module Registration
           ButtonBox(
             PushButton(Id(:cancel), Opt(:key_F9, :cancelButton), Yast::Label.AbortButton),
             # FIXME: Maybe we could remove this option and just warn the user
-            PushButton(Id(:install), _("Ins&tall Release Package")),
+            PushButton(Id(:install), _("Ins&tall addons")),
             PushButton(Id(:sync), _("&Synchronize")),
             PushButton(Id(:next), Opt(:okButton, :key_F10, :default), _("Continue"))
           )
@@ -129,7 +129,7 @@ module Registration
 
         # TRANSLATORS: A RichText warning about all the products registered but
         #   not installed. (2/2)
-        summary << _("<p><b>Synchronize</b> your products if you want to <b>deactive</b> " \
+        summary << _("<p><b>Synchronize</b> your products if you want to <b>deactivate</b> " \
                      "them at your registration server.</p>")
 
         summary

--- a/src/lib/registration/ui/not_installed_products_dialog.rb
+++ b/src/lib/registration/ui/not_installed_products_dialog.rb
@@ -41,6 +41,8 @@ module Registration
       Yast.import "Packages"
       Yast.import "PackagesUI"
 
+      REGISTRATION_CHECK_MSG = N_("Checking registration status")
+
       attr_accessor :registration, :registration_ui
 
       def self.run
@@ -56,7 +58,7 @@ module Registration
       end
 
       def run
-        Yast::Popup.Feedback(RegistrationUI::CONTACTING_MESSAGE, _("Checking product conflicts")) do
+        Yast::Popup.Feedback(RegistrationUI::CONTACTING_MESSAGE, REGISTRATION_CHECK_MSG) do
           return :next if !registered_not_installed_addons?
         end
 
@@ -81,7 +83,7 @@ module Registration
           ButtonBox(
             PushButton(Id(:cancel), Opt(:key_F9, :cancelButton), Yast::Label.AbortButton),
             # FIXME: Maybe we could remove this option and just warn the user
-            PushButton(Id(:install), _("Ins&tall addons")),
+            PushButton(Id(:install), _("Ins&tall products")),
             PushButton(Id(:sync), _("&Deactivate")),
             PushButton(Id(:next), Opt(:okButton, :key_F10, :default), _("Continue"))
           )
@@ -158,8 +160,8 @@ module Registration
 
         # TRANSLATORS: A RichText warning about all the products registered but
         #   not installed. (2/2)
-        summary << _("<p><b>Synchronize</b> your products if you want to <b>deactivate</b> " \
-                     "them at your registration server.</p>")
+        summary << _("<p>It's preferable to <b>deactivate</b> your products at your " \
+                     "registration server if you don't plan to use them anymore.</p>")
 
         summary
       end
@@ -168,7 +170,7 @@ module Registration
       # updating also Addon cache.
       def update_summary
         log.info "Updating summary"
-        Yast::Popup.Feedback(RegistrationUI::CONTACTING_MESSAGE, _("Updating summary")) do
+        Yast::Popup.Feedback(RegistrationUI::CONTACTING_MESSAGE, REGISTRATION_CHECK_MSG) do
           Addon.reset!
           Addon.find_all(registration)
         end

--- a/src/lib/registration/ui/not_installed_products_dialog.rb
+++ b/src/lib/registration/ui/not_installed_products_dialog.rb
@@ -62,7 +62,7 @@ module Registration
         end
       end
 
-    private
+      private
 
       def content
         VBox(
@@ -114,8 +114,6 @@ module Registration
           end
         end
       end
-
-    private
 
       # RichText summary of the installed but not registered products.
       #

--- a/src/lib/registration/ui/not_installed_products_dialog.rb
+++ b/src/lib/registration/ui/not_installed_products_dialog.rb
@@ -32,6 +32,7 @@ module Registration
     class NotInstalledProductsDialog
       include Yast::Logger
       include Yast::I18n
+      extend Yast::I18n
       include Yast::UIShortcuts
       include Yast
 
@@ -134,8 +135,6 @@ module Registration
               # Yast::PackagesUI.show_update_messages(result)
               next
             end
-            #
-            next if result && result[1].empty?
           end
 
           log.error("Product #{addon.identifier} could not be installed")

--- a/src/lib/registration/ui/not_installed_products_dialog.rb
+++ b/src/lib/registration/ui/not_installed_products_dialog.rb
@@ -58,7 +58,7 @@ module Registration
       end
 
       def run
-        Yast::Popup.Feedback(RegistrationUI::CONTACTING_MESSAGE, REGISTRATION_CHECK_MSG) do
+        Yast::Popup.Feedback(RegistrationUI::CONTACTING_MESSAGE, _(REGISTRATION_CHECK_MSG)) do
           return :next if !registered_not_installed_addons?
         end
 
@@ -170,7 +170,7 @@ module Registration
       # updating also Addon cache.
       def update_summary
         log.info "Updating summary"
-        Yast::Popup.Feedback(RegistrationUI::CONTACTING_MESSAGE, REGISTRATION_CHECK_MSG) do
+        Yast::Popup.Feedback(RegistrationUI::CONTACTING_MESSAGE, _(REGISTRATION_CHECK_MSG)) do
           Addon.reset!
           Addon.find_all(registration)
         end

--- a/src/lib/registration/ui/registration_sync_workflow.rb
+++ b/src/lib/registration/ui/registration_sync_workflow.rb
@@ -35,7 +35,7 @@ module Registration
       def initialize
         textdomain "registration"
 
-        registration = Registration.new(UrlHelpers.registration_url)
+        self.registration = Registration.new(UrlHelpers.registration_url)
         self.registration_ui = RegistrationUI.new(registration)
       end
 
@@ -46,24 +46,32 @@ module Registration
 
         restore_repos
 
-        # load the installed products
+        # load the installed products that are activated
         Yast::Pkg.TargetLoad
-        products = SwMgmt.installed_products
+        activated = registration.activated_products.map(&:identifier)
+        products =
+          SwMgmt.installed_products.each_with_object([]) do |product, result|
+            result << product if activated.include?(product["name"])
+          end
+
+        # Ask the user about adding all the registered but not installed addons
+        # to the rollback
+        products.concat(registration_ui.registered_addons_to_rollback)
 
         # downgrade all installed products
         return :abort unless downgrade_products(products)
 
         reload_repos
 
-        # synchronize all installed products (remove additional registrations at the server)
+        # synchronize the products (remove additional registrations at the server)
         registration_ui.synchronize_products(products) ? :next : :abort
       end
 
       private
 
-      attr_accessor :registration_ui
+      attr_accessor :registration_ui, :registration
 
-      # restore the repositpories from the backup archive
+      # restore the repositories from the backup archive
       def restore_repos
         # finish the sources and the target to reload the repositories from the backup
         Yast::Pkg.SourceFinishAll

--- a/src/lib/registration/ui/registration_sync_workflow.rb
+++ b/src/lib/registration/ui/registration_sync_workflow.rb
@@ -56,7 +56,10 @@ module Registration
 
         # Ask the user about adding all the registered but not installed addons
         # to the rollback
-        products.concat(registration_ui.registered_addons_to_rollback)
+        addons = registration_ui.registered_addons_to_rollback
+        log.info "Addons registered but not installed: #{addons}"
+
+        products.concat(addons)
 
         # downgrade all installed products
         return :abort unless downgrade_products(products)

--- a/test/addon_spec.rb
+++ b/test/addon_spec.rb
@@ -92,6 +92,27 @@ describe Registration::Addon do
     end
   end
 
+  describe ".registered_not_installed" do
+    it "returns an array of already registered addons but not installed" do
+      prod1 = addon_generator("name" => "prod1")
+      prod2 = addon_generator("name" => "prod2")
+      registration = double(
+        activated_products: [prod2],
+        get_addon_list:     [prod1, prod2]
+      )
+
+      addons = Registration::Addon.find_all(registration)
+
+      addon2 = addons.find { |addon| addon.name == "prod2" }
+
+      expect(Registration::SwMgmt).to receive(:installed_products).and_return([])
+      reg_not_installed_addons = Registration::Addon.registered_not_installed
+
+      expect(reg_not_installed_addons.size).to eql(1)
+      expect(reg_not_installed_addons.first.name).to eql(addon2.name)
+    end
+  end
+
   describe "#unregistered" do
     it "marks addon as unregistered" do
       Registration::Addon.registered << addon

--- a/test/registration_sync_workflow_spec.rb
+++ b/test/registration_sync_workflow_spec.rb
@@ -4,10 +4,14 @@ require_relative "spec_helper"
 
 describe Registration::UI::RegistrationSyncWorkflow do
   describe "#run_sequence" do
-    let(:registration_ui) { Registration::RegistrationUI.new(nil) }
+    let(:registration) { Registration::Registration.new }
+    let(:registration_ui) { Registration::RegistrationUI.new(registration) }
     let(:products) { load_yaml_fixture("products_legacy_installation.yml") }
+    let(:activated_products) { load_yaml_fixture("activated_products.yml") }
     let(:sles) { products[1] }
     let(:legacy) { products[0] }
+    let(:activated_sles) { activated_products[2] }
+    let(:activated_legacy) { activated_products[2][:extensions][2] }
 
     before do
       allow(Yast::Pkg).to receive(:SourceFinishAll)
@@ -19,6 +23,7 @@ describe Registration::UI::RegistrationSyncWorkflow do
       allow(Registration::UrlHelpers).to receive(:registration_url)
       allow(Registration::SwMgmt).to receive(:get_release_type)
       allow(subject).to receive(:registration_ui).and_return(registration_ui)
+      allow(subject).to receive(:registration).and_return(registration)
       allow(Registration::Releasever).to receive(:set?).and_return(false)
       allow(Registration::SwMgmt).to receive(:installed_products).and_return([])
     end
@@ -26,7 +31,9 @@ describe Registration::UI::RegistrationSyncWorkflow do
     it "restores repositories, downgrades registration and synchronizes the products" do
       expect(Yast::Update).to receive(:restore_backup)
       expect(Registration::SwMgmt).to receive(:installed_products).and_return([sles])
+      expect(registration).to receive(:activated_products).and_return([activated_sles])
 
+      expect(registration_ui).to receive(:registered_addons_to_rollback).and_return([])
       expect(registration_ui).to receive(:downgrade_product)
         .with(sles).and_return([true, nil])
       expect(registration_ui).to receive(:synchronize_products)
@@ -38,7 +45,10 @@ describe Registration::UI::RegistrationSyncWorkflow do
     it "downgrades the base product first" do
       installed_products = [legacy, sles]
       expect(Registration::SwMgmt).to receive(:installed_products).and_return(installed_products)
+      expect(registration).to receive(:activated_products)
+        .and_return([activated_legacy, activated_sles])
 
+      expect(registration_ui).to receive(:registered_addons_to_rollback).and_return([])
       # set the expected downgrade order
       expect(registration_ui).to receive(:downgrade_product)
         .with(sles).ordered.and_return([true, nil])
@@ -52,8 +62,10 @@ describe Registration::UI::RegistrationSyncWorkflow do
 
     it "resets the $releasever if it has been set" do
       allow(registration_ui).to receive(:synchronize_products).and_return(true)
+      expect(registration).to receive(:activated_products).and_return([activated_sles])
       expect(Registration::Releasever).to receive(:set?).and_return(true)
 
+      expect(registration_ui).to receive(:registered_addons_to_rollback).and_return([])
       releasever = Registration::Releasever.new(nil)
       expect(Registration::Releasever).to receive(:new).with(nil).and_return(releasever)
       expect(releasever).to receive(:activate)

--- a/test/registration_ui_test.rb
+++ b/test/registration_ui_test.rb
@@ -75,6 +75,18 @@ describe "Registration::RegistrationUI" do
 
       expect(registration_ui.update_system).to be_true
     end
+
+    it "resets registration credentials and registration url in case of failure" do
+      cache = Registration::Storage::Cache.instance
+      expect(Registration::ConnectHelpers).to receive(:catch_registration_errors)
+        .and_return(false)
+
+      expect(Registration::Helpers).to receive(:reset_registration_status)
+      expect(Registration::UrlHelpers).to receive(:reset_registration_url)
+      expect(cache).to receive(:upgrade_failed=).with(true)
+
+      expect(registration_ui.update_system).to eql false
+    end
   end
 
   describe "#update_base_product" do
@@ -87,6 +99,15 @@ describe "Registration::RegistrationUI" do
         .and_return(remote_product)
 
       expect(registration_ui.update_base_product).to eql([true, remote_product])
+    end
+
+    it "resets registration credentials in case of failure" do
+      expect(Registration::ConnectHelpers).to receive(:catch_registration_errors)
+        .and_return(false)
+
+      expect(Registration::Helpers).to receive(:reset_registration_status)
+
+      expect(registration_ui.update_base_product).to eql([false, nil])
     end
   end
 
@@ -185,6 +206,39 @@ describe "Registration::RegistrationUI" do
       products = [installed_sles]
       expect(registration).to receive(:synchronize_products).with(products)
       expect(registration_ui.synchronize_products(products)).to eq(true)
+    end
+  end
+
+  describe "registered_addons_to_rollback" do
+    let(:not_installed_addon) { addon_generator }
+
+    before do
+      allow(Yast::Popup).to receive(:YesNo).and_return(true)
+      allow(registration_ui).to receive(:get_available_addons)
+    end
+
+    it "returns an empty array in case of not 'registered but not installed' addons" do
+      expect(Registration::Addon).to receive(:registered_not_installed).and_return([])
+
+      expect(registration_ui.registered_addons_to_rollback).to eql([])
+    end
+
+    it "returns an empty array if the user doesn't want to rollback the obtained addons" do
+      expect(Registration::Addon).to receive(:registered_not_installed)
+        .and_return([not_installed_addon])
+      expect(Yast::Popup).to receive(:YesNo).and_return(false)
+
+      expect(registration_ui.registered_addons_to_rollback).to eql([])
+    end
+
+    it "returns an array with all the registered but not installed addons if user accepts" do
+      expect(Registration::Addon).to receive(:registered_not_installed)
+        .and_return([not_installed_addon])
+
+      addons = registration_ui.registered_addons_to_rollback
+
+      expect(addons.size).to eql(1)
+      expect(addons.first["display_name"]).to eql(not_installed_addon.friendly_name)
     end
   end
 end


### PR DESCRIPTION
Trello Card: https://trello.com/c/CyjL1Was

Workflow added:

1. **Start YaST Migration**
2. **Check registered products not installed (continue in case of empty)**
    - The user is able to try to install the **release package** if available.
    - The user is able to synchronize the products deactivating the ones not installed from SCC.
    - Just continue to the migration selection summary.
3. **Find installed products and migrations for them**
    - if not solved inconsistencies we ask the user about the not installed addons allowing him to add them to the current migration (one per one).
    - Show the summary of the available migrations.
    - In case of a third party add-on (not migrations available) we recommend to use manual repository edition.
4. **Continue to the migration proposal**
    - In case of **abort**, the user is asked again about adding all the registered but not installed products to the downgrade and synchronization (not removing the products if accepted)
    - Only the already activated products are downgraded and synchronized (fixing a bug with third party addons).

### New warning dialog (not installed but registered products)

Basically it let you install the release package of the removed product if still present (it is what zypper migration do) or synchronize your current installed products (deactivating the ones not installed but registered).

**animated gif**
![screencast_install_packages](https://cloud.githubusercontent.com/assets/7056681/24539877/8b789a70-15e8-11e7-934d-e78fc4f27bcd.gif)

**screenshot**
![screenshot from 2017-03-30 21-25-13](https://cloud.githubusercontent.com/assets/7056681/24539711/b284bb54-15e7-11e7-8082-3e81c74b5ea7.png)

**Continue without sync or install**
![continue](https://cloud.githubusercontent.com/assets/7056681/24542407/6a0fbd0e-15f3-11e7-8792-cb651a54d7e3.gif)

**Migration selection summary**
![screenshot from 2017-03-31 09-44-12](https://cloud.githubusercontent.com/assets/7056681/24543235/c254455e-15f6-11e7-9d35-a2aff841a6b7.png)

### Abort migration (only already activated products)

![screenshot_sles12_2017-03-23_10 55 01](https://cloud.githubusercontent.com/assets/7056681/24496308/ce61686c-152f-11e7-89ca-99aa1e2dcf78.png)

Previously it always failed in case of third party addons because SCC hasn't got a vision about them. If we only downgrade and synchronize the already activated addons then there is no problem. We also ask about registered but not installed products to be added to the downgrade and synchronization not deactivating them in case of confirm.

**screenshot**
![screenshot from 2017-03-30 23-51-38](https://cloud.githubusercontent.com/assets/7056681/24542641/4a41e83e-15f4-11e7-9b05-849321da486b.png)

