### PR TITLE
Try base product registration code first

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Jan 17 14:24:58 UTC 2018 - mvidner@suse.com
+
+- Try base product registration code first (bsc#1075551).
+  Some add-ons/extensions are not free but can be registered
+  using their base product's registration code. Try it automatically
+  so that the user does not have to enter it again.
+- 4.0.18
+
+-------------------------------------------------------------------
 Tue Jan 16 12:39:14 UTC 2018 - lslezak@suse.cz
 
 - Adjust the base product selection so it is not influenced by

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.17
+Version:        4.0.18
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -103,7 +103,8 @@ module Registration
           check_smt_api(error_msg)
           report_error(message_prefix + _("Connection to registration server failed."), error_msg)
         when 422
-          if silent_reg_code_mismatch && e.message =~ /does not include the requested product/
+          if silent_reg_code_mismatch && e.response.body["error"] =~
+              /does not include the requested product/
             log.info "Reg code does not work for this product, that's OK"
           else
             # Error popup

--- a/test/connect_helpers_spec.rb
+++ b/test/connect_helpers_spec.rb
@@ -4,7 +4,7 @@ require_relative "spec_helper"
 require "registration/connect_helpers"
 
 # helper for creating the SCC API error exceptions
-def api_error(code: 400, headers: {}, body: "")
+def api_error(code: 400, headers: {}, body: {})
   SUSE::Connect::ApiError.new(
     OpenStruct.new(
       code:    code,
@@ -120,6 +120,22 @@ describe Registration::ConnectHelpers do
     [400, 401, 422, 500, 42].each do |error_code|
       context "error #{error_code} is received" do
         include_examples "reports error and returns false", api_error(code: error_code)
+      end
+    end
+
+    context "'silent_reg_code_mismatch' parameter is set and a mismatch error occurs" do
+      before do
+        allow(Registration::UrlHelpers).to receive(:registration_url)
+          .and_return(SUSE::Connect::YaST::DEFAULT_URL)
+      end
+
+      it "does not report an error and returns false" do
+        msg = "Subscription does not include the requested product 'Fountain Wristwatch'"
+        exc = api_error(code: 422, body: { "localized_error" => msg })
+
+        expect(Yast::Report).to_not receive(:Error)
+        expect(helpers.catch_registration_errors(silent_reg_code_mismatch: true) { raise exc })
+          .to eq(false)
       end
     end
 

--- a/test/connect_helpers_spec.rb
+++ b/test/connect_helpers_spec.rb
@@ -131,7 +131,7 @@ describe Registration::ConnectHelpers do
 
       it "does not report an error and returns false" do
         msg = "Subscription does not include the requested product 'Fountain Wristwatch'"
-        exc = api_error(code: 422, body: { "localized_error" => msg })
+        exc = api_error(code: 422, body: { "error" => msg })
 
         expect(Yast::Report).to_not receive(:Error)
         expect(helpers.catch_registration_errors(silent_reg_code_mismatch: true) { raise exc })

--- a/test/registration_ui_test.rb
+++ b/test/registration_ui_test.rb
@@ -127,21 +127,22 @@ describe "Registration::RegistrationUI" do
       it "does not ask for reg. code if all addons are free" do
         # user is not asked for any reg. code
         expect(Registration::UI::AddonRegCodesDialog).to_not receive(:run)
-        allow(registration_ui).to receive(:register_selected_addons) { true }
+        allow(registration_ui).to receive(:try_register_addons).and_return([])
 
         # Register Legacy module
         registration_ui.register_addons([addon_legacy], {})
       end
 
       it "returns :next if everything goes fine" do
-        allow(registration_ui).to receive(:register_selected_addons) { true }
+        allow(registration_ui).to receive(:try_register_addons).and_return([])
         expect(registration_ui.register_addons([addon_legacy], {})).to eq :next
       end
 
       it "returns :back if some registration failed" do
         # FIXME: Since the code is not functional, there is currently no cleaner
         # way to mock a registration failure
-        allow(registration_ui).to receive(:register_selected_addons).and_return false
+        # FIXME: (Some weeks later...) Now there is?
+        allow(registration_ui).to receive(:try_register_addons).and_return([addon_legacy])
 
         expect(registration_ui.register_addons([addon_legacy], {})).to eq :back
       end
@@ -152,7 +153,7 @@ describe "Registration::RegistrationUI" do
 
       it "returns :next if everything goes fine" do
         allow(Registration::UI::AddonRegCodesDialog).to receive(:run).and_return(:next)
-        allow(registration_ui).to receive(:register_selected_addons).with(any_args) { true }
+        allow(registration_ui).to receive(:try_register_addons).with(any_args).and_return([])
 
         selected_addons = [addon_HA_GEO, addon_SDK]
         expect(registration_ui.register_addons(selected_addons, {})).to eq :next
@@ -161,8 +162,8 @@ describe "Registration::RegistrationUI" do
       it "keep asking for a reg. code if some reg. code failed" do
         # Stub user interaction for reg codes
         allow(Registration::UI::AddonRegCodesDialog).to receive(:run).and_return(:next, :next)
-        allow(registration_ui).to receive(:register_selected_addons)
-          .with(any_args).and_return(false, true)
+        allow(registration_ui).to receive(:try_register_addons)
+          .with(any_args).and_return([addon_SDK], [])
 
         # Register HA-GEO + SDK addons
         selected_addons = [addon_HA_GEO, addon_SDK]

--- a/test/registration_ui_test.rb
+++ b/test/registration_ui_test.rb
@@ -174,6 +174,25 @@ describe "Registration::RegistrationUI" do
 
   end
 
+  describe "#try_register_addons" do
+    context "for a non-free product without a known regcode" do
+      it "uses the base product regcode" do
+        selected_addons = [addon_HA_GEO]
+
+        options = Registration::Storage::InstallationOptions.instance
+        expect(options).to receive(:reg_code).and_return("my_regcode_for_base")
+
+        expect(registration_ui)
+          .to receive(:register_selected_addon)
+          .with(addon_HA_GEO, "my_regcode_for_base", silent_reg_code_mismatch: true)
+          .and_return(false)
+
+        expect(registration_ui.send(:try_register_addons, selected_addons, {}))
+          .to eq(selected_addons)
+      end
+    end
+  end
+
   describe "#migration_products" do
     let(:installed_products) { load_yaml_fixture("installed_sles12_product.yml") }
     let(:migration_products) { load_yaml_fixture("migration_to_sles12_sp1.yml") }

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -25,10 +25,12 @@ if ENV["COVERAGE"]
   end
 end
 
-libdir = File.expand_path("../../src/lib", __FILE__)
-$LOAD_PATH.unshift(libdir)
+srcdir = File.expand_path("../../src", __FILE__)
+y2dirs = ENV.fetch("Y2DIR", "").split(":")
+ENV["Y2DIR"] = y2dirs.unshift(srcdir).join(":")
 
-ENV["Y2DIR"] = File.expand_path("../../src", __FILE__)
+libdir = "#{srcdir}/lib"
+$LOAD_PATH.unshift(libdir)
 
 require "suse/connect"
 


### PR DESCRIPTION
Card: https://trello.com/c/K5b1qBj7
Quoting [bsc#1075551](https://bugzilla.suse.com/show_bug.cgi?id=1075551):
> When registering SLES4SAP, the same registration code as for the base product needs to be re-entered for the HA extension, which is part of the subscription.
>
>The installer should assure that for these modules registration code is not asked again.
>
> The idea is: Try to register non-free extensions with the same product as base system and only ask for those for which registration does not succeed.

Now, the twist in the plot is that the above problem is *hypothetical*, because until now, SLES4SAP is using a *free* variant of the HA extension and the problem does not occur.

I have fixed it anyway. At least I think so, I could not test the real thing. I tested the SLES + HA scenario, which uses a *paid* HA which is *not* included with SLES, and the code behaves in a way that I believe will work out.
