### PR TITLE
SLE15 Offline Migration (fate#323163)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 26 16:05:55 UTC 2018 - lslezak@suse.cz
+
+- Initial support for the SLE15 offline migration (fate#323163)
+- 4.0.19
+
+-------------------------------------------------------------------
 Wed Jan 17 14:24:58 UTC 2018 - mvidner@suse.com
 
 - Try base product registration code first (bsc#1075551).

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.18
+Version:        4.0.19
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/clients/inst_migration_repos.rb
+++ b/src/lib/registration/clients/inst_migration_repos.rb
@@ -39,8 +39,8 @@ module Registration
 
       # Pass the target directory to SUSEConnect
       def set_target_path
-        destdir = Yast::Installation.destdir
-        return if destdir.nil? || destdir == "/"
+        destdir = Yast::Installation.destdir || "/"
+        return if destdir == "/"
 
         log.info("Setting SUSEConnect target directory: #{destdir}")
         SUSE::Connect::System.filesystem_root = destdir

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -167,6 +167,18 @@ module Registration
       migrations
     end
 
+    def offline_migration_products(installed_products, target_base_product)
+      log.info "Offline migration for: #{target_base_product}."
+      migration_paths = []
+      ConnectHelpers.catch_registration_errors do
+        migration_paths = SUSE::Connect::YaST
+                          .system_offline_migrations(installed_products, target_base_product)
+      end
+
+      log.info "Received possible migrations paths: #{migration_paths}"
+      migration_paths
+    end
+
     # Get the list of updates for a base product or self_update_id if defined
     #
     # @return [Array<String>] List of URLs of updates repositories.

--- a/src/lib/registration/registration_ui.rb
+++ b/src/lib/registration/registration_ui.rb
@@ -197,6 +197,18 @@ module Registration
       end
     end
 
+    # According to the official SUSE terminology, "online" refers to a running
+    # system and (offline) to a system that is not running. It's NOT about the
+    # network connectivity
+    def offline_migration_products(products, base_product)
+      Yast::Popup.Feedback(
+        _(CONTACTING_MESSAGE),
+        _("Loading Migration Products...")
+      ) do
+        registration.offline_migration_products(products, base_product)
+      end
+    end
+
     # Register the selected addons, asks for reg. codes if required, known_reg_codes
     # @param selected_addons [Array<Addon>] list of addons selected for registration,
     #   successfully registered addons are removed from the list

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -251,7 +251,7 @@ module Registration
       # loads online or offline migrations depending on the system state
       # @return [Symbol] workflow symbol (:next or :abort)
       def load_migration_products
-        if Yast::Stage.initial && Yast::Mode.update
+        if Yast::Stage.initial
           load_migration_products_offline
         else
           load_migration_products_online
@@ -542,10 +542,8 @@ module Registration
 
         # restore the initial status, the package update will be turned on later again
         Yast::Pkg.PkgReset
-        changed = Yast::Pkg.ResolvableProperties("", :package, "").select do |p|
-          p["status"] != :available || p["status"] != :installed
-        end
-        changed.each { |p| Yast::Pkg.PkgNeutral(p["name"]) }
+        changed = Yast::Pkg.GetPackages(:removed, true) + Yast::Pkg.GetPackages(:selected, true)
+        changed.each { |p| Yast::Pkg.PkgNeutral(p) }
 
         log.info("Upgraded base product: #{product.inspect}")
         product

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -33,6 +33,7 @@ module Registration
 
       Yast.import "Sequencer"
       Yast.import "Mode"
+      Yast.import "Stage"
       Yast.import "SourceDialogs"
       Yast.import "Linuxrc"
 
@@ -114,6 +115,7 @@ module Registration
         "load_migration_products"      => {
           abort:  :abort,
           cancel: :abort,
+          empty:  :back,
           next:   "select_migration_products"
         },
         "select_migration_products"    => {
@@ -188,6 +190,11 @@ module Registration
       def not_installed_products_check
         SwMgmt.init(true)
 
+        # FIXME: do the check also at offline upgrade?
+        # Currently it reads the addons for the new SLES15 which is not
+        # registered yet and fails.
+        return :next if Yast::Stage.initial
+
         Addon.find_all(registration)
 
         UI::NotInstalledProductsDialog.run
@@ -240,16 +247,59 @@ module Registration
         products.concat(addons)
       end
 
-      # load migration products for the installed products from the registration server
+      # load migration products for the installed products from the registration server,
+      # loads online or offline migrations depending on the system state
       # @return [Symbol] workflow symbol (:next or :abort)
       def load_migration_products
-        log.info "Loading migration products from server"
+        if Yast::Stage.initial && Yast::Mode.update
+          load_migration_products_offline
+        else
+          load_migration_products_online
+        end
+      end
+
+      # load migration products for the installed products from the registration server
+      # for the currently running system (online migration)
+      # @return [Symbol] workflow symbol (:next or :abort)
+      def load_migration_products_online
+        log.info "Loading online migration products from the server..."
         self.migrations = registration_ui.migration_products(products)
 
         if migrations.empty?
           # TRANSLATORS: Error message
           Yast::Report.Error(_("No migration product found."))
           return :abort
+        end
+
+        :next
+      end
+
+      # load migration products for the installed products from the registration server
+      # on a system that is not running (offline migration)
+      # @return [Symbol] workflow symbol (:next or :abort)
+      def load_migration_products_offline
+        base_product = upgraded_base_product
+        if !base_product
+          # TRANSLATORS: Error message
+          Yast::Report.Error(_("Cannot find a base product to upgrade."))
+          return :empty
+        end
+
+        remote_product = OpenStruct.new(
+          arch:         base_product.arch.to_s,
+          identifier:   base_product.name,
+          version:      base_product.version,
+          # FIXME: not supported by Y2Packager::Product yet
+          release_type: nil
+        )
+
+        log.info "Loading offline migration products from the server..."
+        self.migrations = registration_ui.offline_migration_products(products, remote_product)
+
+        if migrations.empty?
+          # TRANSLATORS: Error message
+          Yast::Report.Error(_("No migration product found."))
+          return :empty
         end
 
         :next
@@ -482,6 +532,23 @@ module Registration
             "will not be updated and the system will be still registered " \
             "using the previous product. The packages from the registration " \
             "repositories can conflict with the new packages.</p>")
+      end
+
+      def upgraded_base_product
+        # temporarily run the update mode to let the solver select the product for upgrade
+        # (this will correctly handle possible product renames)
+        Yast::Pkg.PkgUpdateAll({})
+        product = Y2Packager::Product.selected_base
+
+        # restore the initial status, the package update will be turned on later again
+        Yast::Pkg.PkgReset
+        changed = Yast::Pkg.ResolvableProperties("", :package, "").select do |p|
+          p["status"] != :available || p["status"] != :installed
+        end
+        changed.each { |p| Yast::Pkg.PkgNeutral(p["name"]) }
+
+        log.info("Upgraded base product: #{product.inspect}")
+        product
       end
     end
   end


### PR DESCRIPTION
- See [FATE#323163](https://fate.suse.com/323163) for more details
- Let's ignore the CodeClimate complains, we need this for Beta6
- Also the unit tests will be added later
- Tested manually in an SLES12-SP3 -> SLES15 upgrade

## TODO

- [x] Depens on an SCC fix for ~~[bsc#1076513](https://bugzilla.suse.com/show_bug.cgi?id=1076513)~~ [FIXED]
- [x] Depens on an SCC fix for ~~[bsc#1076611](https://bugzilla.suse.com/show_bug.cgi?id=1076611)~~ [FIXED]
- [x] The product reading needs [this patch](https://github.com/yast/yast-yast2/pull/672) and [this another patch](https://github.com/yast/yast-packager/pull/311) [MERGED]

## Testing

If something goes wrong during the migration the old system might become broken (unregistered). In that case boot the old system and use commands
- `SUSEConnect --status-text` to check the registration status
- If the system is not registered, but was properly registered before then you can use `SUSEConnect --rollback` command to restore the previous registration. If it fails use `SUSEConnect --cleanup` and do a full registration again.
