### PR TITLE
Small fix for displaying the AY summary (in installed system) (bsc#1065432)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Oct 27 11:18:10 UTC 2017 - lslezak@suse.cz
+
+- Do not crash when displaying the AutoYaST summary in installed
+  system (bsc#1065432)
+- 4.0.10
+
+-------------------------------------------------------------------
 Thu Oct 26 12:42:18 UTC 2017 - lslezak@suse.cz
 
 - Use the correct install.inf key for media base upgrade (related

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.9
+Version:        4.0.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/scc_auto.rb
+++ b/src/clients/scc_auto.rb
@@ -42,6 +42,7 @@ require "registration/ui/autoyast_config_workflow"
 # A helper used to get ERB out of Yast context
 class RegistrationErbRendered
   include Yast::I18n
+  include ERB::Util
 
   def initialize(config)
     @config = config
@@ -55,7 +56,6 @@ end
 module Yast
   class SccAutoClient < Client
     include Yast::Logger
-    include ERB::Util
     extend Yast::I18n
 
     # popup message

--- a/src/clients/scc_auto.rb
+++ b/src/clients/scc_auto.rb
@@ -27,7 +27,6 @@
 #
 
 require "yast/suse_connect"
-require "erb"
 
 require "registration/storage"
 require "registration/sw_mgmt"
@@ -38,20 +37,7 @@ require "registration/connect_helpers"
 require "registration/ssl_certificate"
 require "registration/url_helpers"
 require "registration/ui/autoyast_config_workflow"
-
-# A helper used to get ERB out of Yast context
-class RegistrationErbRendered
-  include Yast::I18n
-  include ERB::Util
-
-  def initialize(config)
-    @config = config
-  end
-
-  def render_erb_template(file)
-    ::Registration::Helpers.render_erb_template(file, binding)
-  end
-end
+require "registration/erb_renderer.rb"
 
 module Yast
   class SccAutoClient < Client
@@ -152,7 +138,7 @@ module Yast
     # Create a textual summary
     # @return [String] summary of the current configuration
     def summary
-      RegistrationErbRendered.new(@config).render_erb_template("autoyast_summary.erb")
+      Registration::ErbRenderer.new(@config).render_erb_template("autoyast_summary.erb")
     end
 
     # set the registration URL from the profile or use the default

--- a/src/lib/registration/erb_renderer.rb
+++ b/src/lib/registration/erb_renderer.rb
@@ -1,0 +1,34 @@
+# ***************************************************************************
+# Copyright (c) 2017 SUSE LLC
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+# ***************************************************************************
+
+require "erb"
+require "yast"
+require "yast/i18n"
+
+module Registration
+  # A helper used to get ERB out of Yast context
+  # to workaround the YaST::String and ::String conflict inside Ruby Erb
+  class ErbRenderer
+    include Yast::I18n
+    include ERB::Util
+
+    def initialize(config)
+      @config = config
+    end
+
+    def render_erb_template(file)
+      ::Registration::Helpers.render_erb_template(file, binding)
+    end
+  end
+end

--- a/test/erb_renderer_spec.rb
+++ b/test/erb_renderer_spec.rb
@@ -1,0 +1,11 @@
+require_relative "spec_helper"
+
+require "registration/erb_renderer.rb"
+
+describe Registration::ErbRenderer do
+  subject { Registration::ErbRenderer.new(::Registration::Storage::Config.instance) }
+
+  it "renders an ERB file" do
+    expect(subject.render_erb_template("autoyast_summary.erb")).to be_a(String)
+  end
+end

--- a/test/erb_renderer_spec.rb
+++ b/test/erb_renderer_spec.rb
@@ -3,9 +3,15 @@ require_relative "spec_helper"
 require "registration/erb_renderer.rb"
 
 describe Registration::ErbRenderer do
-  subject { Registration::ErbRenderer.new(::Registration::Storage::Config.instance) }
+  subject { Registration::ErbRenderer.new(Registration::Storage::Config.instance) }
 
-  it "renders an ERB file" do
+  it "renders the ERB file as String" do
     expect(subject.render_erb_template("autoyast_summary.erb")).to be_a(String)
+  end
+
+  it "renders the AY configuration" do
+    result = subject.render_erb_template("autoyast_summary.erb")
+    # test the header, it is always present regardless the actual AY configuration
+    expect(result).to include("Product Registration")
   end
 end


### PR DESCRIPTION
- The original issue was caused by not moving the relevant `include` call, the fix itself was trivial, see the first commit (6afb30a)
- Introduced in Ruby 2.4 fix (https://github.com/yast/yast-registration/pull/332) so SLE12 is not affected
- I have refactored the code and added an unit test for that
- Also tested manually
- Related bug report: [bsc#1065432](https://bugzilla.suse.com/show_bug.cgi?id=1065432)