### PR TITLE
Do no send the product release version at upgrade (bsc#1079051)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb  7 12:26:17 UTC 2018 - lslezak@suse.cz
+
+- Do no send the product release version ("11.4-1.109") at upgrade,
+  send only the major and minor version ("11.4") (bsc#1079051)
+- 4.0.21
+
+-------------------------------------------------------------------
 Fri Feb  2 14:20:22 UTC 2018 - lslezak@suse.cz
 
 - Fixes for the SLE11 -> SLE15 offline migration (fate#323395)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.20
+Version:        4.0.21
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -213,11 +213,13 @@ module Registration
     # convert a libzypp Product Hash to a SUSE::Connect::Remote::Product object
     # @param product [Hash] product Hash obtained from pkg-bindings
     # @return [SUSE::Connect::Remote::Product] the remote product
-    def self.remote_product(product)
+    def self.remote_product(product, version_release: true)
       OpenStruct.new(
         arch:         product["arch"],
         identifier:   product["name"],
-        version:      product["version"],
+        # the "version_version" key does not contain the release number,
+        # e.g. if "version" is "11.4-1.109" then "version_version" is just "11.4"
+        version:      version_release ? product["version"] : product["version_version"],
         release_type: product["release_type"]
       )
     end

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -207,7 +207,8 @@ module Registration
         log.info "Loading installed products"
 
         self.products = ::Registration::SwMgmt.installed_products.map do |product|
-          ::Registration::SwMgmt.remote_product(product)
+          # report the installed products without the version release (bsc#1079051#c11)
+          ::Registration::SwMgmt.remote_product(product, version_release: false)
         end
 
         if products.empty?

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -456,4 +456,30 @@ describe Registration::SwMgmt do
       end
     end
   end
+
+  describe ".remote_product" do
+    let(:product) do
+      {
+        "name"            => "SLES",
+        "arch"            => "x86_64",
+        "version"         => "12.1-1.47",
+        "version_version" => "12.1",
+        "flavor"          => "DVD"
+      }
+    end
+
+    it "converts a Hash into OpenStruct" do
+      expect(subject.remote_product(product)).to be_an(OpenStruct)
+    end
+
+    it "includes the version release" do
+      v = subject.remote_product(product).version
+      expect(v).to include("-")
+    end
+
+    it "does not includes the version release if 'version_release' parameter is false" do
+      v = subject.remote_product(product, version_release: false).version
+      expect(v).to_not include("-")
+    end
+  end
 end


### PR DESCRIPTION
- Fix for the SLES11 offline upgrade, see the [details](https://bugzilla.suse.com/show_bug.cgi?id=1079051#c11)
- Send only the major and minor version to SCC (`11.4` instead of `11.4-1.109`)
- 4.0.21