### PR TITLE
Support for media based upgrade (FATE#323163)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Thu Oct 19 11:53:37 UTC 2017 - lslezak@suse.cz
+
+- Display an informative popup when upgrading an unregistered
+  system, preselect adding DVD add-ons to make upgrade using media
+  easier (fate#323163)
+- Support "media_upgrade=1" boot parameter for media based upgrade
+  even for registered systems (fate#323163)
+- 4.0.7
+
+-------------------------------------------------------------------
 Thu Oct 12 11:57:29 UTC 2017 - mfilka@suse.com
 
 - fate#323450

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.6
+Version:        4.0.7
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- Display an informative popup when upgrading an unregistered system, preselect adding DVD add-ons to make upgrade using media easier
- Support `media_upgrade=1` boot parameter for media based upgrade even for registered systems 
- See [FATE#323163](https://fate.suse.com/323163)
- 4.0.7

## Screenshots

#### Selecting an Unregistered System to Upgrade
![media_upgrade_message](https://user-images.githubusercontent.com/907998/31774490-37b36fc6-b4e6-11e7-94e4-6b48a92b11ac.png)

#### Adding the Upgrade Media
In the next dialog user is requested to add the additional installation media (the "SLE15-Packages" DVD), the DVD choice is preselected:
![media_upgrade_selection](https://user-images.githubusercontent.com/907998/31774500-3c40f0c2-b4e6-11e7-9790-9fb15cfb20ee.png)

## Screencast

A complete upgrade workflow could look like this:
![media_upgrade](https://user-images.githubusercontent.com/907998/31774531-4fb3ced6-b4e6-11e7-9f21-03d5ec127a9c.gif)

Note: the upgrade wrongly installs the Desktop and SLES4SAP products, that should be fixed later.
