### PR TITLE
Don't crash in case of an invalid linuxrc registration url is provided (bsc#1035908)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+
+Mon May  8 13:27:09 UTC 2017 - knut.anderssen@suse.com
+
+- Don't crash if the regurl provided by linuxrc is invalid using
+  the one provided by the control file as fallback (bsc#1035908).
+- 3.2.10
+
+-------------------------------------------------------------------
 Fri Apr 28 11:11:22 CEST 2017 - schubi@suse.de
 
 - AY inst-sys: Copy certificate to /etc/pki/trust/anchors instead of
@@ -30,7 +38,6 @@ Mon Apr 10 07:38:45 WEST 2017 - knut.anderssen@suse.com
 - 3.2.7
 
 -------------------------------------------------------------------
-
 Mon Mar 20 12:28:45 UTC 2017 - okurz@suse.com
 
 - Be explicit about 'Details' box not being localized (bsc#1025846)

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -2,7 +2,7 @@
 
 Mon May  8 13:27:09 UTC 2017 - knut.anderssen@suse.com
 
-- Don't crash if the regurl provided by linuxrc is invalid using
+- Don't crash if the regurl provided by linuxrc is invalid, use
   the one provided by the control file as fallback (bsc#1035908).
 - 3.2.10
 

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.2.9
+Version:        3.2.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/exceptions.rb
+++ b/src/lib/registration/exceptions.rb
@@ -41,7 +41,4 @@ module Registration
   # generic download error
   class DownloadError < RuntimeError
   end
-
-  class InvalidURL < StandardError
-  end
 end

--- a/src/lib/registration/exceptions.rb
+++ b/src/lib/registration/exceptions.rb
@@ -41,4 +41,7 @@ module Registration
   # generic download error
   class DownloadError < RuntimeError
   end
+
+  class InvalidURL < StandardError
+  end
 end

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -218,30 +218,30 @@ module Registration
       # Default registration server
       #
       # The boot_url takes precedence over the SUSE::Connect default
-      # one.
+      # one. It shows a message if the boot_url is not valid.
       #
       # @return [String] URL for the registration server
       def default_url
-        @default_url ||= boot_url || SUSE::Connect::Config.new.url
+        return @default_url if @default_url
+
+        if boot_url
+          return (@default_url = boot_url) if valid_custom_url?(boot_url)
+
+          Yast::Report.Error(
+            # TRANSLATORS: Wrong url for registration provided, %s is an URL.
+            _("The registration URL provided by the command line is not valid.\n\n" \
+              "URL: %s\n\nThe default one will be used instead.") % boot_url
+          )
+        end
+
+        @default_url = SUSE::Connect::Config.new.url
       end
 
       # Registration server URL given through Linuxrc
       #
       # @return [String,nil] URL for the registration server; nil if not given.
       def boot_url
-        return nil unless UrlHelpers.boot_reg_url
-
-        unless valid_custom_url?(UrlHelpers.boot_reg_url)
-          Yast::Report.Error(
-            # TRANSLATORS: Wrong url for registration provided, %s is an URL.
-            _("The registration URL provided by Linuxrc is not valid.\n\n" \
-              "URL: %s\n\nThe default one will be used.") % UrlHelpers.boot_reg_url
-          )
-
-          return nil
-        end
-
-        UrlHelpers.boot_reg_url
+        @boot_url ||= UrlHelpers.boot_reg_url
       end
 
       # Widgets for :register_scc action

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -229,7 +229,19 @@ module Registration
       #
       # @return [String,nil] URL for the registration server; nil if not given.
       def boot_url
-        @boot_url ||= UrlHelpers.boot_reg_url
+        return nil unless UrlHelpers.boot_reg_url
+
+        unless valid_custom_url?(UrlHelpers.boot_reg_url)
+          Yast::Report.Error(
+            # TRANSLATORS: Wrong url for registration provided, %s is an URL.
+            _("The registration URL provided by Linuxrc is not valid.\n\n" \
+              "URL: %s\n\nThe default one will be used.") % UrlHelpers.boot_reg_url
+          )
+
+          return nil
+        end
+
+        UrlHelpers.boot_reg_url
       end
 
       # Widgets for :register_scc action


### PR DESCRIPTION
This PR is related to yast/yast-installation#563

### Screenshot during manual installation

![screenshot_sled12sp3_2017-05-08_12 03 41](https://cloud.githubusercontent.com/assets/7056681/25806519/5df94a1e-33fb-11e7-83d0-59133ce1a0ac.png)

### AutoYast fail currently catch it as a connection error.

![screenshot_sle12sp3_2017-05-08_14 50 16](https://cloud.githubusercontent.com/assets/7056681/25812580/aa66d7dc-340e-11e7-9f9b-c03ffaa44fe0.png)