### PR TITLE
Do not preselect the default addons when some addon is already registered

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Oct 27 12:44:58 UTC 2017 - lslezak@suse.cz
+
+- Do not preselect the default addons when some addon is already
+  registered (avoid selecting again when going back after
+  registration) (related to bsc#1056413)
+- 4.0.11
+
+-------------------------------------------------------------------
 Fri Oct 27 11:18:10 UTC 2017 - lslezak@suse.cz
 
 - Do not crash when displaying the AutoYaST summary in installed

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -322,8 +322,8 @@ module Registration
       end
 
       def preselect_recommended
-        # something is already selected, keep the user selection unchanged
-        return if !Addon.selected.empty? || @addons.nil?
+        # something is already selected/registered, keep the user selection unchanged
+        return if !Addon.selected.empty? || !Addon.registered.empty? || @addons.nil?
 
         @addons.each do |a|
           next unless a.recommended

--- a/test/addon_selection_dialog_test.rb
+++ b/test/addon_selection_dialog_test.rb
@@ -68,9 +68,12 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
     context "a recommended addon is available" do
       let(:registration) { double(activated_products: [], get_addon_list: [recommended_addon]) }
 
-      it "preselects the recommended addons" do
-        expect(Registration::Addon).to receive(:selected).and_return([]).at_least(:once)
+      before do
+        allow(Registration::Addon).to receive(:selected).and_return([])
+        allow(Registration::Addon).to receive(:registered).and_return([])
+      end
 
+      it "preselects the recommended addons" do
         # check the displayed content
         expect_any_instance_of(described_class).to receive(:RichText)
           .with(Yast::Term.new(:id, :items), /checkbox-on\.png/).and_call_original
@@ -83,6 +86,20 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       it "does not preselect the recommended addons if something is already selected" do
         # just to have an unknown, but "selected" addon for the Addon.selected call
         expect(Registration::Addon).to receive(:selected).and_return([addon_generator])
+          .at_least(:once)
+
+        # check the displayed content
+        expect_any_instance_of(described_class).to receive(:RichText)
+          .with(Yast::Term.new(:id, :items), /checkbox-off\.png/).and_call_original
+        expect_any_instance_of(described_class).to_not receive(:RichText)
+          .with(Yast::Term.new(:id, :items), /checkbox-on\.png/)
+
+        subject.run(registration)
+      end
+
+      it "does not preselect the recommended addons if something is already registered" do
+        # just to have an unknown, but "registered" addon for the Addon.registered call
+        expect(Registration::Addon).to receive(:registered).and_return([addon_generator])
           .at_least(:once)
 
         # check the displayed content


### PR DESCRIPTION
- Avoid selecting again when going back after registration
- Related to [bsc#1056413](https://bugzilla.suse.com/show_bug.cgi?id=1056413)
- 4.0.11