### PR TITLE
Added devel/dump_ay_addons.rb script

### DIFF
--- a/devel/dump_ay_addons.rb
+++ b/devel/dump_ay_addons.rb
@@ -18,7 +18,7 @@ def dump_addon(a)
 
   ret = prefix + "<!-- #{a.name} -->\n"
 
-  ret +=  prefix + "<!-- Depends on: #{a.depends_on.name} -->\n" if a.depends_on
+  ret += prefix + "<!-- Depends on: #{a.depends_on.name} -->\n" if a.depends_on
 
   ret += prefix + "<name>#{a.identifier}</name>\n" +
     prefix + "<version>#{a.version}</version>\n" +

--- a/devel/dump_ay_addons.rb
+++ b/devel/dump_ay_addons.rb
@@ -1,0 +1,45 @@
+#! /usr/bin/ruby
+
+# This is a simple generator for creating the addons list displayed at
+# https://github.com/yast/yast-registration/wiki/Available-SCC-Extensions-for-Use-in-Autoyast
+# from the /var/log/YaST2/registration_addons.yml file.
+
+require "yast"
+require "registration/addon"
+require "registration/addon_sorter"
+
+require_relative "yaml_workaround"
+
+INDENT_WIDTH = 4
+
+# convert addon data to an XML document snippet
+def dump_addon(a)
+  prefix = " " * INDENT_WIDTH
+
+  ret = prefix + "<!-- #{a.name} -->\n" +
+    prefix + "<name>#{a.identifier}</name>\n" +
+    prefix + "<version>#{a.version}</version>\n" +
+    prefix + "<arch>#{a.arch}</arch>\n"
+
+  ret += prefix + "<reg_code>REG_CODE_REQUIRED</reg_code>\n" unless a.free
+
+  ret
+end
+
+if ARGV[0]
+  addons = YAML.load_file(ARGV[0])
+  # sort the addons
+  addons.sort!(&::Registration::ADDON_SORTER)
+
+  puts "<addons config:type=\"list\">"
+  puts addons.map { |a| dump_addon(a) }.join("\n")
+  puts "</addons>"
+else
+  puts "This is a simple generator for AutoYaST addons configuration."
+  puts
+  puts "Usage: dump_ay_addons <file_path>"
+  puts
+  puts "  <file_path> is the addons dump file, originally stored at"
+  puts "  /var/log/YaST2/registration_addons.yml"
+  exit 1
+end

--- a/devel/dump_ay_addons.rb
+++ b/devel/dump_ay_addons.rb
@@ -16,8 +16,11 @@ INDENT_WIDTH = 4
 def dump_addon(a)
   prefix = " " * INDENT_WIDTH
 
-  ret = prefix + "<!-- #{a.name} -->\n" +
-    prefix + "<name>#{a.identifier}</name>\n" +
+  ret = prefix + "<!-- #{a.name} -->\n"
+
+  ret +=  prefix + "<!-- Depends on: #{a.depends_on.name} -->\n" if a.depends_on
+
+  ret += prefix + "<name>#{a.identifier}</name>\n" +
     prefix + "<version>#{a.version}</version>\n" +
     prefix + "<arch>#{a.arch}</arch>\n"
 

--- a/devel/dump_reader.rb
+++ b/devel/dump_reader.rb
@@ -6,28 +6,7 @@
 require "yast"
 require "registration/addon"
 
-# Monkey Patch to workaround issue in ruby 2.4 Psych (bsc#1048526)
-# when fixed or if suseconnect is changed then remove
-# (copied from test/spec_helper.rb)
-module SUSE
-  module Connect
-    module Remote
-      class Product
-        alias_method :initialize_orig, :initialize
-        def initialize(arg = {})
-          initialize_orig(arg)
-        end
-      end
-
-      class Service
-        alias_method :initialize_orig, :initialize
-        def initialize(arg = { "product" => {} })
-          initialize_orig(arg)
-        end
-      end
-    end
-  end
-end
+require_relative "yaml_workaround"
 
 INDENT_WIDTH = 2
 

--- a/devel/yaml_workaround.rb
+++ b/devel/yaml_workaround.rb
@@ -1,0 +1,22 @@
+# Monkey Patch to workaround issue in ruby 2.4 Psych (bsc#1048526)
+# when fixed or if suseconnect is changed then remove
+# (copied from test/spec_helper.rb)
+module SUSE
+  module Connect
+    module Remote
+      class Product
+        alias_method :initialize_orig, :initialize
+        def initialize(arg = {})
+          initialize_orig(arg)
+        end
+      end
+
+      class Service
+        alias_method :initialize_orig, :initialize
+        def initialize(arg = { "product" => {} })
+          initialize_orig(arg)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I just have used this script to generate the list of available addons for [SLES12-SP3](https://github.com/yast/yast-registration/wiki/Available-SCC-Extensions-for-Use-in-Autoyast#sles-12-sp3) and the [SLES15](https://github.com/yast/yast-registration/wiki/Available-SCC-Extensions-for-Use-in-Autoyast#sles-15) at the wiki page.