### PR TITLE
Wrap connect helper errors text (bsc#1055643)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 30 14:20:46 UTC 2017 - knut.anderssen@suse.com
+
+- Wrap text of connection_helpers error messages (bsc#1055643)
+- 3.3.2
+
+-------------------------------------------------------------------
 Mon Jul 31 14:20:44 UTC 2017 - lslezak@suse.cz
 
 - LeanOS: Better handle multiple products on the installation

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.3.1
+Version:        3.3.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -26,8 +26,8 @@ Source0:        %{name}-%{version}.tar.bz2
 Group:          System/YaST
 License:        GPL-2.0
 
-# Popup.Feedback
-Requires:       yast2 >= 3.1.26
+## UI::TextHelpers wrap_text
+Requires:       yast2 >= 4.0.1
 # "dupAllowVendorChange" option in Pkg.SetSolverFlags()
 Requires:       yast2-pkg-bindings >= 3.1.34
 # N_() method
@@ -48,7 +48,7 @@ Requires:       yast2-add-on >= 3.1.8
 Requires:       yast2-packager >= 3.1.95
 Requires:       yast2-update >= 3.1.36
 
-BuildRequires:  yast2 >= 3.1.26
+BuildRequires:  yast2 >= 4.0.1
 BuildRequires:  update-desktop-files
 BuildRequires:  yast2-devtools >= 3.1.39
 BuildRequires:  rubygem(yast-rake) >= 0.2.5

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -175,7 +175,7 @@ module Registration
       return error if !details || details.empty?
 
       # %s are error details
-      error + "\n\n" + (_("Details: %s") % wrap_text(details))
+      error + "\n\n" + wrap_text(_("Details: %s") % details)
     end
 
     def self.ssl_error_details(cert)

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -175,7 +175,15 @@ module Registration
       return error if !details || details.empty?
 
       # %s are error details
-      error + "\n\n" + wrap_text(_("Details: %s") % details)
+      details_msg = _("Details: %s") % details
+      displayinfo = Yast::UI.GetDisplayInfo || {}
+
+      return (error + "\n\n" + details_msg) unless displayinfo["TextMode"]
+
+      # Use almost the max width available
+      max_size = (displayinfo["Width"] || 80) - 4
+
+      error + "\n\n" + wrap_text(details_msg, max_size)
     end
 
     def self.ssl_error_details(cert)

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -23,6 +23,7 @@
 
 require "yast"
 require "suse/connect"
+require "ui/text_helpers"
 
 require "registration/helpers"
 require "registration/exceptions"
@@ -37,6 +38,7 @@ module Registration
   # FIXME: change to a module and include it in the clients
   class ConnectHelpers
     include Yast::Logger
+    extend ::UI::TextHelpers
     extend Yast::I18n
 
     # openSSL error codes for which the import SSL certificate dialog is shown,
@@ -173,7 +175,7 @@ module Registration
       return error if !details || details.empty?
 
       # %s are error details
-      error + "\n\n" + (_("Details: %s") % details)
+      error + "\n\n" + (_("Details: %s") % wrap_text(details))
     end
 
     def self.ssl_error_details(cert)

--- a/test/connect_helpers_spec.rb
+++ b/test/connect_helpers_spec.rb
@@ -21,6 +21,11 @@ describe Registration::ConnectHelpers do
   describe "#catch_registration_errors" do
     before do
       allow(Yast::Report).to receive(:Error)
+      allow(Yast::UI).to receive(:GetDisplayInfo).and_return(
+        "TextMode" => true,
+        "Width"    => 80,
+        "Height"   => 25
+      )
     end
 
     it "returns true if not exception is raised" do
@@ -43,7 +48,7 @@ describe Registration::ConnectHelpers do
       details = _("Make sure that the registration server is reachable and\n" \
         "the connection is reliable.")
 
-      expect(subject).to receive(:wrap_text).with("Details: #{details}")
+      expect(subject).to receive(:wrap_text).with("Details: #{details}", 76)
         .and_return("Details wrapped text")
       expect(Yast::Report).to receive(:Error).with(
         "Registration: " + _("Connection time out.") + "\n\n\nDetails wrapped text"

--- a/test/connect_helpers_spec.rb
+++ b/test/connect_helpers_spec.rb
@@ -19,11 +19,13 @@ describe Registration::ConnectHelpers do
   subject(:helpers) { Registration::ConnectHelpers }
 
   describe "#catch_registration_errors" do
+    let(:screen_width) { 80 }
+
     before do
       allow(Yast::Report).to receive(:Error)
       allow(Yast::UI).to receive(:GetDisplayInfo).and_return(
         "TextMode" => true,
-        "Width"    => 80,
+        "Width"    => screen_width,
         "Height"   => 25
       )
     end
@@ -48,7 +50,7 @@ describe Registration::ConnectHelpers do
       details = _("Make sure that the registration server is reachable and\n" \
         "the connection is reliable.")
 
-      expect(subject).to receive(:wrap_text).with("Details: #{details}", 76)
+      expect(subject).to receive(:wrap_text).with("Details: #{details}", screen_width - 4)
         .and_return("Details wrapped text")
       expect(Yast::Report).to receive(:Error).with(
         "Registration: " + _("Connection time out.") + "\n\n\nDetails wrapped text"

--- a/test/connect_helpers_spec.rb
+++ b/test/connect_helpers_spec.rb
@@ -43,9 +43,10 @@ describe Registration::ConnectHelpers do
       details = _("Make sure that the registration server is reachable and\n" \
         "the connection is reliable.")
 
-      expect(subject).to receive(:wrap_text).with(details).and_return("wrapped text")
+      expect(subject).to receive(:wrap_text).with("Details: #{details}")
+        .and_return("Details wrapped text")
       expect(Yast::Report).to receive(:Error).with(
-        "Registration: " + _("Connection time out.") + "\n\n\nDetails: wrapped text"
+        "Registration: " + _("Connection time out.") + "\n\n\nDetails wrapped text"
       )
 
       helpers.catch_registration_errors(message_prefix: "Registration: ") do

--- a/test/connect_helpers_spec.rb
+++ b/test/connect_helpers_spec.rb
@@ -42,8 +42,10 @@ describe Registration::ConnectHelpers do
     it "reports an error with details on timeout" do
       details = _("Make sure that the registration server is reachable and\n" \
         "the connection is reliable.")
+
+      expect(subject).to receive(:wrap_text).with(details).and_return("wrapped text")
       expect(Yast::Report).to receive(:Error).with(
-        "Registration: " + _("Connection time out.") + "\n\n\nDetails: #{details}"
+        "Registration: " + _("Connection time out.") + "\n\n\nDetails: wrapped text"
       )
 
       helpers.catch_registration_errors(message_prefix: "Registration: ") do

--- a/test/registration_ui_test.rb
+++ b/test/registration_ui_test.rb
@@ -127,6 +127,7 @@ describe "Registration::RegistrationUI" do
       it "does not ask for reg. code if all addons are free" do
         # user is not asked for any reg. code
         expect(Registration::UI::AddonRegCodesDialog).to_not receive(:run)
+        allow(registration_ui).to receive(:register_selected_addons) { true }
 
         # Register Legacy module
         registration_ui.register_addons([addon_legacy], {})


### PR DESCRIPTION

- It depends on yast/yast-yast2#618

## Before the fix
![registration - message too long to read](https://user-images.githubusercontent.com/7056681/29880593-14c30fde-8da0-11e7-8138-1dd2f6b47b1a.png)

## After the fix
![registration - wrap message](https://user-images.githubusercontent.com/7056681/29896083-87c57912-8dd3-11e7-851c-0086861c51ba.png)
