### PR TITLE
Adjust the base product selection (related to bsc#1071742)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Jan 16 12:39:14 UTC 2018 - lslezak@suse.cz
+
+- Adjust the base product selection so it is not influenced by
+  a possibly changed repository priority, use the
+  "system-installation()" provides just like the other code in the
+  installer (related to bsc#1071742)
+- 4.0.17
+
+-------------------------------------------------------------------
 Fri Jan 12 10:07:29 UTC 2018 - mfilka@suse.com
 
 - bnc#1075723

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.16
+Version:        4.0.17
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -117,6 +117,8 @@ module Registration
     end
 
     def self.find_base_product
+      # FIXME: refactor the code to use Y2Packager::Product
+
       # just for debugging:
       return FAKE_BASE_PRODUCT if ENV["FAKE_BASE_PRODUCT"]
 
@@ -151,10 +153,10 @@ module Registration
 
     # Evaluate the product if it is a base product depending on the current
     # system status.
-    # @param p Hash the product from pkg-bindings
+    # @param p [Hash] the product from pkg-bindings
     # @param selected [Boolean,nil] is any product selected?
     # @param installed [Boolean,nil] is any product istalled?
-    # @return [Boolean]
+    # @return [Boolean] true if it is a base product
     def self.evaluate_product(p, selected, installed)
       if Stage.initial && Mode.auto
         Yast.import "AutoinstFunctions"

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -297,6 +297,13 @@ describe Registration::SwMgmt do
   end
 
   describe ".find_base_product" do
+    before do
+      allow(Y2Packager::ProductReader).to receive(:installation_package_mapping)
+        .and_return("SLES"     => "skelcd-control-SLES",
+                    "SLED"     => "skelcd-control-SLED",
+                    "SLES_SAP" => "skelcd-control-SLES_SAP")
+    end
+
     context "in installed system" do
       let(:products) { load_yaml_fixture("products_legacy_installation.yml") }
       it "returns installed products" do

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -298,6 +298,7 @@ describe Registration::SwMgmt do
 
   describe ".find_base_product" do
     before do
+      # mapping of the "system-installation()" provides
       allow(Y2Packager::ProductReader).to receive(:installation_package_mapping)
         .and_return("SLES"     => "skelcd-control-SLES",
                     "SLED"     => "skelcd-control-SLED",
@@ -317,8 +318,11 @@ describe Registration::SwMgmt do
     context "at installation" do
       let(:products) { load_yaml_fixture("products_sp2_update.yml") }
 
-      it "returns the selected product if a product is selected" do
+      before do
         allow(Yast::Stage).to receive(:initial).and_return(true)
+      end
+
+      it "returns the selected product if a product is selected" do
         expect(Yast::Pkg).to receive(:ResolvableProperties).and_return(products).exactly(3).times
         # sanity check: just make sure the fixture contains the expected data
         expect(products.any? { |p| p["status"] == :selected })
@@ -328,8 +332,6 @@ describe Registration::SwMgmt do
       end
 
       it "returns the product from the installation medium if no product is selected" do
-        allow(Yast::Stage).to receive(:initial).and_return(true)
-
         # patch the fixture so no product is selected
         products2 = products.dup
         products2[3]["status"] = :available
@@ -339,6 +341,15 @@ describe Registration::SwMgmt do
         expect(Yast::Pkg).to receive(:ResolvableProperties).and_return(products2).exactly(3).times
         # the SLES product in the list is installed
         expect(subject.find_base_product).to eq(products[3])
+      end
+
+      it "ignores a selected product not marked by the `system-installation()` provides" do
+        products3 = [{ "name" => "foo", "status" => :selected },
+                     { "name" => "SLES", "status" => :selected }]
+
+        expect(Yast::Pkg).to receive(:ResolvableProperties).and_return(products3).exactly(3).times
+        # the selected product is ignored, the result is nil
+        expect(subject.find_base_product).to eq(products3[1])
       end
     end
   end


### PR DESCRIPTION
Ensure that the base product selection is not influenced by a possibly changed repository priority, use the `system-installation()` provides instead of the hardcoded repository `0`, just like the other code in the installer.

Fix for bug [bsc#1071742](https://bugzilla.suse.com/show_bug.cgi?id=1071742) might lower the priority of the initial installation repository and then the base product is selected from the `Packages` DVD instead from the `Installer` DVD (with ID 0) and the code then does not work correctly.

- Skips the products which are not marked by the `system-installation()` provides as a base product (only in installation, in an installed system these provides might not be available)
- Tested manually in the latest build
- 4.0.17