### PR TITLE
Fixed registering addons in AutoYaST (bsc#1065438) + Recommended BETA Addons

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -4,6 +4,9 @@ Wed Nov 22 09:52:16 UTC 2017 - lslezak@suse.cz
 - AutoYaST fixes (bsc#1065438):
   - fixed addon registration order
   - automatically register the dependant addons
+- Preselect also the recommended beta addons, display them by
+  default even when the beta filter is active
+  (related to bsc#1056413)
 - 4.0.13
 
 -------------------------------------------------------------------

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Nov 22 09:52:16 UTC 2017 - lslezak@suse.cz
+
+- AutoYaST fixes (bsc#1065438):
+  - fixed addon registration order
+  - automatically register the dependant addons
+- 4.0.13
+
+-------------------------------------------------------------------
 Wed Nov  8 14:36:05 CET 2017 - schubi@suse.de
 
 - Changed warning text if user has skipped registration.

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.12
+Version:        4.0.13
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -44,6 +44,8 @@ module Registration
       def reset!
         @cached_addons = nil
         @registered    = nil
+        @selected      = nil
+        @auto_selected = nil
       end
 
       # list of registered add-ons

--- a/src/lib/registration/autoyast_addons.rb
+++ b/src/lib/registration/autoyast_addons.rb
@@ -28,6 +28,8 @@ module Registration
     # @param registration [Registration::Registration] the Registration object to use
     #   for registering the addons
     def initialize(requested_addons, registration)
+      textdomain "registration"
+
       self.requested_addons = requested_addons
       self.registration = registration
     end

--- a/src/lib/registration/autoyast_addons.rb
+++ b/src/lib/registration/autoyast_addons.rb
@@ -1,0 +1,125 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+#
+
+require "yast"
+
+module Registration
+  # This class handles the AutoYaST addons
+  class AutoyastAddons
+    include Yast::I18n
+
+    attr_accessor :requested_addons, :selected_addons
+
+    Yast.import "Report"
+
+    # Constructor
+    # @param requested_addons [Array<Hash<String,String>>] the addons configuration
+    #   from the AutoYaST profile
+    # @param registration [Registration::Registration] the Registration object to use
+    #   for registering the addons
+    def initialize(requested_addons, registration)
+      self.requested_addons = requested_addons
+      self.registration = registration
+    end
+
+    # read the available addons from the server, sort the addons from the profile
+    # according to the dependencies
+    def select
+      # ask the server for all available addons (with UI feedback)
+      all_addons = registration_ui.get_available_addons
+
+      # remove the addons marked as not available
+      rejected = all_addons.reject! { |a| a.available? == false }
+      log.info("Not available addons: #{rejected.map(&:label).inspect}") if rejected
+
+      # select the requested addons from the available addons
+      self.selected_addons = select_addons(all_addons)
+    end
+
+    # register the selected addons, the #select method must be called before
+    def register
+      regcodes = collect_reg_codes
+      registration_ui.register_addons(selected_addons, regcodes)
+    end
+
+  private
+
+    attr_writer :selected_addons
+    attr_accessor :registration
+
+    # select the requested addons
+    # @param all_addons [Array<Registration::Addon>] all addons available on the server
+    def select_addons(all_addons)
+      # select the requested addons from the AY profile
+      requested_addons.each do |addon|
+        server_addon = all_addons.find do |a|
+          a.identifier == addon["name"] && a.version == addon["version"] &&
+            a.arch == addon["arch"]
+        end
+
+        if server_addon
+          # mark it as selected
+          server_addon.selected
+        else
+          # otherwise report an error
+          report_missing_addon(addon)
+        end
+      end
+
+      ordered_addons
+    end
+
+    # report error about a missing addon
+    # @param addon [Hash]
+    def report_missing_addon(addon)
+      log.error("Unavailable addon: #{addon.inspect}")
+      Yast::Report.Error(
+        # TRANSLATORS: %s is an addon name (including version and arch)
+        # from the AutoYast XML installation profile
+        _("Addon '%s'\nis not available for registration.") % \
+          "#{addon["name"]}-#{addon["version"]}-#{addon["arch"]}"
+      )
+    end
+
+    # Order the addons according to thier dependencies, the result is sorted
+    # in the registration order. The result also includes the dependant addons
+    # (even not specified in the profile).
+    # @return [Array<Registration::Addon>]
+    def ordered_addons
+      # include also the automatically selected dependent modules/extensions
+      ret = Addon.registration_order(Addon.selected + Addon.auto_selected)
+
+      log.info("Addons to register: #{ret.map(&:label).inspect}")
+
+      ret
+    end
+
+    # collect the registration codes specified in the profile
+    # @return [Hash<String,String>] mapping "product identifier" => "reg code"
+    def collect_reg_codes
+      ret = {}
+
+      requested_addons.each do |a|
+        ret[a["name"]] = a["reg_code"] if a["reg_code"]
+      end
+
+      log.info("Found reg codes for addons: #{ret.keys.inspect}")
+
+      ret
+    end
+
+    def registration_ui
+      @registration_ui ||= RegistrationUI.new(registration)
+    end
+  end
+end

--- a/test/addon_selection_dialog_test.rb
+++ b/test/addon_selection_dialog_test.rb
@@ -206,6 +206,16 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
         allow(subject).to receive(:RichText).and_call_original
         dialog.run
       end
+
+      it "displays recommended beta add-ons" do
+        allow(addon).to receive(:beta_release?).and_return(true)
+        allow(addon).to receive(:registered?).and_return(false)
+        allow(addon).to receive(:recommended).and_return(true)
+        allow(Registration::Addon).to receive(:find_all).and_return([addon])
+        expect(subject).to receive(:RichText).with(Yast::Term.new(:id, :items), /#{addon.name}/)
+        allow(subject).to receive(:RichText).and_call_original
+        dialog.run
+      end
     end
 
     context "when there is no beta versions to filter" do

--- a/test/autoyast_addons_spec.rb
+++ b/test/autoyast_addons_spec.rb
@@ -1,0 +1,99 @@
+#! /usr/bin/env rspec
+
+require_relative "spec_helper"
+require "yaml"
+
+describe Registration::AutoyastAddons do
+  let(:registration) { double("registration") }
+  let(:unsorted_addons) do
+    [
+      # deliberately in a wrong registration order, the "sle-module-basesystem"
+      # module needs to be registered first
+      { "name" => "sle-module-desktop-applications", "version" => "15", "arch" => "x86_64" },
+      { "name" => "sle-module-basesystem", "version" => "15", "arch" => "x86_64" }
+    ]
+  end
+
+  # it depends on the "sle-module-basesystem" which is not listed here
+  let(:incomplete_addons) do
+    ["name" => "sle-module-desktop-applications", "version" => "15",
+    "arch" => "x86_64"]
+  end
+
+  # the basesystem module does not need a reg. key in reality
+  # but let's use it in this test for the simplicity
+  let(:addons_with_reg_key) do
+    ["name" => "sle-module-basesystem", "version" => "15", "arch" => "x86_64",
+      "reg_code" => "abcd42"]
+  end
+
+  # some dummy non-existing addon to test error handling
+  let(:missing_addons) do
+    ["name" => "non-existing-module", "version" => "42", "arch" => "x86_64"]
+  end
+
+  # the addons to register in the expcted correct order
+  let(:expected_registration_order) { ["sle-module-basesystem", "sle-module-desktop-applications"] }
+
+  before do
+    addons = load_yaml_fixture("sle15_addons.yaml")
+    allow(Registration::Addon).to receive(:find_all).and_return(addons)
+    allow(registration).to receive(:get_addon_list).and_return(addons)
+  end
+
+  after do
+    Registration::Addon.reset!
+  end
+
+  describe "#select" do
+    it "sorts the addons according to their dependencies" do
+      ayaddons = Registration::AutoyastAddons.new(unsorted_addons, registration)
+      ayaddons.select
+
+      expect(ayaddons.selected_addons.map(&:identifier)).to eq(expected_registration_order)
+    end
+
+    it "automatically selects the dependent addons" do
+      ayaddons = Registration::AutoyastAddons.new(incomplete_addons, registration)
+      ayaddons.select
+
+      expect(ayaddons.selected_addons.map(&:identifier)).to eq(expected_registration_order)
+    end
+
+    it "reports error for not available addons" do
+      expect(Yast::Report).to receive(:Error).with(/is not available for registration/)
+
+      ayaddons = Registration::AutoyastAddons.new(missing_addons, registration)
+      ayaddons.select
+    end
+  end
+
+  describe "#register" do
+    it "registers the selected addons" do
+      expect(registration).to receive(:register_product).with(
+        "name" => "sle-module-basesystem", "reg_code" => nil, "arch" => "x86_64",
+        "version" => "15"
+      ).ordered
+      expect(registration).to receive(:register_product).with(
+        "name" => "sle-module-desktop-applications", "reg_code" => nil,
+        "arch" => "x86_64", "version" => "15"
+      ).ordered
+
+      ayaddons = Registration::AutoyastAddons.new(unsorted_addons, registration)
+      ayaddons.select
+      ayaddons.register
+    end
+
+    it "registers the selected addon using the provided reg. key" do
+      expect(registration).to receive(:register_product).with(
+        "name" => "sle-module-basesystem", "reg_code" => "abcd42", "arch" => "x86_64",
+        "version" => "15"
+      )
+
+      ayaddons = Registration::AutoyastAddons.new(addons_with_reg_key, registration)
+      ayaddons.select
+      ayaddons.register
+    end
+  end
+
+end


### PR DESCRIPTION
## AutoYaST Fix

- Fixes https://bugzilla.suse.com/show_bug.cgi?id=1065438
  - Reorders the addons according to the dependencies
  - Automaticaly selects the dependent addons
- Added unit test


### Tested manually with this snippet in AY profile:

```xml
<addons config:type="list">
    <addon>
        <name>sle-module-server-applications</name>
        <version>15</version>
        <arch>x86_64</arch>
    </addon>
    <addon>
        <name>sle-module-development-tools</name>
        <version>15</version>
        <arch>x86_64</arch>
    </addon>
    <addon>
        <name>sle-module-desktop-applications</name>
        <version>15</version>
        <arch>x86_64</arch>
    </addon>
    <addon>
        <name>sle-module-basesystem</name>
        <version>15</version>
        <arch>x86_64</arch>
    </addon>
</addons>
```

The addons were registered successfully in the correct order, a snippet from `y2log` :

```
Addons to register: ["Basesystem Module 15 x86_64 (BETA)",
"Desktop Applications Module 15 x86_64 (BETA)",
"Server Applications Module 15 x86_64 (BETA)",
"Development Tools Module 15 x86_64 (BETA)"]
```

## Preselect Also the Recommended BETA Addons

Originally the recommended BETA addons were not selected and were hiddnen. With an additional path the BETA addons are selected and displayed even when the BETA filter is active. (To not add the addons silently without user notification.)

![recommended_beta_addon](https://user-images.githubusercontent.com/907998/33140912-bd79f9e6-cfb1-11e7-8aa3-545746d6311b.png)
