### PR TITLE
Add the /mnt prefix only at upgrade (bsc#1062468)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 10 08:19:27 UTC 2017 - lslezak@suse.cz
+
+- Add the /mnt prefix only at upgrade, in installation still use /
+  for storing the credentials (bsc#1062468)
+- 4.0.3
+
+-------------------------------------------------------------------
 Mon Oct  9 12:33:17 UTC 2017 - jreidinger@suse.com
 
 - Fix showing modules and extensions when there is more then

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.2
+Version:        4.0.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
In installation still use `/`  for storing the credentials, see [bsc#1062468](https://bugzilla.suse.com/show_bug.cgi?id=1062468)

- 4.0.3