### PR TITLE
Support for the SLE11 migration

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb  2 14:20:22 UTC 2018 - lslezak@suse.cz
+
+- Fixes for the SLE11 -> SLE15 offline migration (fate#323395)
+- 4.0.20
+
+-------------------------------------------------------------------
 Fri Jan 26 16:05:55 UTC 2018 - lslezak@suse.cz
 
 - Initial support for the SLE15 offline migration (fate#323163)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.19
+Version:        4.0.20
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/clients/inst_migration_repos.rb
+++ b/src/lib/registration/clients/inst_migration_repos.rb
@@ -42,23 +42,8 @@ module Registration
         destdir = Yast::Installation.destdir || "/"
         return if destdir == "/"
 
-        log.info("Setting SUSEConnect target directory: #{destdir}")
-        SUSE::Connect::System.filesystem_root = destdir
-
-        # copy the old config from the upgraded system to inst-sys
-        # to correctly work in the SMT case
-        # FIXME: this should not be needed, it should be possible to read
-        # the config from the /mnt directly...
-        target_path = SUSE::Connect::YaST::DEFAULT_CONFIG_FILE
-        source_path = File.join(destdir, target_path)
-
-        if File.exist?(source_path)
-          log.info("Copying #{source_path} -> #{target_path}")
-          ::FileUtils.cp(source_path, target_path)
-        elsif File.exist?(target_path)
-          log.info("Removing #{target_path}...")
-          ::FileUtils.rm(target_path)
-        end
+        # copy the old NCC/SCC credentials to inst-sys
+        SwMgmt.copy_old_credentials(destdir)
       end
     end
   end

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -208,11 +208,7 @@ module Registration
 
     # Full path to the SCC credentials file.
     def self.credentials_path
-      # Use /mnt only at upgrade, during installation /mnt is not yet mounted
-      # at the registration step, the credentials are later copied to
-      # the target system
-      prefix = (Yast::Stage.initial && Yast::Mode.update) ? Yast::Installation.destdir : "/"
-      File.join(prefix, SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE)
+      SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE
     end
 
     def self.is_registered?

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -36,6 +36,7 @@ module Registration
       Yast.import "Stage"
       Yast.import "SourceDialogs"
       Yast.import "Linuxrc"
+      Yast.import "Installation"
 
       # the constructor
       def initialize
@@ -215,7 +216,10 @@ module Registration
           return :abort
         end
 
-        merge_registered_addons
+        # do not read addons when upgrading from an NCC based system (SLE11)
+        ncc_file = File.join(Yast::Installation.destdir,
+          SUSE::Connect::YaST::DEFAULT_CREDENTIALS_DIR, "NCCcredentials")
+        merge_registered_addons unless File.exist?(ncc_file)
 
         log.info "Products to migrate: #{products}"
 
@@ -293,7 +297,8 @@ module Registration
           release_type: nil
         )
 
-        log.info "Loading offline migration products from the server..."
+        log.info "Loading offline migrations for target product: #{remote_product.inspect}"
+        log.info "Installed products: #{products.inspect}"
         self.migrations = registration_ui.offline_migration_products(products, remote_product)
 
         if migrations.empty?

--- a/test/inst_migration_repos_spec.rb
+++ b/test/inst_migration_repos_spec.rb
@@ -6,21 +6,8 @@ require "registration/clients/inst_migration_repos"
 
 describe Registration::Clients::InstMigrationRepos do
   before do
-    allow(SUSE::Connect::System).to receive(:filesystem_root=)
     allow(Yast::Installation).to receive(:destdir).and_return("/")
     allow(Yast::WFM).to receive(:call)
-  end
-
-  it "passes the target path to SUSEConnect" do
-    destdir = "/foo"
-    expect(Yast::Installation).to receive(:destdir).and_return(destdir).at_least(:once)
-    expect(SUSE::Connect::System).to receive(:filesystem_root=).with(destdir)
-    subject.main
-  end
-
-  it "does not pass the path if it is \"/\"" do
-    expect(SUSE::Connect::System).to_not receive(:filesystem_root=)
-    subject.main
   end
 
   it "runs the standard \"migration_repos\" client" do

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -271,7 +271,7 @@ describe Registration::Registration do
       expect(Registration::Registration.is_registered?).to eq(true)
     end
 
-    it "returns false if the global credentials file exists" do
+    it "returns false if the global credentials file does not exist" do
       expect(File).to receive(:exist?).with(SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE)
         .and_return(false)
       expect(Registration::Registration.is_registered?).to eq(false)

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -77,20 +77,6 @@ describe Registration::Registration do
       expect(registered_service).to eq(service)
     end
 
-    it "honors the target system prefix at upgrade" do
-      expect(Yast::Mode).to receive(:update).and_return(true)
-      expect(Yast::Stage).to receive(:initial).and_return(true)
-      expect(Yast::Installation).to receive(:destdir).and_return(destdir)
-
-      expect(File).to receive(:exist?).with(/\A#{Regexp.escape(destdir)}\//)
-        .and_return(true)
-
-      expect(File).to receive(:read).with(/\A#{Regexp.escape(destdir)}\//)
-        .and_return("username=SCC_foo\npassword=bar")
-
-      subject.send(yast_method, product)
-    end
-
     it "does not add the target system prefix if not at upgrade" do
       allow(Yast::Mode).to receive(:update).and_return(false)
       allow(Yast::Stage).to receive(:initial).and_return(false)
@@ -279,23 +265,16 @@ describe Registration::Registration do
   end
 
   describe ".is_registered?" do
-    let(:destdir) { "/foo" }
-
-    it "honors the target system prefix at upgrade" do
-      expect(Yast::Mode).to receive(:update).and_return(true)
-      expect(Yast::Stage).to receive(:initial).and_return(true)
-      expect(Yast::Installation).to receive(:destdir).and_return(destdir)
-      expect(File).to receive(:exist?).with(/\A#{Regexp.escape(destdir)}/)
-      Registration::Registration.is_registered?
-    end
-
-    it "does not add the prefix if not at upgrade" do
-      allow(Yast::Mode).to receive(:update).and_return(false)
-      allow(Yast::Stage).to receive(:initial).and_return(false)
-      expect(Yast::Installation).to_not receive(:destdir)
+    it "returns true if the global credentials file exists" do
       expect(File).to receive(:exist?).with(SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE)
-      Registration::Registration.is_registered?
+        .and_return(true)
+      expect(Registration::Registration.is_registered?).to eq(true)
     end
 
+    it "returns false if the global credentials file exists" do
+      expect(File).to receive(:exist?).with(SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE)
+        .and_return(false)
+      expect(Registration::Registration.is_registered?).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
- Always copy the credentials file to inst-sys (reuse the existing code, removed some duplication)
- As the credentials are copied we do not need to handle the `/mnt` prefix in specific cases
- Manually tested with SLES11-SP3 and SLES11-SP4
- Also manually tested with SLES12-SP3 to avoid regressions