### PR TITLE
bsc#1043033: the system should use existent SMT URL during upgrade

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun  9 09:52:43 UTC 2017 - gsouza@suse.com
+
+- A system registered in a local SMT server uses the same SMT
+  server URL to register during upgrade (bsc#1043033).
+- 3.2.11
+
+-------------------------------------------------------------------
 
 Mon May  8 13:27:09 UTC 2017 - knut.anderssen@suse.com
 

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.2.10
+Version:        3.2.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/url_helpers.rb
+++ b/src/lib/registration/url_helpers.rb
@@ -148,17 +148,22 @@ module Registration
       # (the config file exists even on a not registered system)
       dir = SUSE::Connect::YaST::DEFAULT_CREDENTIALS_DIR
       ncc_creds = File.join(Yast::Installation.destdir, dir, "NCCcredentials")
+      scc_creds = File.join(Yast::Installation.destdir, SUSE::Connect::Config::DEFAULT_CONFIG_FILE)
 
       # do not use the old URL when it has failed before
-      if !::Registration::Storage::Cache.instance.upgrade_failed && File.exist?(ncc_creds)
-        # FIXME: check at first new suseconnect conf
-        old_conf = SuseRegister.new(Yast::Installation.destdir)
-
-        if old_conf.found?
-          # use default if ncc was used in past
-          return nil if old_conf.ncc?
-          # if specific server is used, then also use it
-          return old_conf.stripped_url.to_s
+      if !::Registration::Storage::Cache.instance.upgrade_failed
+        if File.exist?(scc_creds)
+          config = SUSE::Connect::Config.new(scc_creds)
+          return config.url
+        end
+        if File.exist?(ncc_creds)
+          old_conf = SuseRegister.new(Yast::Installation.destdir)
+          if old_conf.found?
+            # use default if ncc was used in past
+            return nil if old_conf.ncc?
+            # if specific server is used, then also use it
+            return old_conf.stripped_url.to_s
+          end
         end
       end
 

--- a/test/fixtures/SUSEConnect
+++ b/test/fixtures/SUSEConnect
@@ -1,0 +1,1 @@
+url: https://myserver.com

--- a/test/url_helpers_spec.rb
+++ b/test/url_helpers_spec.rb
@@ -122,7 +122,7 @@ describe "Registration::UrlHelpers" do
 
     context "at upgrade" do
       let(:suse_register) { "/mnt/etc/suseRegister.conf" }
-      let(:suse_connect) {"/mnt/etc/SUSEConnect"}
+      let(:suse_connect) { "/mnt/etc/SUSEConnect" }
 
       before do
         allow(Yast::Mode).to receive(:mode).and_return("update")

--- a/test/url_helpers_spec.rb
+++ b/test/url_helpers_spec.rb
@@ -122,6 +122,7 @@ describe "Registration::UrlHelpers" do
 
     context "at upgrade" do
       let(:suse_register) { "/mnt/etc/suseRegister.conf" }
+      let(:suse_connect) {"/mnt/etc/SUSEConnect"}
 
       before do
         allow(Yast::Mode).to receive(:mode).and_return("update")
@@ -139,10 +140,12 @@ describe "Registration::UrlHelpers" do
         expect(Registration::UrlHelpers.registration_url).to eq(url)
       end
 
-      context "the system has been already registered" do
+      context "the system has been already registered with NCC" do
         before do
           allow(File).to receive(:exist?)
             .with("/mnt/etc/zypp/credentials.d/NCCcredentials").and_return(true)
+          allow(File).to receive(:exist?)
+            .with("/mnt/etc/SUSEConnect").and_return(false)
           expect(Yast::Linuxrc).to receive(:InstallInf).with("regurl").and_return(nil)
         end
 
@@ -153,12 +156,18 @@ describe "Registration::UrlHelpers" do
 
           expect(Registration::UrlHelpers.registration_url).to be_nil
         end
+      end
 
-        it "return URL of SMT server when used" do
-          expect(File).to receive(:exist?).with(suse_register).and_return(true)
-          expect(File).to receive(:readlines).with(suse_register)\
-            .and_return(File.readlines(fixtures_file("old_conf_custom/etc/suseRegister.conf")))
+      context " when the system has been already registered with SMT server" do
+        before do
+          allow(File).to receive(:exist?)
+            .with("/mnt/etc/SUSEConnect").and_return(true)
+        end
 
+        it "returns URL of SMT server" do
+          expect(File).to receive(:exist?).with(fixtures_file("SUSEConnect")).and_return(true)
+          expect(SUSE::Connect::Config).to receive(:new).with(suse_connect)
+            .and_return(SUSE::Connect::Config.new(fixtures_file("SUSEConnect")))
           expect(Registration::UrlHelpers.registration_url).to eq("https://myserver.com")
         end
 
@@ -171,6 +180,8 @@ describe "Registration::UrlHelpers" do
 
       context "the system has not been registered" do
         before do
+          allow(File).to receive(:exist?)
+            .with("/mnt/etc/SUSEConnect").and_return(false)
           expect(File).to receive(:exist?).with("/mnt/etc/zypp/credentials.d/NCCcredentials")
             .and_return(false)
           expect(Yast::Linuxrc).to receive(:InstallInf).with("regurl").and_return(nil)


### PR DESCRIPTION
When the system is already registered in a local SMT server, during the upgrade this system should be registered against this SMT server again.