### PR TITLE
Copy certificate to /etc/pki/trust/anchors instead of

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 28 11:11:22 CEST 2017 - schubi@suse.de
+
+- AY inst-sys: Copy certificate to /etc/pki/trust/anchors instead of
+  /usr/share/pki/trust/anchors wich is read only (bnc#103466).
+- 3.1.193
+
+-------------------------------------------------------------------
 Mon Apr 10 07:38:45 WEST 2017 - knut.anderssen@suse.com
 
 - Online Migration (fate#320534)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.1.192
+Version:        3.1.193
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/scc_auto.rb
+++ b/src/clients/scc_auto.rb
@@ -252,7 +252,7 @@ module Yast
       end
 
       Popup.Feedback(_("Importing SSL Certificate"), cert.subject_name) do
-        cert.import_to_system
+        cert.import
       end
     end
 


### PR DESCRIPTION
+  /usr/share/pki/trust/anchors

scc_auto:Write will be called quite after the scc_auto:Import function in inst_autosetup. 
So there is no installed system available at that point.