### PR TITLE
Translation fix (bsc#1038077)

### DIFF
--- a/test/connect_helpers_spec.rb
+++ b/test/connect_helpers_spec.rb
@@ -11,7 +11,7 @@ describe Registration::ConnectHelpers do
       details = _("Make sure that the registration server is reachable and\n" \
         "the connection is reliable.")
       expect(Yast::Report).to receive(:Error).with(
-        "Registration: #{_("Connection time out.")}\n\n\nDetails: #{details}"
+        "Registration: " + _("Connection time out.") + "\n\n\nDetails: #{details}"
       )
 
       helpers.catch_registration_errors(message_prefix: "Registration: ") do


### PR DESCRIPTION
Ruby gettext cannot extract translatable texts from interpolated strings.

- The fix is located in a test, the same string is correctly marked for translation in the real code at another place.
- This is only to avoid false positives later when grepping for translations in interpolations again.
- The version change is not required.

