### PR TITLE
Media based upgrade warnings, preselect recommended addons, better help text

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Thu Oct 26 12:42:18 UTC 2017 - lslezak@suse.cz
+
+- Use the correct install.inf key for media base upgrade (related
+  to fate#323163)
+- Warn when doing media based upgrade for a registered system
+- Preselect the recommended modules and extensions (bsc#1056413)
+- Describe the icons in the modules and extensions dialog help
+- 4.0.9
+
+-------------------------------------------------------------------
 Thu Oct 26 08:35:42 UTC 2017 - jsrain@suse.cz
 
 - fixed detection of base product during upgrade (bsc#1064191)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.8
+Version:        4.0.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -184,10 +184,11 @@ module Registration
       :identifier,
       :name,
       :product_type,
-      :release_type,
+      :recommended,
       :release_stage,
-      :version,
-      :repositories
+      :release_type,
+      :repositories,
+      :version
 
     # the constructor
     # @param pure_addon [SUSE::Connect::Product] a pure add-on from the registration server

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -286,8 +286,39 @@ module Registration
         _("<p>Please note, that some extensions or modules might need "\
             "specific registration code.</p>") +
           # help text (3/3)
-          _("<p>If you want to remove any extension or module you need to log"\
+          _("<p>If you want to remove any extension or module you need to log "\
               "into the SUSE Customer Center and remove them manually there.</p>")
+      end
+
+      def checkboxes_help
+        header = _("<p>The extensions and modules can have several states depending " \
+          "how they were selected.</p>")
+
+        # TRANSLATORS: help text for checked check box
+        selected = _("The extension or module is selected to install by user or is " \
+          "pre-selected as a recommended addon.") + "<br>"
+        # TRANSLATORS: help text for unchecked check box
+        deselected = _("The extension or module is not selected to install.") + "<br>"
+        # TRANSLATORS: help text for automatically checked check box (it has a
+        # different look that a user selected check box)
+        auto_selected = _("The extension or module was selected automatically as a dependency " \
+          "of another extension or module.")
+
+        if Yast::UI.TextMode
+          return header + "<p>" \
+              "[x] = " + selected +
+              "[ ] = " + deselected +
+              "[a] = " + auto_selected +
+              "</p>"
+        end
+
+        mode = (ENV["Y2STYLE"] == "installation.qss") ? "inst" : "normal"
+
+        header + "<p>" \
+          "<img src='#{IMAGE_DIR}/#{IMAGES["#{mode}:on:enabled"]}'></img> = " + selected +
+          "<img src='#{IMAGE_DIR}/#{IMAGES["#{mode}:off:enabled"]}'></img> = " + deselected +
+          "<img src='#{IMAGE_DIR}/#{IMAGES["#{mode}:auto:enabled"]}'></img> = " + auto_selected +
+          "</p>"
       end
 
       def preselect_recommended

--- a/src/lib/registration/ui/addon_selection_registration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_registration_dialog.rb
@@ -32,7 +32,7 @@ module Registration
           content,
           # help text (1/3)
           _("<p>Here you can select available extensions and modules for your"\
-              "system.</p>") + generic_help_text,
+              "system.</p>") + generic_help_text + checkboxes_help,
           # always enable Back/Next, the dialog cannot be the first in workflow
           true,
           true

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -402,7 +402,11 @@ module Registration
         # media based upgrade requested by user
         if Yast::Linuxrc.InstallInf("MediaUpgrade") == "1"
           log.info "Skipping SCC upgrade, media based upgrade requested"
-          Yast::Popup.LongMessage(media_upgrade)
+          if Registration.is_registered?
+            Yast::Popup.LongMessageGeometry(media_upgrade(true), 60, 15)
+          else
+            Yast::Popup.LongMessage(media_upgrade(false))
+          end
           return :skip
         # the system is registered, continue with the SCC/SMT based upgrade
         elsif Registration.is_registered?
@@ -440,16 +444,28 @@ module Registration
       end
 
       # Informative message
+      # @param registered [Boolean] is the system registered?
       # @return [String] translated message
-      def media_upgrade
-        # TRANSLATORS: Media based upgrade requested by user (1/2)
+      def media_upgrade(registered)
+        # TRANSLATORS: Media based upgrade requested by user (1/3)
         #   User requested media based upgrade which does not use SCC/SMT
         #   but the downloaded media (physical DVD or shared repo on a local server).
-        _("<h2>Media Based Upgrade</h2><p>The media based upgrade is requested. " \
+        ret = _("<h2>Media Based Upgrade</h2><p>The media based upgrade is requested. " \
           "In this mode YaST will not contact the registration server to obtain " \
           "the new software repositories required for migration.</p>") +
-          # TRANSLATORS: Media based upgrade requested by user (2/2)
+          # TRANSLATORS: Media based upgrade requested by user (2/3)
           _("<p>Please add the installation media manually in the next step.</p>")
+
+        return ret unless registered
+
+        # TRANSLATORS: a warning message, upgrading the registered systems
+        #   using media is not supported
+        ret + _("<h2>Warning!</h2><p><b>The media based upgrade for registered " \
+          "systems is not supported!<b></p>") +
+          _("<p>If you upgrade the system using media the registration status " \
+            "will not be upgraded and the system will be still registered " \
+            "using the previous product. The packages from the registration " \
+            "repositories can conflict with the new packages.</p>")
       end
     end
   end

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -479,7 +479,7 @@ module Registration
         ret + _("<h2>Warning!</h2><p><b>The media based upgrade for registered " \
           "systems is not supported!<b></p>") +
           _("<p>If you upgrade the system using media the registration status " \
-            "will not be upgraded and the system will be still registered " \
+            "will not be updated and the system will be still registered " \
             "using the previous product. The packages from the registration " \
             "repositories can conflict with the new packages.</p>")
       end

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -400,7 +400,7 @@ module Registration
       #   continue with the SCC/SMT based upgrade
       def system_upgrade_check
         # media based upgrade requested by user
-        if Yast::Linuxrc.InstallInf("UpgradeMedia") == "1"
+        if Yast::Linuxrc.InstallInf("MediaUpgrade") == "1"
           log.info "Skipping SCC upgrade, media based upgrade requested"
           Yast::Popup.LongMessage(media_upgrade)
           return :skip

--- a/test/addon_spec.rb
+++ b/test/addon_spec.rb
@@ -85,7 +85,8 @@ describe Registration::Addon do
       expected_output = [
         "sle-module-basesystem", "sle-module-desktop-applications",
         "sle-module-legacy", "sle-module-public-cloud", "sle-ha",
-        "sle-module-development-tools", "sle-module-server-applications", "sle-we" ]
+        "sle-module-development-tools", "sle-module-server-applications", "sle-we"
+      ]
 
       expect(addons.size).to eq sorted_addons.size
       expect(sorted_addons.map(&:identifier)).to eq expected_output

--- a/test/addon_spec.rb
+++ b/test/addon_spec.rb
@@ -82,9 +82,10 @@ describe Registration::Addon do
     it "returns addons sorted in the registration order" do
       addons = load_yaml_fixture("sle15_addons.yaml")
       sorted_addons = Registration::Addon.registration_order(addons)
-      expected_output = ["sle-module-basesystem", "sle-ha", "sle-we", "sle-module-legacy",
-                         "sle-module-scripting", "sle-module-desktop-applications",
-                         "sle-module-development-tools", "sle-module-server-applications"]
+      expected_output = [
+        "sle-module-basesystem", "sle-module-desktop-applications",
+        "sle-module-legacy", "sle-module-public-cloud", "sle-ha",
+        "sle-module-development-tools", "sle-module-server-applications", "sle-we" ]
 
       expect(addons.size).to eq sorted_addons.size
       expect(sorted_addons.map(&:identifier)).to eq expected_output

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -16,6 +16,7 @@ def suse_connect_product_generator(attrs = {})
   params["extensions"] = attrs["extensions"] || []
   params["former_identifier"] = attrs["former_identifier"]
   params["release_stage"] = attrs["release_stage"]
+  params["recommended"] = attrs["recommended"] || false
 
   params
 end
@@ -39,6 +40,7 @@ module Registration
         @cached_addons = nil
         @registered = nil
         @selected = nil
+        @auto_selected = nil
       end
     end
   end

--- a/test/fixtures/sle15_addons.yaml
+++ b/test/fixtures/sle15_addons.yaml
@@ -1,573 +1,557 @@
+# see https://github.com/yast/yast-registration/tree/master/devel/dump_reader.rb
+# for an example how to read this dump file
 ---
-- &10 !ruby/object:Registration::Addon
-  pure_addon: &1 !ruby/object:SUSE::Connect::Remote::Product
+- &2 !ruby/object:Registration::Addon
+  pure_addon: !ruby/object:OpenStruct
     table:
-      :id: 1582
-      :name: SUSE Linux Enterprise High Availability Extension
-      :identifier: sle-ha
-      :former_identifier: sle-hae
+      :id: 1576
+      :name: Basesystem Module
+      :identifier: sle-module-basesystem
+      :former_identifier: sle-module-basesystem
       :version: '15'
       :release_type: 
       :arch: x86_64
-      :friendly_name: SUSE Linux Enterprise High Availability Extension 15 x86_64
-        (ALPHA)
-      :product_class: SLE-HAE-X86-ALPHA
-      :cpe: cpe:/o:suse:sle-ha:15
-      :free: false
-      :description: SUSE Linux Enterprise High Availability Extension.
+      :friendly_name: Basesystem Module 15 x86_64 (ALPHA)
+      :product_class: 7261-ALPHA
+      :cpe: cpe:/o:suse:sle-module-basesystem:15
+      :free: true
+      :description: "<p> The SUSE Linux Enterprise Basesystem Module delivers the
+        base system of the product. </p>"
       :release_stage: alpha
-      :eula_url: https://updates.suse.com/SUSE/Updates/SLE-HA/15/x86_64/update.license/
+      :eula_url: ''
       :repositories:
-      - id: 2554
-        url: https://updates.suse.com/SUSE/Updates/SLE-HA/15/x86_64/update/
-        name: SLE-HA15-Updates
+      - id: 2528
+        url: https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product_source/
+        name: SLE-Module-Basesystem15-Source-Pool
         distro_target: sle-15-x86_64
-        description: SLE-HA15-Updates for sle-15-x86_64
+        description: SLE-Module-Basesystem15-Source-Pool for sle-15-x86_64
+        enabled: false
+        autorefresh: false
+        installer_updates: false
+      - id: 2527
+        url: https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product_debug/
+        name: SLE-Module-Basesystem15-Debuginfo-Pool
+        distro_target: sle-15-x86_64
+        description: SLE-Module-Basesystem15-Debuginfo-Pool for sle-15-x86_64
+        enabled: false
+        autorefresh: false
+        installer_updates: false
+      - id: 2526
+        url: https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product/
+        name: SLE-Module-Basesystem15-Pool
+        distro_target: sle-15-x86_64
+        description: SLE-Module-Basesystem15-Pool for sle-15-x86_64
+        enabled: true
+        autorefresh: false
+        installer_updates: false
+      - id: 2525
+        url: https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update_debug/
+        name: SLE-Module-Basesystem15-Debuginfo-Updates
+        distro_target: sle-15-x86_64
+        description: SLE-Module-Basesystem15-Debuginfo-Updates for sle-15-x86_64
+        enabled: false
+        autorefresh: true
+        installer_updates: false
+      - id: 2524
+        url: https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update/
+        name: SLE-Module-Basesystem15-Updates
+        distro_target: sle-15-x86_64
+        description: SLE-Module-Basesystem15-Updates for sle-15-x86_64
         enabled: true
         autorefresh: true
         installer_updates: false
-      - id: 2555
-        url: https://updates.suse.com/SUSE/Updates/SLE-HA/15/x86_64/update_debug/
-        name: SLE-HA15-Debuginfo-Updates
-        distro_target: sle-15-x86_64
-        description: SLE-HA15-Debuginfo-Updates for sle-15-x86_64
-        enabled: false
-        autorefresh: true
-        installer_updates: false
-      - id: 2556
-        url: https://updates.suse.com/SUSE/Products/SLE-HA/15/x86_64/product/
-        name: SLE-HA15-Pool
-        distro_target: sle-15-x86_64
-        description: SLE-HA15-Pool for sle-15-x86_64
-        enabled: true
-        autorefresh: false
-        installer_updates: false
-      - id: 2557
-        url: https://updates.suse.com/SUSE/Products/SLE-HA/15/x86_64/product_debug/
-        name: SLE-HA15-Debuginfo-Pool
-        distro_target: sle-15-x86_64
-        description: SLE-HA15-Debuginfo-Pool for sle-15-x86_64
-        enabled: false
-        autorefresh: false
-        installer_updates: false
-      - id: 2558
-        url: https://updates.suse.com/SUSE/Products/SLE-HA/15/x86_64/product_source/
-        name: SLE-HA15-Source-Pool
-        distro_target: sle-15-x86_64
-        description: SLE-HA15-Source-Pool for sle-15-x86_64
-        enabled: false
-        autorefresh: false
-        installer_updates: false
-      :product_type: extension
+      :product_type: module
       :predecessor_ids: []
-      :shortname: SLEHA15
-      :extensions: []
-    modifiable: true
-  children: []
-  depends_on: &8 !ruby/object:Registration::Addon
-    pure_addon: !ruby/object:OpenStruct
-      table:
-        :id: 1576
-        :name: Basesystem Module
-        :identifier: sle-module-basesystem
-        :former_identifier: sle-module-basesystem
-        :version: '15'
-        :release_type: 
-        :arch: x86_64
-        :friendly_name: Basesystem Module 15 x86_64 (ALPHA)
-        :product_class: 7261-ALPHA
-        :cpe: cpe:/o:suse:sle-module-basesystem:15
-        :free: true
-        :description: "<p> The SUSE Linux Enterprise Basesystem Module delivers the
-          base system of the product. </p>"
-        :release_stage: alpha
-        :eula_url: https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update.license/
-        :repositories:
-        - id: 2524
-          url: https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update/
-          name: SLE-Module-Basesystem15-Updates
-          distro_target: sle-15-x86_64
-          description: SLE-Module-Basesystem15-Updates for sle-15-x86_64
-          enabled: true
-          autorefresh: true
-          installer_updates: false
-        - id: 2525
-          url: https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update_debug/
-          name: SLE-Module-Basesystem15-Debuginfo-Updates
-          distro_target: sle-15-x86_64
-          description: SLE-Module-Basesystem15-Debuginfo-Updates for sle-15-x86_64
-          enabled: false
-          autorefresh: true
-          installer_updates: false
-        - id: 2526
-          url: https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product/
-          name: SLE-Module-Basesystem15-Pool
-          distro_target: sle-15-x86_64
-          description: SLE-Module-Basesystem15-Pool for sle-15-x86_64
-          enabled: true
-          autorefresh: false
-          installer_updates: false
-        - id: 2527
-          url: https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product_debug/
-          name: SLE-Module-Basesystem15-Debuginfo-Pool
-          distro_target: sle-15-x86_64
-          description: SLE-Module-Basesystem15-Debuginfo-Pool for sle-15-x86_64
-          enabled: false
-          autorefresh: false
-          installer_updates: false
-        - id: 2528
-          url: https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product_source/
-          name: SLE-Module-Basesystem15-Source-Pool
-          distro_target: sle-15-x86_64
-          description: SLE-Module-Basesystem15-Source-Pool for sle-15-x86_64
-          enabled: false
-          autorefresh: false
-          installer_updates: false
-        :product_type: module
-        :predecessor_ids: []
-        :shortname: Basesystem-Module
-        :extensions:
-        - &2 !ruby/object:SUSE::Connect::Remote::Product
-          table:
-            :id: 1577
-            :name: Scripting Languages Module
-            :identifier: sle-module-scripting
-            :former_identifier: sle-module-scripting
-            :version: '15'
-            :release_type: 
-            :arch: x86_64
-            :friendly_name: Scripting Languages Module 15 x86_64 (ALPHA)
-            :product_class: 7261-ALPHA
-            :cpe: cpe:/o:suse:sle-module-scripting:15
-            :free: true
-            :description: "<p> The SUSE Linux Enterprise Scripting Languages Module
-              delivers a comprehensive suite of scripting languages, frameworks, and
-              related tools helping developers and systems administrators accelerate
-              the creation of stable, modern web applications, using dynamic languages,
-              such as PHP, Ruby on Rails, and Python. It contains those packages of
-              the scripting language that are not included with other modules. </p>
-              <p> Access to the Scripting Languages Module is included in your SUSE
-              Linux Enterprise Server subscription. The module has a different lifecycle
-              than SUSE Linux Enterprise Server itself: Package versions in the this
-              module are usually supported for at most three years. We are planning
-              to release more recent versions on a schedule of approximately 18 month;
-              the exact dates may differ per package. </p>"
-            :release_stage: alpha
-            :eula_url: https://updates.suse.com/SUSE/Updates/SLE-Module-Scripting/15/x86_64/update.license/
-            :repositories:
-            - id: 2529
-              url: https://updates.suse.com/SUSE/Updates/SLE-Module-Scripting/15/x86_64/update/
-              name: SLE-Module-Scripting15-Updates
-              distro_target: sle-15-x86_64
-              description: SLE-Module-Scripting15-Updates for sle-15-x86_64
-              enabled: true
-              autorefresh: true
-              installer_updates: false
-            - id: 2530
-              url: https://updates.suse.com/SUSE/Updates/SLE-Module-Scripting/15/x86_64/update_debug/
-              name: SLE-Module-Scripting15-Debuginfo-Updates
-              distro_target: sle-15-x86_64
-              description: SLE-Module-Scripting15-Debuginfo-Updates for sle-15-x86_64
-              enabled: false
-              autorefresh: true
-              installer_updates: false
-            - id: 2531
-              url: https://updates.suse.com/SUSE/Products/SLE-Module-Scripting/15/x86_64/product/
-              name: SLE-Module-Scripting15-Pool
-              distro_target: sle-15-x86_64
-              description: SLE-Module-Scripting15-Pool for sle-15-x86_64
-              enabled: true
-              autorefresh: false
-              installer_updates: false
-            - id: 2532
-              url: https://updates.suse.com/SUSE/Products/SLE-Module-Scripting/15/x86_64/product_debug/
-              name: SLE-Module-Scripting15-Debuginfo-Pool
-              distro_target: sle-15-x86_64
-              description: SLE-Module-Scripting15-Debuginfo-Pool for sle-15-x86_64
-              enabled: false
-              autorefresh: false
-              installer_updates: false
-            - id: 2533
-              url: https://updates.suse.com/SUSE/Products/SLE-Module-Scripting/15/x86_64/product_source/
-              name: SLE-Module-Scripting15-Source-Pool
-              distro_target: sle-15-x86_64
-              description: SLE-Module-Scripting15-Source-Pool for sle-15-x86_64
-              enabled: false
-              autorefresh: false
-              installer_updates: false
-            :product_type: module
-            :predecessor_ids: []
-            :shortname: Scripting-Module
-            :extensions:
-            - &3 !ruby/object:SUSE::Connect::Remote::Product
-              table:
-                :id: 1578
-                :name: Desktop Applications Module
-                :identifier: sle-module-desktop-applications
-                :former_identifier: sle-module-desktop-applications
-                :version: '15'
-                :release_type: 
-                :arch: x86_64
-                :friendly_name: Desktop Applications Module 15 x86_64 (ALPHA)
-                :product_class: 7261-ALPHA
-                :cpe: cpe:/o:suse:sle-module-desktop-applications:15
-                :free: true
-                :description: "<p> The SUSE Linux Enterprise Desktop Applications
-                  Module delivers a basic set of Desktop functionality. </p> <p> Access
-                  to the Desktop Applications Module is included in your SUSE Linux
-                  Enterprise product subscription. </p>"
-                :release_stage: alpha
-                :eula_url: https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15/x86_64/update.license/
-                :repositories:
-                - id: 2534
-                  url: https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15/x86_64/update/
-                  name: SLE-Module-Desktop-Applications15-Updates
-                  distro_target: sle-15-x86_64
-                  description: SLE-Module-Desktop-Applications15-Updates for sle-15-x86_64
-                  enabled: true
-                  autorefresh: true
-                  installer_updates: false
-                - id: 2535
-                  url: https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15/x86_64/update_debug/
-                  name: SLE-Module-Desktop-Applications15-Debuginfo-Updates
-                  distro_target: sle-15-x86_64
-                  description: SLE-Module-Desktop-Applications15-Debuginfo-Updates
-                    for sle-15-x86_64
-                  enabled: false
-                  autorefresh: true
-                  installer_updates: false
-                - id: 2536
-                  url: https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15/x86_64/product/
-                  name: SLE-Module-Desktop-Applications15-Pool
-                  distro_target: sle-15-x86_64
-                  description: SLE-Module-Desktop-Applications15-Pool for sle-15-x86_64
-                  enabled: true
-                  autorefresh: false
-                  installer_updates: false
-                - id: 2537
-                  url: https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15/x86_64/product_debug/
-                  name: SLE-Module-Desktop-Applications15-Debuginfo-Pool
-                  distro_target: sle-15-x86_64
-                  description: SLE-Module-Desktop-Applications15-Debuginfo-Pool for
-                    sle-15-x86_64
-                  enabled: false
-                  autorefresh: false
-                  installer_updates: false
-                - id: 2538
-                  url: https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15/x86_64/product_source/
-                  name: SLE-Module-Desktop-Applications15-Source-Pool
-                  distro_target: sle-15-x86_64
-                  description: SLE-Module-Desktop-Applications15-Source-Pool for sle-15-x86_64
-                  enabled: false
-                  autorefresh: false
-                  installer_updates: false
-                :product_type: module
-                :predecessor_ids: []
-                :shortname: Desktop-Applications-Module
-                :extensions:
-                - &4 !ruby/object:SUSE::Connect::Remote::Product
-                  table:
-                    :id: 1579
-                    :name: Development Tools Module
-                    :identifier: sle-module-development-tools
-                    :former_identifier: sle-module-development-tools
-                    :version: '15'
-                    :release_type: 
-                    :arch: x86_64
-                    :friendly_name: Development Tools Module 15 x86_64 (ALPHA)
-                    :product_class: 7261-ALPHA
-                    :cpe: cpe:/o:suse:sle-module-development-tools:15
-                    :free: true
-                    :description: "<p> The Development Tools Module helps you developing
-                      applications for SUSE Linux Enterprise 15. </p> <p> Access to
-                      the Development Tools Module is included in your SUSE Linux
-                      Enterprise product subscription. The module has a different
-                      lifecycle than SUSE Linux Enterprise itself. </p>"
-                    :release_stage: alpha
-                    :eula_url: https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15/x86_64/update.license/
-                    :repositories:
-                    - id: 2539
-                      url: https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15/x86_64/update/
-                      name: SLE-Module-DevTools15-Updates
-                      distro_target: sle-15-x86_64
-                      description: SLE-Module-DevTools15-Updates for sle-15-x86_64
-                      enabled: true
-                      autorefresh: true
-                      installer_updates: false
-                    - id: 2540
-                      url: https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15/x86_64/update_debug/
-                      name: SLE-Module-DevTools15-Debuginfo-Updates
-                      distro_target: sle-15-x86_64
-                      description: SLE-Module-DevTools15-Debuginfo-Updates for sle-15-x86_64
-                      enabled: false
-                      autorefresh: true
-                      installer_updates: false
-                    - id: 2541
-                      url: https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15/x86_64/product/
-                      name: SLE-Module-DevTools15-Pool
-                      distro_target: sle-15-x86_64
-                      description: SLE-Module-DevTools15-Pool for sle-15-x86_64
-                      enabled: true
-                      autorefresh: false
-                      installer_updates: false
-                    - id: 2542
-                      url: https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15/x86_64/product_debug/
-                      name: SLE-Module-DevTools15-Debuginfo-Pool
-                      distro_target: sle-15-x86_64
-                      description: SLE-Module-DevTools15-Debuginfo-Pool for sle-15-x86_64
-                      enabled: false
-                      autorefresh: false
-                      installer_updates: false
-                    - id: 2543
-                      url: https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15/x86_64/product_source/
-                      name: SLE-Module-DevTools15-Source-Pool
-                      distro_target: sle-15-x86_64
-                      description: SLE-Module-DevTools15-Source-Pool for sle-15-x86_64
-                      enabled: false
-                      autorefresh: false
-                      installer_updates: false
-                    :product_type: module
-                    :predecessor_ids: []
-                    :shortname: Development-Tools-Module
-                    :extensions: []
-                  modifiable: true
-                - &6 !ruby/object:SUSE::Connect::Remote::Product
-                  table:
-                    :id: 1580
-                    :name: Server Applications Module
-                    :identifier: sle-module-server-applications
-                    :former_identifier: sle-module-server-applications
-                    :version: '15'
-                    :release_type: 
-                    :arch: x86_64
-                    :friendly_name: Server Applications Module 15 x86_64 (ALPHA)
-                    :product_class: 7261-ALPHA
-                    :cpe: cpe:/o:suse:sle-module-server-applications:15
-                    :free: true
-                    :description: "<p> The SUSE Linux Enterprise Server Applications
-                      Module delivers a basic set of Server functionality. </p> <p>
-                      Access to the Server Applications Module is included in your
-                      SUSE Linux Enterprise Server subscription. </p>"
-                    :release_stage: alpha
-                    :eula_url: https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15/x86_64/update.license/
-                    :repositories:
-                    - id: 2544
-                      url: https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15/x86_64/update/
-                      name: SLE-Module-Server-Applications15-Updates
-                      distro_target: sle-15-x86_64
-                      description: SLE-Module-Server-Applications15-Updates for sle-15-x86_64
-                      enabled: true
-                      autorefresh: true
-                      installer_updates: false
-                    - id: 2545
-                      url: https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15/x86_64/update_debug/
-                      name: SLE-Module-Server-Applications15-Debuginfo-Updates
-                      distro_target: sle-15-x86_64
-                      description: SLE-Module-Server-Applications15-Debuginfo-Updates
-                        for sle-15-x86_64
-                      enabled: false
-                      autorefresh: true
-                      installer_updates: false
-                    - id: 2546
-                      url: https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product/
-                      name: SLE-Module-Server-Applications15-Pool
-                      distro_target: sle-15-x86_64
-                      description: SLE-Module-Server-Applications15-Pool for sle-15-x86_64
-                      enabled: true
-                      autorefresh: false
-                      installer_updates: false
-                    - id: 2547
-                      url: https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product_debug/
-                      name: SLE-Module-Server-Applications15-Debuginfo-Pool
-                      distro_target: sle-15-x86_64
-                      description: SLE-Module-Server-Applications15-Debuginfo-Pool
-                        for sle-15-x86_64
-                      enabled: false
-                      autorefresh: false
-                      installer_updates: false
-                    - id: 2548
-                      url: https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product_source/
-                      name: SLE-Module-Server-Applications15-Source-Pool
-                      distro_target: sle-15-x86_64
-                      description: SLE-Module-Server-Applications15-Source-Pool for
-                        sle-15-x86_64
-                      enabled: false
-                      autorefresh: false
-                      installer_updates: false
-                    :product_type: module
-                    :predecessor_ids: []
-                    :shortname: Server-Applications-Module
-                    :extensions: []
-                  modifiable: true
-              modifiable: true
-          modifiable: true
-        - &9 !ruby/object:SUSE::Connect::Remote::Product
-          table:
-            :id: 1581
-            :name: Legacy Module
-            :identifier: sle-module-legacy
-            :former_identifier: sle-module-legacy
-            :version: '15'
-            :release_type: 
-            :arch: x86_64
-            :friendly_name: Legacy Module 15 x86_64 (ALPHA)
-            :product_class: 7261-ALPHA
-            :cpe: cpe:/o:suse:sle-module-legacy:15
-            :free: true
-            :description: "<p> The Legacy Module helps you migrating applications
-              from SUSE Linux Enterprise 12 and other systems to SUSE Linux Enterprise
-              15, by providing packages which are discontinued on SUSE Linux Enterprise
-              Server, such as: ntp, IBM Java7, and a number of libraries. </p> <p>
-              Access to the Legacy Module is included in your SUSE Linux Enterprise
-              Server subscription. The module has a different lifecycle than SUSE
-              Linux Enterprise Server itself. Packages in the this module are usually
-              supported for at most three years. </p>"
-            :release_stage: alpha
-            :eula_url: https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15/x86_64/update.license/
-            :repositories:
-            - id: 2549
-              url: https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15/x86_64/update/
-              name: SLE-Module-Legacy15-Updates
-              distro_target: sle-15-x86_64
-              description: SLE-Module-Legacy15-Updates for sle-15-x86_64
-              enabled: true
-              autorefresh: true
-              installer_updates: false
-            - id: 2550
-              url: https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15/x86_64/update_debug/
-              name: SLE-Module-Legacy15-Debuginfo-Updates
-              distro_target: sle-15-x86_64
-              description: SLE-Module-Legacy15-Debuginfo-Updates for sle-15-x86_64
-              enabled: false
-              autorefresh: true
-              installer_updates: false
-            - id: 2551
-              url: https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15/x86_64/product/
-              name: SLE-Module-Legacy15-Pool
-              distro_target: sle-15-x86_64
-              description: SLE-Module-Legacy15-Pool for sle-15-x86_64
-              enabled: true
-              autorefresh: false
-              installer_updates: false
-            - id: 2552
-              url: https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15/x86_64/product_debug/
-              name: SLE-Module-Legacy15-Debuginfo-Pool
-              distro_target: sle-15-x86_64
-              description: SLE-Module-Legacy15-Debuginfo-Pool for sle-15-x86_64
-              enabled: false
-              autorefresh: false
-              installer_updates: false
-            - id: 2553
-              url: https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15/x86_64/product_source/
-              name: SLE-Module-Legacy15-Source-Pool
-              distro_target: sle-15-x86_64
-              description: SLE-Module-Legacy15-Source-Pool for sle-15-x86_64
-              enabled: false
-              autorefresh: false
-              installer_updates: false
-            :product_type: module
-            :predecessor_ids: []
-            :shortname: Legacy-Module
-            :extensions: []
-          modifiable: true
-        - *1
-        - &11 !ruby/object:SUSE::Connect::Remote::Product
-          table:
-            :id: 1583
-            :name: SUSE Linux Enterprise Workstation Extension
-            :identifier: sle-we
-            :former_identifier: sle-we
-            :version: '15'
-            :release_type: 
-            :arch: x86_64
-            :friendly_name: SUSE Linux Enterprise Workstation Extension 15 x86_64
-              (ALPHA)
-            :product_class: SLE-WE-ALPHA
-            :cpe: cpe:/o:suse:sle-we:15
-            :free: false
-            :description: SUSE Linux Enterprise Workstation Extension extends the
-              functionality of SUSE Linux Enterprise Server with packages of SUSE
-              Linux Enterprise Desktop, like additional desktop applications (office
-              suite, email client, graphical editor ...) and libraries. It allows
-              to combine both products to create a full featured Workstation.
-            :release_stage: alpha
-            :eula_url: https://updates.suse.com/SUSE/Updates/SLE-WE/15/x86_64/update.license/
-            :repositories:
-            - id: 2559
-              url: https://updates.suse.com/SUSE/Updates/SLE-WE/15/x86_64/update/
-              name: SLE-WE15-Updates
-              distro_target: sle-15-x86_64
-              description: SLE-WE15-Updates for sle-15-x86_64
-              enabled: true
-              autorefresh: true
-              installer_updates: false
-            - id: 2560
-              url: https://updates.suse.com/SUSE/Updates/SLE-WE/15/x86_64/update_debug/
-              name: SLE-WE15-Debuginfo-Updates
-              distro_target: sle-15-x86_64
-              description: SLE-WE15-Debuginfo-Updates for sle-15-x86_64
-              enabled: false
-              autorefresh: true
-              installer_updates: false
-            - id: 2561
-              url: https://updates.suse.com/SUSE/Products/SLE-WE/15/x86_64/product/
-              name: SLE-WE15-Pool
-              distro_target: sle-15-x86_64
-              description: SLE-WE15-Pool for sle-15-x86_64
-              enabled: true
-              autorefresh: false
-              installer_updates: false
-            - id: 2562
-              url: https://updates.suse.com/SUSE/Products/SLE-WE/15/x86_64/product_debug/
-              name: SLE-WE15-Debuginfo-Pool
-              distro_target: sle-15-x86_64
-              description: SLE-WE15-Debuginfo-Pool for sle-15-x86_64
-              enabled: false
-              autorefresh: false
-              installer_updates: false
-            - id: 2563
-              url: https://updates.suse.com/SUSE/Products/SLE-WE/15/x86_64/product_source/
-              name: SLE-WE15-Source-Pool
-              distro_target: sle-15-x86_64
-              description: SLE-WE15-Source-Pool for sle-15-x86_64
-              enabled: false
-              autorefresh: false
-              installer_updates: false
-            :product_type: extension
-            :predecessor_ids: []
-            :shortname: SLEWE15
-            :extensions: []
-          modifiable: true
-    children:
-    - &7 !ruby/object:Registration::Addon
-      pure_addon: *2
-      children:
-      - &5 !ruby/object:Registration::Addon
-        pure_addon: *3
-        children:
-        - &13 !ruby/object:Registration::Addon
-          pure_addon: *4
-          children: []
-          depends_on: *5
-        - &15 !ruby/object:Registration::Addon
-          pure_addon: *6
-          children: []
-          depends_on: *5
-        depends_on: *7
-      depends_on: *8
-    - &14 !ruby/object:Registration::Addon
-      pure_addon: *9
-      children: []
-      depends_on: *8
-    - *10
-    - &12 !ruby/object:Registration::Addon
-      pure_addon: *11
-      children: []
-      depends_on: *8
-- *12
-- *8
-- *5
-- *13
-- *14
-- *7
-- *15
+      :shortname: Basesystem-Module
+      :recommended: true
+      :extensions:
+      - &1 !ruby/object:SUSE::Connect::Remote::Product
+        table:
+          :id: 1578
+          :name: Desktop Applications Module
+          :identifier: sle-module-desktop-applications
+          :former_identifier: sle-module-desktop-applications
+          :version: '15'
+          :release_type: 
+          :arch: x86_64
+          :friendly_name: Desktop Applications Module 15 x86_64 (ALPHA)
+          :product_class: 7261-ALPHA
+          :cpe: cpe:/o:suse:sle-module-desktop-applications:15
+          :free: true
+          :description: "<p> The SUSE Linux Enterprise Desktop Applications Module
+            delivers a basic set of Desktop functionality. </p> <p> Access to the
+            Desktop Applications Module is included in your SUSE Linux Enterprise
+            product subscription. </p>"
+          :release_stage: alpha
+          :eula_url: ''
+          :repositories:
+          - id: 2538
+            url: https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15/x86_64/product_source/
+            name: SLE-Module-Desktop-Applications15-Source-Pool
+            distro_target: sle-15-x86_64
+            description: SLE-Module-Desktop-Applications15-Source-Pool for sle-15-x86_64
+            enabled: false
+            autorefresh: false
+            installer_updates: false
+          - id: 2537
+            url: https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15/x86_64/product_debug/
+            name: SLE-Module-Desktop-Applications15-Debuginfo-Pool
+            distro_target: sle-15-x86_64
+            description: SLE-Module-Desktop-Applications15-Debuginfo-Pool for sle-15-x86_64
+            enabled: false
+            autorefresh: false
+            installer_updates: false
+          - id: 2536
+            url: https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15/x86_64/product/
+            name: SLE-Module-Desktop-Applications15-Pool
+            distro_target: sle-15-x86_64
+            description: SLE-Module-Desktop-Applications15-Pool for sle-15-x86_64
+            enabled: true
+            autorefresh: false
+            installer_updates: false
+          - id: 2535
+            url: https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15/x86_64/update_debug/
+            name: SLE-Module-Desktop-Applications15-Debuginfo-Updates
+            distro_target: sle-15-x86_64
+            description: SLE-Module-Desktop-Applications15-Debuginfo-Updates for sle-15-x86_64
+            enabled: false
+            autorefresh: true
+            installer_updates: false
+          - id: 2534
+            url: https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15/x86_64/update/
+            name: SLE-Module-Desktop-Applications15-Updates
+            distro_target: sle-15-x86_64
+            description: SLE-Module-Desktop-Applications15-Updates for sle-15-x86_64
+            enabled: true
+            autorefresh: true
+            installer_updates: false
+          :product_type: module
+          :predecessor_ids: []
+          :shortname: Desktop-Applications-Module
+          :recommended: false
+          :extensions:
+          - &6 !ruby/object:SUSE::Connect::Remote::Product
+            table:
+              :id: 1579
+              :name: Development Tools Module
+              :identifier: sle-module-development-tools
+              :former_identifier: sle-module-development-tools
+              :version: '15'
+              :release_type: 
+              :arch: x86_64
+              :friendly_name: Development Tools Module 15 x86_64 (ALPHA)
+              :product_class: 7261-ALPHA
+              :cpe: cpe:/o:suse:sle-module-development-tools:15
+              :free: true
+              :description: "<p> The Development Tools Module helps you developing
+                applications for SUSE Linux Enterprise 15. </p> <p> Access to the
+                Development Tools Module is included in your SUSE Linux Enterprise
+                product subscription. The module has a different lifecycle than SUSE
+                Linux Enterprise itself. </p>"
+              :release_stage: alpha
+              :eula_url: ''
+              :repositories:
+              - id: 2543
+                url: https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15/x86_64/product_source/
+                name: SLE-Module-DevTools15-Source-Pool
+                distro_target: sle-15-x86_64
+                description: SLE-Module-DevTools15-Source-Pool for sle-15-x86_64
+                enabled: false
+                autorefresh: false
+                installer_updates: false
+              - id: 2542
+                url: https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15/x86_64/product_debug/
+                name: SLE-Module-DevTools15-Debuginfo-Pool
+                distro_target: sle-15-x86_64
+                description: SLE-Module-DevTools15-Debuginfo-Pool for sle-15-x86_64
+                enabled: false
+                autorefresh: false
+                installer_updates: false
+              - id: 2541
+                url: https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15/x86_64/product/
+                name: SLE-Module-DevTools15-Pool
+                distro_target: sle-15-x86_64
+                description: SLE-Module-DevTools15-Pool for sle-15-x86_64
+                enabled: true
+                autorefresh: false
+                installer_updates: false
+              - id: 2540
+                url: https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15/x86_64/update_debug/
+                name: SLE-Module-DevTools15-Debuginfo-Updates
+                distro_target: sle-15-x86_64
+                description: SLE-Module-DevTools15-Debuginfo-Updates for sle-15-x86_64
+                enabled: false
+                autorefresh: true
+                installer_updates: false
+              - id: 2539
+                url: https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15/x86_64/update/
+                name: SLE-Module-DevTools15-Updates
+                distro_target: sle-15-x86_64
+                description: SLE-Module-DevTools15-Updates for sle-15-x86_64
+                enabled: true
+                autorefresh: true
+                installer_updates: false
+              :product_type: module
+              :predecessor_ids: []
+              :shortname: Development-Tools-Module
+              :recommended: false
+              :extensions: []
+            modifiable: true
+          - &8 !ruby/object:SUSE::Connect::Remote::Product
+            table:
+              :id: 1580
+              :name: Server Applications Module
+              :identifier: sle-module-server-applications
+              :former_identifier: sle-module-server-applications
+              :version: '15'
+              :release_type: 
+              :arch: x86_64
+              :friendly_name: Server Applications Module 15 x86_64 (ALPHA)
+              :product_class: 7261-ALPHA
+              :cpe: cpe:/o:suse:sle-module-server-applications:15
+              :free: true
+              :description: "<p> The SUSE Linux Enterprise Server Applications Module
+                delivers a basic set of Server functionality. </p> <p> Access to the
+                Server Applications Module is included in your SUSE Linux Enterprise
+                Server subscription. </p>"
+              :release_stage: alpha
+              :eula_url: ''
+              :repositories:
+              - id: 2548
+                url: https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product_source/
+                name: SLE-Module-Server-Applications15-Source-Pool
+                distro_target: sle-15-x86_64
+                description: SLE-Module-Server-Applications15-Source-Pool for sle-15-x86_64
+                enabled: false
+                autorefresh: false
+                installer_updates: false
+              - id: 2547
+                url: https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product_debug/
+                name: SLE-Module-Server-Applications15-Debuginfo-Pool
+                distro_target: sle-15-x86_64
+                description: SLE-Module-Server-Applications15-Debuginfo-Pool for sle-15-x86_64
+                enabled: false
+                autorefresh: false
+                installer_updates: false
+              - id: 2546
+                url: https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product/
+                name: SLE-Module-Server-Applications15-Pool
+                distro_target: sle-15-x86_64
+                description: SLE-Module-Server-Applications15-Pool for sle-15-x86_64
+                enabled: true
+                autorefresh: false
+                installer_updates: false
+              - id: 2545
+                url: https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15/x86_64/update_debug/
+                name: SLE-Module-Server-Applications15-Debuginfo-Updates
+                distro_target: sle-15-x86_64
+                description: SLE-Module-Server-Applications15-Debuginfo-Updates for
+                  sle-15-x86_64
+                enabled: false
+                autorefresh: true
+                installer_updates: false
+              - id: 2544
+                url: https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15/x86_64/update/
+                name: SLE-Module-Server-Applications15-Updates
+                distro_target: sle-15-x86_64
+                description: SLE-Module-Server-Applications15-Updates for sle-15-x86_64
+                enabled: true
+                autorefresh: true
+                installer_updates: false
+              :product_type: module
+              :predecessor_ids: []
+              :shortname: Server-Applications-Module
+              :recommended: false
+              :extensions: []
+            modifiable: true
+          - &9 !ruby/object:SUSE::Connect::Remote::Product
+            table:
+              :id: 1583
+              :name: SUSE Linux Enterprise Workstation Extension
+              :identifier: sle-we
+              :former_identifier: sle-we
+              :version: '15'
+              :release_type: 
+              :arch: x86_64
+              :friendly_name: SUSE Linux Enterprise Workstation Extension 15 x86_64
+                (ALPHA)
+              :product_class: SLE-WE-ALPHA
+              :cpe: cpe:/o:suse:sle-we:15
+              :free: false
+              :description: SUSE Linux Enterprise Workstation Extension extends the
+                functionality of SUSE Linux Enterprise Server with packages of SUSE
+                Linux Enterprise Desktop, like additional desktop applications (office
+                suite, email client, graphical editor ...) and libraries. It allows
+                to combine both products to create a full featured Workstation.
+              :release_stage: alpha
+              :eula_url: ''
+              :repositories:
+              - id: 2563
+                url: https://updates.suse.com/SUSE/Products/SLE-WE/15/x86_64/product_source/
+                name: SLE-WE15-Source-Pool
+                distro_target: sle-15-x86_64
+                description: SLE-WE15-Source-Pool for sle-15-x86_64
+                enabled: false
+                autorefresh: false
+                installer_updates: false
+              - id: 2562
+                url: https://updates.suse.com/SUSE/Products/SLE-WE/15/x86_64/product_debug/
+                name: SLE-WE15-Debuginfo-Pool
+                distro_target: sle-15-x86_64
+                description: SLE-WE15-Debuginfo-Pool for sle-15-x86_64
+                enabled: false
+                autorefresh: false
+                installer_updates: false
+              - id: 2561
+                url: https://updates.suse.com/SUSE/Products/SLE-WE/15/x86_64/product/
+                name: SLE-WE15-Pool
+                distro_target: sle-15-x86_64
+                description: SLE-WE15-Pool for sle-15-x86_64
+                enabled: true
+                autorefresh: false
+                installer_updates: false
+              - id: 2560
+                url: https://updates.suse.com/SUSE/Updates/SLE-WE/15/x86_64/update_debug/
+                name: SLE-WE15-Debuginfo-Updates
+                distro_target: sle-15-x86_64
+                description: SLE-WE15-Debuginfo-Updates for sle-15-x86_64
+                enabled: false
+                autorefresh: true
+                installer_updates: false
+              - id: 2559
+                url: https://updates.suse.com/SUSE/Updates/SLE-WE/15/x86_64/update/
+                name: SLE-WE15-Updates
+                distro_target: sle-15-x86_64
+                description: SLE-WE15-Updates for sle-15-x86_64
+                enabled: true
+                autorefresh: true
+                installer_updates: false
+              :product_type: extension
+              :predecessor_ids: []
+              :shortname: SLEWE15
+              :recommended: false
+              :extensions: []
+            modifiable: true
+        modifiable: true
+      - &3 !ruby/object:SUSE::Connect::Remote::Product
+        table:
+          :id: 1581
+          :name: Legacy Module
+          :identifier: sle-module-legacy
+          :former_identifier: sle-module-legacy
+          :version: '15'
+          :release_type: 
+          :arch: x86_64
+          :friendly_name: Legacy Module 15 x86_64 (ALPHA)
+          :product_class: 7261-ALPHA
+          :cpe: cpe:/o:suse:sle-module-legacy:15
+          :free: true
+          :description: "<p> The Legacy Module helps you migrating applications from
+            SUSE Linux Enterprise 12 and other systems to SUSE Linux Enterprise 15,
+            by providing packages which are discontinued on SUSE Linux Enterprise
+            Server, such as: ntp, IBM Java7, and a number of libraries. </p> <p> Access
+            to the Legacy Module is included in your SUSE Linux Enterprise Server
+            subscription. The module has a different lifecycle than SUSE Linux Enterprise
+            Server itself. Packages in the this module are usually supported for at
+            most three years. </p>"
+          :release_stage: alpha
+          :eula_url: ''
+          :repositories:
+          - id: 2553
+            url: https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15/x86_64/product_source/
+            name: SLE-Module-Legacy15-Source-Pool
+            distro_target: sle-15-x86_64
+            description: SLE-Module-Legacy15-Source-Pool for sle-15-x86_64
+            enabled: false
+            autorefresh: false
+            installer_updates: false
+          - id: 2552
+            url: https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15/x86_64/product_debug/
+            name: SLE-Module-Legacy15-Debuginfo-Pool
+            distro_target: sle-15-x86_64
+            description: SLE-Module-Legacy15-Debuginfo-Pool for sle-15-x86_64
+            enabled: false
+            autorefresh: false
+            installer_updates: false
+          - id: 2551
+            url: https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15/x86_64/product/
+            name: SLE-Module-Legacy15-Pool
+            distro_target: sle-15-x86_64
+            description: SLE-Module-Legacy15-Pool for sle-15-x86_64
+            enabled: true
+            autorefresh: false
+            installer_updates: false
+          - id: 2550
+            url: https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15/x86_64/update_debug/
+            name: SLE-Module-Legacy15-Debuginfo-Updates
+            distro_target: sle-15-x86_64
+            description: SLE-Module-Legacy15-Debuginfo-Updates for sle-15-x86_64
+            enabled: false
+            autorefresh: true
+            installer_updates: false
+          - id: 2549
+            url: https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15/x86_64/update/
+            name: SLE-Module-Legacy15-Updates
+            distro_target: sle-15-x86_64
+            description: SLE-Module-Legacy15-Updates for sle-15-x86_64
+            enabled: true
+            autorefresh: true
+            installer_updates: false
+          :product_type: module
+          :predecessor_ids: []
+          :shortname: Legacy-Module
+          :recommended: false
+          :extensions: []
+        modifiable: true
+      - &4 !ruby/object:SUSE::Connect::Remote::Product
+        table:
+          :id: 1611
+          :name: Public Cloud Module
+          :identifier: sle-module-public-cloud
+          :former_identifier: sle-module-public-cloud
+          :version: '15'
+          :release_type: 
+          :arch: x86_64
+          :friendly_name: Public Cloud Module 15 x86_64 (ALPHA)
+          :product_class: 7261-ALPHA
+          :cpe: cpe:/o:suse:sle-module-public-cloud:15
+          :free: true
+          :description: "<p> The Public Cloud Module is a collection of tools that
+            enables you to create and manage cloud images from the commandline on
+            SUSE Linux Enterprise Server. When building your own images with KIWI
+            or SUSE Studio, initialization code specific to the target cloud is included
+            in that image. </p> <p> Access to the Public Cloud Module is included
+            in your SUSE Linux Enterprise Server subscription. The module has a different
+            lifecycle than SUSE Linux Enterprise Server itself; please check the Release
+            Notes for further details. </p>"
+          :release_stage: alpha
+          :eula_url: ''
+          :repositories:
+          - id: 2676
+            url: https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15/x86_64/product_debug/
+            name: SLE-Module-Public-Cloud15-Debuginfo-Pool
+            distro_target: sle-15-x86_64
+            description: SLE-Module-Public-Cloud15-Debuginfo-Pool for sle-15-x86_64
+            enabled: false
+            autorefresh: false
+            installer_updates: false
+          - id: 2675
+            url: https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15/x86_64/product/
+            name: SLE-Module-Public-Cloud15-Pool
+            distro_target: sle-15-x86_64
+            description: SLE-Module-Public-Cloud15-Pool for sle-15-x86_64
+            enabled: true
+            autorefresh: false
+            installer_updates: false
+          - id: 2674
+            url: https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15/x86_64/update_debug/
+            name: SLE-Module-Public-Cloud15-Debuginfo-Updates
+            distro_target: sle-15-x86_64
+            description: SLE-Module-Public-Cloud15-Debuginfo-Updates for sle-15-x86_64
+            enabled: false
+            autorefresh: true
+            installer_updates: false
+          - id: 2673
+            url: https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15/x86_64/update/
+            name: SLE-Module-Public-Cloud15-Updates
+            distro_target: sle-15-x86_64
+            description: SLE-Module-Public-Cloud15-Updates for sle-15-x86_64
+            enabled: true
+            autorefresh: true
+            installer_updates: false
+          :product_type: module
+          :predecessor_ids: []
+          :shortname: Public-Cloud-Module
+          :recommended: false
+          :extensions: []
+        modifiable: true
+      - &5 !ruby/object:SUSE::Connect::Remote::Product
+        table:
+          :id: 1582
+          :name: SUSE Linux Enterprise High Availability Extension
+          :identifier: sle-ha
+          :former_identifier: sle-ha
+          :version: '15'
+          :release_type: 
+          :arch: x86_64
+          :friendly_name: SUSE Linux Enterprise High Availability Extension 15 x86_64
+            (ALPHA)
+          :product_class: SLE-HAE-X86-ALPHA
+          :cpe: cpe:/o:suse:sle-ha:15
+          :free: false
+          :description: SUSE Linux High Availability Extension provides mature, industry-leading
+            open-source high-availability clustering technologies that are easy to
+            set up and use. It can be deployed in physical and/or virtual environments,
+            and can cluster physical servers, virtual servers, or any combination
+            of the two to suit your business’ needs.
+          :release_stage: alpha
+          :eula_url: ''
+          :repositories:
+          - id: 2558
+            url: https://updates.suse.com/SUSE/Products/SLE-HA/15/x86_64/product_source/
+            name: SLE-HA15-Source-Pool
+            distro_target: sle-ha-15-x86_64
+            description: SLE-HA15-Source-Pool for sle-ha-15-x86_64
+            enabled: false
+            autorefresh: false
+            installer_updates: false
+          - id: 2557
+            url: https://updates.suse.com/SUSE/Products/SLE-HA/15/x86_64/product_debug/
+            name: SLE-HA15-Debuginfo-Pool
+            distro_target: sle-ha-15-x86_64
+            description: SLE-HA15-Debuginfo-Pool for sle-ha-15-x86_64
+            enabled: false
+            autorefresh: false
+            installer_updates: false
+          - id: 2556
+            url: https://updates.suse.com/SUSE/Products/SLE-HA/15/x86_64/product/
+            name: SLE-HA15-Pool
+            distro_target: sle-ha-15-x86_64
+            description: SLE-HA15-Pool for sle-ha-15-x86_64
+            enabled: true
+            autorefresh: false
+            installer_updates: false
+          - id: 2555
+            url: https://updates.suse.com/SUSE/Updates/SLE-HA/15/x86_64/update_debug/
+            name: SLE-HA15-Debuginfo-Updates
+            distro_target: sle-ha-15-x86_64
+            description: SLE-HA15-Debuginfo-Updates for sle-ha-15-x86_64
+            enabled: false
+            autorefresh: true
+            installer_updates: false
+          - id: 2554
+            url: https://updates.suse.com/SUSE/Updates/SLE-HA/15/x86_64/update/
+            name: SLE-HA15-Updates
+            distro_target: sle-ha-15-x86_64
+            description: SLE-HA15-Updates for sle-ha-15-x86_64
+            enabled: true
+            autorefresh: true
+            installer_updates: false
+          :product_type: extension
+          :predecessor_ids: []
+          :shortname: SLEHA15
+          :recommended: false
+          :extensions: []
+        modifiable: true
+  depends_on: 
+- &7 !ruby/object:Registration::Addon
+  pure_addon: *1
+  depends_on: *2
+- !ruby/object:Registration::Addon
+  pure_addon: *3
+  depends_on: *2
+- !ruby/object:Registration::Addon
+  pure_addon: *4
+  depends_on: *2
+- !ruby/object:Registration::Addon
+  pure_addon: *5
+  depends_on: *2
+- !ruby/object:Registration::Addon
+  pure_addon: *6
+  depends_on: *7
+- !ruby/object:Registration::Addon
+  pure_addon: *8
+  depends_on: *7
+- !ruby/object:Registration::Addon
+  pure_addon: *9
+  depends_on: *7

--- a/test/migration_repos_workflow_spec.rb
+++ b/test/migration_repos_workflow_spec.rb
@@ -20,13 +20,18 @@ describe Registration::UI::MigrationReposWorkflow do
       allow(Yast::Linuxrc).to receive(:InstallInf)
     end
 
-    shared_examples "media based upgrade" do
+    shared_examples "media based upgrade" do |popup_method|
       before do
-        expect(Yast::Linuxrc).to receive(:InstallInf).with("UpgradeMedia").and_return("1")
+        expect(Yast::Linuxrc).to receive(:InstallInf).with("MediaUpgrade").and_return("1")
       end
 
       it "displays a popup about media based upgrade" do
-        expect(Yast::Popup).to receive(:LongMessage).with(/media based upgrade/i)
+        if popup_method == :LongMessageGeometry
+          expect(Yast::Popup).to receive(popup_method).with(/media based upgrade/i,
+            anything, anything)
+        else
+          expect(Yast::Popup).to receive(popup_method).with(/media based upgrade/i)
+        end
         subject.run_sequence
       end
 
@@ -49,7 +54,7 @@ describe Registration::UI::MigrationReposWorkflow do
         end
 
         context "the 'media_upgrade=1' boot parameter is used" do
-          include_examples "media based upgrade"
+          include_examples "media based upgrade", :LongMessageGeometry
         end
       end
     end
@@ -107,7 +112,7 @@ describe Registration::UI::MigrationReposWorkflow do
         end
 
         context "the 'media_upgrade=1' boot parameter is used" do
-          include_examples "media based upgrade"
+          include_examples "media based upgrade", :LongMessage
         end
       end
     end


### PR DESCRIPTION
# Summary

This pull request contains several improvements, I merged them into a single PR as they are quite simple. If you want to see the isolated changes then review each commit separately.

Note: I'll ask Ken for a feedback, maybe something will change a bit later, esp. the texts.


## Media Based Upgrade

Media based upgrade can be triggered by `upgrade=1` (or selecting the "Upgrade" item in the boot menu) and using `media_upgrade=1` boot option.

#### Unregistered System

When the system is not registered user have to use the DVD media for system upgrade and this message will be displayed:

![media_upgrade](https://user-images.githubusercontent.com/907998/32038752-aca08e32-ba2b-11e7-9bcf-bc216c119fb6.png)

#### Registered System

If the system is registered we display some additional warning. The problem is that in this case we do not upgrade the registration status. The system is then in inconsistent state and we cannot provide support for this.

This is an experimental feature for experienced users who are aware of the consequences and are able to fix the possible problems manually.

![media_upgrade_registered](https://user-images.githubusercontent.com/907998/32038814-fb06c8a2-ba2b-11e7-8902-ed0690a3ad83.png)

## Preselect the Recommended Addons

SCC provides an extra flag indicating whether the addon should be selected by default. This solves the issue with the SLE15 module split and also addresses the old problem we had on ARM ([fate#320679](https://fate.suse.com/320679)) which we can remove now. See [bsc#1056413](https://bugzilla.suse.com/show_bug.cgi?id=1056413) for more details.

This feature is already implemented on the SCC side, currently the "Base system" module is marked as recommended.

The preselection behaves as if the modules were selected by the user. Unfortunately we cannot use the "auto selected" state as it would be removed by the dependency solver (nothing requires that module).

![preselect_addons](https://user-images.githubusercontent.com/907998/32039081-f7e40f1c-ba2c-11e7-972e-7a2affcb9567.png)

## Improved Help Text

The help text has been improved to include the description of the check box states. This is especially important for the "auto selected" state which is specific to this dialog and is not used anywhere else.

The help text is properly displayed in both graphical and text mode.

##### Graphical Mode

![addon_help_gui](https://user-images.githubusercontent.com/907998/32039210-7f0b9fc8-ba2d-11e7-8f04-5114a3b04e14.png)

##### Text Mode
![addon_help_tui](https://user-images.githubusercontent.com/907998/32039219-85138782-ba2d-11e7-83dd-d5ef4545fddc.png)

## Test Update

I have updated the SLE15 addons fixture (`sle15_addons.yaml`) with the latest real data from the SCC to test the real current state. 
