### PR TITLE
Offline migration from SLE11 to SLE15 (fate#323395)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 19 13:08:55 UTC 2018 - lslezak@suse.cz
+
+- Support for offline migration from SLE11 to SLE15 (fate#323395)
+- 4.0.22
+
+-------------------------------------------------------------------
 Wed Feb  7 12:26:17 UTC 2018 - lslezak@suse.cz
 
 - Do no send the product release version ("11.4-1.109") at upgrade,

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -2,6 +2,8 @@
 Mon Feb 19 13:08:55 UTC 2018 - lslezak@suse.cz
 
 - Support for offline migration from SLE11 to SLE15 (fate#323395)
+- Fixed evaluating the migration summary for renamed or merged
+  products (bsc#1080913)
 - 4.0.22
 
 -------------------------------------------------------------------

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -55,8 +55,8 @@ BuildRequires:  rubygem(yast-rake) >= 0.2.5
 BuildRequires:  rubygem(rspec)
 BuildRequires:  rubygem(suse-connect) >= 0.2.22
 BuildRequires:  yast2-slp >= 3.1.9
-# packager/product_patterns.rb
-BuildRequires:  yast2-packager >= 3.1.95
+# updated product renames
+BuildRequires:  yast2-packager >= 4.0.40
 BuildRequires:  yast2-update >= 3.1.36
 
 BuildArch:      noarch

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.21
+Version:        4.0.22
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -328,8 +328,7 @@ module Registration
       msg = _("Check that this system is known to the registration server.")
 
       # probably missing NCC->SCC sync, display a hint unless SMT is used
-      if UrlHelpers.registration_url == SUSE::Connect::YaST::DEFAULT_URL ||
-          UrlHelpers.registration_url.nil?
+      if [nil, SUSE::Connect::YaST::DEFAULT_URL].include?(UrlHelpers.registration_url)
 
         msg += "\n\n"
         # TRANSLATORS: additional hint for an error message

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -328,7 +328,9 @@ module Registration
       msg = _("Check that this system is known to the registration server.")
 
       # probably missing NCC->SCC sync, display a hint unless SMT is used
-      if UrlHelpers.registration_url == SUSE::Connect::YaST::DEFAULT_URL
+      if UrlHelpers.registration_url == SUSE::Connect::YaST::DEFAULT_URL ||
+          UrlHelpers.registration_url.nil?
+
         msg += "\n\n"
         # TRANSLATORS: additional hint for an error message
         msg += _("If you are upgrading from SLE11 make sure the SCC server\n" \

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -150,7 +150,7 @@ module Registration
     def activated_products
       log.info "Reading activated products..."
       activated = SUSE::Connect::YaST.status(connect_params).activated_products || []
-      log.info "Activated products: #{activated.map(&:id)}"
+      log.info "Activated products: #{activated.map(&:identifier)}"
       activated
     end
 

--- a/src/lib/registration/registration_ui.rb
+++ b/src/lib/registration/registration_ui.rb
@@ -300,6 +300,24 @@ module Registration
       Yast::Popup.YesNo(msg) ? addons : []
     end
 
+    # Read the activated products for this system
+    # @return [Array] list of activated products
+    def activated_products
+      activations = []
+
+      ConnectHelpers.catch_registration_errors do
+        Yast::Popup.Feedback(
+          _(CONTACTING_MESSAGE),
+          # TRANSLATORS: progress label
+          _("Reading the Activated Products...")
+        ) do
+          activations = registration.activated_products
+        end
+      end
+
+      activations
+    end
+
   private
 
     attr_accessor :registration

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -326,8 +326,8 @@ module Registration
       #   products on the server
       # @return [Boolean] true = continue with the migration, false = stop
       def migration_confirmed?(base_product, activations)
-        # version without the release, e.g. "15-0" => "15"
-        base_product_version = base_product.version.split("-", 2).first
+        # split the release version, e.g. "15-0" => ["15", "0"]
+        base_product_version, _release = base_product.version.split("-", 2)
         activated_base = activations.find do |a|
           a.identifier == base_product.name && a.version == base_product_version
         end

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -256,6 +256,12 @@ module Registration
       # loads online or offline migrations depending on the system state
       # @return [Symbol] workflow symbol (:next or :abort)
       def load_migration_products
+        # just for easier debugging log the currently registered products
+        ConnectHelpers.catch_registration_errors do
+          activated = registration.activated_products.map(&:friendly_name)
+          log.info("Activated products: #{activated.inspect}")
+        end
+
         if Yast::Stage.initial
           load_migration_products_offline
         else

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -321,6 +321,9 @@ module Registration
 
       # check if the target producte has been already activated, if yes
       # require user confirmation for the migration (though it will very likely fail)
+      # @param base_product [Y2Packager::Product] the base product to which migrate to
+      # @param activations [Array<SUSE::Connect::Remote::Product>] already activated
+      #   products on the server
       # @return [Boolean] true = continue with the migration, false = stop
       def migration_confirmed?(base_product, activations)
         # version without the release, e.g. "15-0" => "15"

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -32,6 +32,7 @@ module Registration
       Yast.import "Report"
       Yast.import "HTML"
       Yast.import "GetInstArgs"
+      Yast.import "AddOnProduct"
 
       attr_accessor :selected_migration, :manual_repo_selection, :installed_products
 
@@ -181,7 +182,11 @@ module Registration
 
         details = sorted_migrations[idx].map do |product|
           installed = installed_products.find do |installed_product|
-            installed_product["name"] == product.identifier
+            product_name = installed_product["name"]
+
+            # the same product or a renamed product
+            product_name == product.identifier ||
+              Yast::AddOnProduct.renamed?(product_name, product.identifier)
           end
 
           products_to_migrate << installed if installed

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -182,11 +182,7 @@ module Registration
 
         details = sorted_migrations[idx].map do |product|
           installed = installed_products.find do |installed_product|
-            product_name = installed_product["name"]
-
-            # the same product or a renamed product
-            product_name == product.identifier ||
-              Yast::AddOnProduct.renamed?(product_name, product.identifier)
+            same_products?(installed_product, product)
           end
 
           products_to_migrate << installed if installed
@@ -197,11 +193,24 @@ module Registration
         installed_products.each do |installed_product|
           next if products_to_migrate.include?(installed_product)
 
-          details << "<li>" + product_summary(nil, installed_product) + "</li>"
+          migrated_product = sorted_migrations[idx].find do |product|
+            same_products?(installed_product, product)
+          end
+
+          details << "<li>" + product_summary(migrated_product, installed_product) + "</li>"
         end
 
         # TRANSLATORS: RichText header (details for the selected item)
-        "<h3>" + _("Migration Summary") + "</h3><ul>" + details.join + "</ul>"
+        det = "<h3>" + _("Migration Summary") + "</h3><ul>" + details.join + "</ul>"
+        puts det
+        det
+      end
+
+      def same_products?(installed, migrated)
+        product_name = installed["name"]
+        # the same product or a renamed product
+        product_name == migrated.identifier ||
+          Yast::AddOnProduct.renamed?(product_name, migrated.identifier)
       end
 
       # create a product summary for the details widget

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -201,9 +201,9 @@ module Registration
         end
 
         # TRANSLATORS: RichText header (details for the selected item)
-        det = "<h3>" + _("Migration Summary") + "</h3><ul>" + details.join + "</ul>"
-        puts det
-        det
+        details = "<h3>" + _("Migration Summary") + "</h3><ul>" + details.join("\n") + "</ul>"
+        log.info("Migration summary: #{details}")
+        details
       end
 
       def same_products?(installed, migrated)

--- a/test/connect_helpers_spec.rb
+++ b/test/connect_helpers_spec.rb
@@ -152,7 +152,7 @@ describe Registration::ConnectHelpers do
       end
 
       it "does not display the NCC sync hint when not using SCC" do
-        expect(Registration::UrlHelpers).to receive(:registration_url)
+        expect(Registration::UrlHelpers).to receive(:registration_url).at_least(:once)
           .and_return("https://example.com")
 
         expect(Yast::Report).to_not receive(:Error).with(/Synchronization from NCC to SCC/)

--- a/test/finish_dialog_test.rb
+++ b/test/finish_dialog_test.rb
@@ -31,36 +31,44 @@ describe ::Registration::FinishDialog do
         subject.run("Write")
       end
 
-      it "creates at target system configuration for suse connect" do
-        expect(Registration::Registration).to receive(:is_registered?).once
-          .and_return(true)
-        expect(Yast::WFM).to receive(:Execute)
+      context "the system is registered" do
+        before do
+          expect(Registration::Registration).to receive(:is_registered?).and_return(true)
 
-        expect(Registration::Helpers).to receive(:write_config)
-        expect(Registration::Helpers).to receive(:copy_certificate_to_target)
+          allow(Registration::Helpers).to receive(:write_config)
+          allow(Registration::Helpers).to receive(:copy_certificate_to_target)
+          allow(Registration::RepoStateStorage.instance).to receive(:repositories)
+            .and_return([])
 
-        expect(Registration::RepoStateStorage.instance).to receive(:repositories)
-          .and_return([])
-        expect(Yast::Pkg).to_not receive(:SourceSetEnabled)
+          allow(FileUtils).to receive(:mv)
+          allow(File).to receive(:exist?).and_return(false)
+        end
 
-        subject.run("Write")
-      end
+        it "creates at target system configuration for suse connect" do
+          expect(Registration::Helpers).to receive(:write_config)
+          expect(Registration::Helpers).to receive(:copy_certificate_to_target)
 
-      it "restores the repository setup" do
-        expect(Registration::Registration).to receive(:is_registered?).once
-          .and_return(true)
-        expect(Yast::WFM).to receive(:Execute)
+          subject.run("Write")
+        end
 
-        expect(Registration::Helpers).to receive(:write_config)
-        expect(Registration::Helpers).to receive(:copy_certificate_to_target)
+        it "restores the repository setup" do
+          # changed repository with ID 42, originally enabled
+          repo_state = Registration::RepoState.new(42, true)
+          allow(Registration::RepoStateStorage.instance).to receive(:repositories)
+            .and_return([repo_state])
+          expect(Yast::Pkg).to receive(:SourceSetEnabled).with(42, true)
+          expect(Yast::Pkg).to receive(:SourceSaveAll)
 
-        # changed repository with ID 42, originally enabled
-        repo_state = Registration::RepoState.new(42, true)
-        Registration::RepoStateStorage.instance.repositories = [repo_state]
-        expect(Yast::Pkg).to receive(:SourceSetEnabled).with(42, true)
-        expect(Yast::Pkg).to receive(:SourceSaveAll)
+          subject.run("Write")
+        end
 
-        subject.run("Write")
+        it "removes the old NCC credentials" do
+          ncc_credentials = "/mnt/etc/zypp/credentials.d/NCCcredentials"
+          expect(File).to receive(:exist?).with(ncc_credentials).and_return(true)
+          expect(File).to receive(:delete).with(ncc_credentials)
+
+          subject.run("Write")
+        end
       end
     end
 

--- a/test/fixtures/installed_sles11-sp4_products.yml
+++ b/test/fixtures/installed_sles11-sp4_products.yml
@@ -1,0 +1,48 @@
+---
+- arch: x86_64
+  category: base
+  description: |-
+    SUSE Linux Enterprise offers a comprehensive
+            suite of products built on a single code base.
+            The platform addresses business needs from
+            the smallest thin-client devices to the world’s
+            most powerful high-performance computing
+            and mainframe servers. SUSE Linux Enterprise
+            offers common management tools and technology
+            certifications across the platform, and
+            each product is enterprise-class.
+  display_name: SUSE Linux Enterprise Server 11 SP4
+  download_size: 0
+  eol: 1553990400
+  flags: []
+  flavor: ''
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: SUSE_SLES
+  on_system_by_user: false
+  product_file: "/mnt/etc/products.d/SUSE_SLES.prod"
+  product_line: sles
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-11-x86_64
+  register_urls:
+  - http://register.novell.com/
+  relnotes_url: https://www.suse.com/releasenotes/x86_64/SUSE-SLES/11-SP4/release-notes-sles.rpm
+  relnotes_urls:
+  - https://www.suse.com/releasenotes/x86_64/SUSE-SLES/11-SP4/release-notes-sles.rpm
+  short_name: SLES11_SP4
+  smolt_urls:
+  - http://smolt.novell.com/register.pl
+  source: -1
+  status: :installed
+  summary: SUSE Linux Enterprise Server 11 SP4
+  transact_by: :solver
+  type: base
+  update_urls: []
+  upgrades: []
+  vendor: SUSE LINUX Products GmbH, Nuernberg, Germany
+  version: 11.4-1.109
+  version_epoch: 
+  version_release: '1.109'
+  version_version: '11.4'

--- a/test/fixtures/installed_sles12-sp3_products.yml
+++ b/test/fixtures/installed_sles12-sp3_products.yml
@@ -1,0 +1,196 @@
+---
+- arch: x86_64
+  category: addon
+  description: "<p>\n\tSUSE Linux Enterprise Software Development Kit is the Software\n\tDevelopment
+    Kit for the family of SUSE Linux Enterprise products. It is a\n\tfree of charge
+    extension for partners and customers working with SUSE\n\tLinux Enterprise Server
+    and Desktop and derived products.\n\t</p>\n\t<p>\n\tPackages on the SDK are delivered
+    without L3 support; maintenance updates\n\twill be done for  critical security
+    and critical non-security issues, and\n\twhere needed to remain in sync with packages
+    delivered in the SUSE Linux\n\tEnterprise Server and Desktop products.\n\t</p>\n\t<p>\n\tPackages
+    to rebuild SUSE Linux Enterprise Server are not part of the SUSE\n\tLinux Enterprise
+    Software Development Kit.\n\t</p>"
+  display_name: SUSE Linux Enterprise Software Development Kit 12 SP3
+  download_size: 0
+  eol: 1730332800
+  flags: []
+  flavor: POOL
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: sle-sdk
+  on_system_by_user: true
+  product_file: "/mnt/etc/products.d/sle-sdk.prod"
+  product_line: sle
+  register_flavor: extension
+  register_release: ''
+  register_target: sle-12-x86_64
+  relnotes_url: https://www.suse.com/releasenotes/x86_64/SLE-SDK/12-SP3/release-notes-sdk.rpm
+  relnotes_urls:
+  - https://www.suse.com/releasenotes/x86_64/SLE-SDK/12-SP3/release-notes-sdk.rpm
+  short_name: SDK12-SP3
+  source: -1
+  status: :installed
+  summary: SUSE Linux Enterprise Software Development Kit 12 SP3
+  transact_by: :solver
+  type: addon
+  update_urls: []
+  upgrades: []
+  vendor: SUSE
+  version: 12.3-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '12.3'
+- arch: x86_64
+  category: addon
+  description: |-
+    Via this Module you will have access to a more recent GCC and
+    Toolchain in addition to the default compiler of SUSE Linux Enterprise.
+
+    Access to the Toolchain Module is included in your SUSE Linux
+    Enterprise Server subscription. The module has a different lifecycle than SUSE
+    Linux Enterprise Server itself.  Please check the Release Notes for further
+    details.
+  display_name: Toolchain Module
+  download_size: 0
+  eol: 1730332800
+  flags: []
+  flavor: POOL
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: sle-module-toolchain
+  on_system_by_user: true
+  product_file: "/mnt/etc/products.d/sle-module-toolchain.prod"
+  product_line: sle-module-toolchain
+  register_flavor: module
+  register_release: ''
+  register_target: sle-12-x86_64
+  relnotes_url: ''
+  short_name: Toolchain-Module
+  source: -1
+  status: :installed
+  summary: Toolchain Module
+  transact_by: :solver
+  type: addon
+  update_urls: []
+  upgrades: []
+  vendor: SUSE
+  version: 12-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '12'
+- arch: x86_64
+  category: addon
+  description: "<p>This Module contains several packages revolving around containers
+    \n        and related tools. </p>"
+  display_name: Containers module
+  download_size: 0
+  eol: 1561939200
+  flags: []
+  flavor: POOL
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: sle-module-containers
+  on_system_by_user: true
+  product_file: "/mnt/etc/products.d/sle-module-containers.prod"
+  product_line: sle-module-containers
+  register_flavor: module
+  register_release: ''
+  register_target: sle-12-x86_64
+  relnotes_url: ''
+  short_name: containers-module
+  source: -1
+  status: :installed
+  summary: Containers module
+  transact_by: :solver
+  type: addon
+  update_urls: []
+  upgrades: []
+  vendor: SUSE
+  version: 12-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '12'
+- arch: x86_64
+  category: addon
+  description: "<p>\n\tThe Public Cloud Module is a collection of tools that enables
+    you to\n\tcreate and manage cloud images from the commandline on SUSE Linux\n\tEnterprise
+    Server. When building your own images with KIWI or SUSE\n\tStudio, initialization
+    code specific to the target cloud is included in\n\tthat image.\n\t</p>\n\t<p>\n\tAccess
+    to the Public Cloud Module is included in your SUSE Linux\n\tEnterprise Server
+    subscription. The module has a different lifecycle\n\tthan SUSE Linux Enterprise
+    Server itself; please check the Release\n\tNotes for further details.\n\t</p>"
+  display_name: Public Cloud Module
+  download_size: 0
+  eol: 1509408000
+  flags: []
+  flavor: POOL
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: sle-module-public-cloud
+  on_system_by_user: true
+  product_file: "/mnt/etc/products.d/sle-module-public-cloud.prod"
+  product_line: sle-module-public-cloud
+  register_flavor: module
+  register_release: ''
+  register_target: sle-12-x86_64
+  relnotes_url: ''
+  short_name: Public-Cloud-module
+  source: -1
+  status: :installed
+  summary: Public Cloud Module
+  transact_by: :solver
+  type: addon
+  update_urls: []
+  upgrades: []
+  vendor: SUSE
+  version: 12-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '12'
+- arch: x86_64
+  category: base
+  description: |-
+    SUSE Linux Enterprise offers a comprehensive
+            suite of products built on a single code base.
+            The platform addresses business needs from
+            the smallest thin-client devices to the world's
+            most powerful high-performance computing
+            and mainframe servers. SUSE Linux Enterprise
+            offers common management tools and technology
+            certifications across the platform, and
+            each product is enterprise-class.
+  display_name: SUSE Linux Enterprise Server 12 SP3
+  download_size: 0
+  eol: 1730332800
+  flags: []
+  flavor: DVD
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: SLES
+  on_system_by_user: true
+  product_file: "/mnt/etc/products.d/SLES.prod"
+  product_line: sles
+  register_flavor: ''
+  register_release: ''
+  register_target: sle-12-x86_64
+  relnotes_url: https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12-SP3/release-notes-sles.rpm
+  relnotes_urls:
+  - https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12-SP3/release-notes-sles.rpm
+  short_name: SLES12-SP3
+  source: -1
+  status: :installed
+  summary: SUSE Linux Enterprise Server 12 SP3
+  transact_by: :app_high
+  type: base
+  update_urls: []
+  upgrades: []
+  vendor: SUSE
+  version: 12.3-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '12.3'

--- a/test/fixtures/migration_sles15_activated_products.yml
+++ b/test/fixtures/migration_sles15_activated_products.yml
@@ -1,0 +1,1583 @@
+---
+- !ruby/object:SUSE::Connect::Remote::Product
+  table:
+    :id: 1421
+    :name: SUSE Linux Enterprise Server
+    :identifier: SLES
+    :former_identifier: SLES
+    :version: '12.3'
+    :release_type: 
+    :arch: x86_64
+    :friendly_name: SUSE Linux Enterprise Server 12 SP3 x86_64
+    :product_class: '7261'
+    :cpe: cpe:/o:suse:sles:12:sp3
+    :free: false
+    :description: SUSE Linux Enterprise offers a comprehensive suite of products built
+      on a single code base. The platform addresses business needs from the smallest
+      thin-client devices to the world's most powerful high-performance computing
+      and mainframe servers. SUSE Linux Enterprise offers common management tools
+      and technology certifications across the platform, and each product is enterprise-class.
+    :eula_url: https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product.license/
+    :repositories:
+    - id: 2194
+      url: https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product_source
+      name: SLES12-SP3-Source-Pool
+      distro_target: sle-12-x86_64
+      description: SLES12-SP3-Source-Pool for sle-12-x86_64
+      enabled: false
+      autorefresh: false
+    - id: 2193
+      url: https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product_debug
+      name: SLES12-SP3-Debuginfo-Pool
+      distro_target: sle-12-x86_64
+      description: SLES12-SP3-Debuginfo-Pool for sle-12-x86_64
+      enabled: false
+      autorefresh: false
+    - id: 2192
+      url: https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product
+      name: SLES12-SP3-Pool
+      distro_target: sle-12-x86_64
+      description: SLES12-SP3-Pool for sle-12-x86_64
+      enabled: true
+      autorefresh: false
+    - id: 2190
+      url: https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update_debug
+      name: SLES12-SP3-Debuginfo-Updates
+      distro_target: sle-12-x86_64
+      description: SLES12-SP3-Debuginfo-Updates for sle-12-x86_64
+      enabled: false
+      autorefresh: true
+    - id: 2189
+      url: https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update
+      name: SLES12-SP3-Updates
+      distro_target: sle-12-x86_64
+      description: SLES12-SP3-Updates for sle-12-x86_64
+      enabled: true
+      autorefresh: true
+    :product_type: base
+    :extensions:
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1574
+        :name: SUSE Manager for Retail
+        :identifier: suse-manager-retail
+        :former_identifier: suse-manager-retail
+        :version: '3.1'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Manager for Retail 3.1 x86_64
+        :product_class: SLE-POS-AS-SMRBS-X86
+        :cpe: cpe:/o:suse:suse-manager-retail:3.1
+        :free: false
+        :description: SUSE Manager for Retail
+        :eula_url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Retail/3.1/x86_64/product.license/
+        :repositories:
+        - id: 2523
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Retail/3.1/x86_64/product_source
+          name: SUSE-Manager-Retail-3.1-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Retail-3.1-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2522
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Retail/3.1/x86_64/product_debug
+          name: SUSE-Manager-Retail-3.1-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Retail-3.1-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2521
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Retail/3.1/x86_64/product
+          name: SUSE-Manager-Retail-3.1-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Retail-3.1-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2520
+          url: https://updates.suse.com/SUSE/Updates/SUSE-Manager-Retail/3.1/x86_64/update_debug
+          name: SUSE-Manager-Retail-3.1-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Retail-3.1-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2519
+          url: https://updates.suse.com/SUSE/Updates/SUSE-Manager-Retail/3.1/x86_64/update
+          name: SUSE-Manager-Retail-3.1-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Retail-3.1-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1536
+        :name: SUSE Linux Enterprise Live Patching
+        :identifier: sle-live-patching
+        :former_identifier: sle-live-patching
+        :version: '12.3'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Linux Enterprise Live Patching 12 SP3 x86_64
+        :product_class: SLE-LP
+        :cpe: cpe:/o:suse:sle-live-patching:12:sp3
+        :free: false
+        :description: "<p> SUSE Linux Enterprise Live Patching provides packages to
+          update critical kernel modules live in SUSE Linux Enterprise. With SUSE
+          Linux Enterprise Live Patching, you can perform critical kernel patching
+          without shutting down your system, reducing the need for planned downtime
+          and increasing service availability. <p>"
+        :eula_url: https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12-SP3/x86_64/product.license/
+        :repositories:
+        - id: 2466
+          url: https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12-SP3/x86_64/product_debug
+          name: SLE-Live-Patching12-SP3-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Live-Patching12-SP3-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2465
+          url: https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12-SP3/x86_64/product
+          name: SLE-Live-Patching12-SP3-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Live-Patching12-SP3-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2464
+          url: https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12-SP3/x86_64/update_debug
+          name: SLE-Live-Patching12-SP3-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Live-Patching12-SP3-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2463
+          url: https://updates.suse.com/SUSE/Updates/SLE-Live-Patching/12-SP3/x86_64/update
+          name: SLE-Live-Patching12-SP3-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Live-Patching12-SP3-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1153
+        :name: Web and Scripting Module
+        :identifier: sle-module-web-scripting
+        :former_identifier: sle-module-web-scripting
+        :version: '12'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: Web and Scripting Module 12 x86_64
+        :product_class: MODULE
+        :cpe: cpe:/o:suse:sle-module-web-scripting:12
+        :free: true
+        :description: "<p> The SUSE Linux Enterprise Web and Scripting Module delivers
+          a comprehensive suite of scripting languages, frameworks, and related tools
+          helping developers and systems administrators accelerate the creation of
+          stable, modern web applications, using dynamic languages, such as PHP, Ruby
+          on Rails, and Python. </p> <p> Access to the Web and Scripting Module is
+          included in your SUSE Linux Enterprise Server subscription. The module has
+          a different lifecycle than SUSE Linux Enterprise Server itself: Package
+          versions in the this module are usually supported for at most three years.
+          We are planning to release more recent versions on a schedule of approximately
+          18 month; the exact dates may differ per package. </p>"
+        :eula_url: https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/x86_64/product.license/
+        :repositories:
+        - id: 1992
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/x86_64/product_source
+          name: SLE-Module-Web-Scripting12-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Web-Scripting12-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 1691
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/x86_64/product_debug
+          name: SLE-Module-Web-Scripting12-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Web-Scripting12-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 1690
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/12/x86_64/product
+          name: SLE-Module-Web-Scripting12-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Web-Scripting12-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 1689
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/x86_64/update_debug
+          name: SLE-Module-Web-Scripting12-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Web-Scripting12-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 1688
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/12/x86_64/update
+          name: SLE-Module-Web-Scripting12-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Web-Scripting12-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: module
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1518
+        :name: SUSE Manager Server
+        :identifier: SUSE-Manager-Server
+        :former_identifier: SUSE-Manager-Server
+        :version: '3.1'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Manager Server 3.1 x86_64
+        :product_class: SMS-X86
+        :cpe: cpe:/o:suse:suse-manager-server:3.1
+        :free: false
+        :description: SUSE Manager lets you efficiently manage physical, virtual,
+          and cloud-based Linux systems. It provides automated and cost-effective
+          configuration and software management, asset management, and system provisioning.
+        :eula_url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Server/3.1/x86_64/product.license/
+        :repositories:
+        - id: 2404
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Server/3.1/x86_64/product_source
+          name: SUSE-Manager-Server-3.1-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Server-3.1-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2403
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Server/3.1/x86_64/product_debug
+          name: SUSE-Manager-Server-3.1-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Server-3.1-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2402
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Server/3.1/x86_64/product
+          name: SUSE-Manager-Server-3.1-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Server-3.1-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2401
+          url: https://updates.suse.com/SUSE/Updates/SUSE-Manager-Server/3.1/x86_64/update_debug
+          name: SUSE-Manager-Server-3.1-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Server-3.1-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2400
+          url: https://updates.suse.com/SUSE/Updates/SUSE-Manager-Server/3.1/x86_64/update
+          name: SUSE-Manager-Server-3.1-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Server-3.1-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1678
+        :name: SUSE Cloud Application Platform Tools Module
+        :identifier: sle-module-cap-tools
+        :former_identifier: sle-module-cap-tools
+        :version: '12'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Cloud Application Platform Tools Module 12 x86_64
+        :product_class: MODULE
+        :cpe: cpe:/o:suse:sle-module-cap-tools:12
+        :free: true
+        :description: "<p> The SUSE Cloud Application Platform Tools Module is a collection
+          of tools that enables you to interact with the SUSE Cloud Application Platform
+          product itself, providing the commandline client for instance. </p> <p>
+          Access to the SUSE Cloud Application Platform Tools Module is included in
+          your SUSE Linux Enterprise Server subscription. The module has a different
+          lifecycle than SUSE Linux Enterprise Server itself; please check the Release
+          Notes for further details. </p>"
+        :eula_url: ''
+        :repositories:
+        - id: 2916
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/12/x86_64/product_source
+          name: SLE-Module-CAP-Tools-12-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-CAP-Tools-12-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2915
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/12/x86_64/product_debug
+          name: SLE-Module-CAP-Tools-12-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-CAP-Tools-12-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2914
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/12/x86_64/product
+          name: SLE-Module-CAP-Tools-12-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-CAP-Tools-12-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2913
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/12/x86_64/update_debug
+          name: SLE-Module-CAP-Tools-12-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-CAP-Tools-12-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2912
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/12/x86_64/update
+          name: SLE-Module-CAP-Tools-12-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-CAP-Tools-12-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: module
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1427
+        :name: SUSE Linux Enterprise Software Development Kit
+        :identifier: sle-sdk
+        :former_identifier: sle-sdk
+        :version: '12.3'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Linux Enterprise Software Development Kit 12 SP3 x86_64
+        :product_class: SLE-SDK
+        :cpe: cpe:/o:suse:sle-sdk:12:sp3
+        :free: true
+        :description: "<p> SUSE Linux Enterprise Software Development Kit is the Software
+          Development Kit for the family of SUSE Linux Enterprise products. It is
+          a free of charge extension for partners and customers working with SUSE
+          Linux Enterprise Server and Desktop and derived products. </p> <p> Packages
+          on the SDK are delivered without L3 support; maintenance updates will be
+          done for critical security and critical non-security issues, and where needed
+          to remain in sync with packages delivered in the SUSE Linux Enterprise Server
+          and Desktop products. </p> <p> Packages to rebuild SUSE Linux Enterprise
+          Server are not part of the SUSE Linux Enterprise Software Development Kit.
+          </p>"
+        :eula_url: https://updates.suse.com/SUSE/Products/SLE-SDK/12-SP3/x86_64/product.license/
+        :repositories:
+        - id: 2234
+          url: https://updates.suse.com/SUSE/Products/SLE-SDK/12-SP3/x86_64/product_source
+          name: SLE-SDK12-SP3-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-SDK12-SP3-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2233
+          url: https://updates.suse.com/SUSE/Products/SLE-SDK/12-SP3/x86_64/product_debug
+          name: SLE-SDK12-SP3-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-SDK12-SP3-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2232
+          url: https://updates.suse.com/SUSE/Products/SLE-SDK/12-SP3/x86_64/product
+          name: SLE-SDK12-SP3-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-SDK12-SP3-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2231
+          url: https://updates.suse.com/SUSE/Updates/SLE-SDK/12-SP3/x86_64/update_debug
+          name: SLE-SDK12-SP3-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-SDK12-SP3-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2230
+          url: https://updates.suse.com/SUSE/Updates/SLE-SDK/12-SP3/x86_64/update
+          name: SLE-SDK12-SP3-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-SDK12-SP3-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1617
+        :name: SUSE OpenStack Cloud
+        :identifier: suse-openstack-cloud
+        :former_identifier: suse-openstack-cloud
+        :version: '8'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE OpenStack Cloud 8 x86_64 (BETA)
+        :product_class: SUSE_CLOUD-BETA
+        :cpe: cpe:/o:suse:suse-openstack-cloud:8
+        :free: false
+        :description: SUSE OpenStack Cloud 8
+        :eula_url: https://updates.suse.com/SUSE/Products/OpenStack-Cloud/8/x86_64/product.license/
+        :repositories:
+        - id: 2695
+          url: https://updates.suse.com/SUSE/Products/OpenStack-Cloud/8/x86_64/product_source
+          name: SUSE-OpenStack-Cloud-8-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-OpenStack-Cloud-8-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2694
+          url: https://updates.suse.com/SUSE/Products/OpenStack-Cloud/8/x86_64/product_debug
+          name: SUSE-OpenStack-Cloud-8-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-OpenStack-Cloud-8-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2693
+          url: https://updates.suse.com/SUSE/Products/OpenStack-Cloud/8/x86_64/product
+          name: SUSE-OpenStack-Cloud-8-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-OpenStack-Cloud-8-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2692
+          url: https://updates.suse.com/SUSE/Updates/OpenStack-Cloud/8/x86_64/update_debug
+          name: SUSE-OpenStack-Cloud-8-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-OpenStack-Cloud-8-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2691
+          url: https://updates.suse.com/SUSE/Updates/OpenStack-Cloud/8/x86_64/update
+          name: SUSE-OpenStack-Cloud-8-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-OpenStack-Cloud-8-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1220
+        :name: Public Cloud Module
+        :identifier: sle-module-public-cloud
+        :former_identifier: sle-module-public-cloud
+        :version: '12'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: Public Cloud Module 12 x86_64
+        :product_class: MODULE
+        :cpe: cpe:/o:suse:sle-module-public-cloud:12
+        :free: true
+        :description: "<p> The Public Cloud Module is a collection of tools that enables
+          you to create and manage cloud images from the commandline on SUSE Linux
+          Enterprise Server. When building your own images with KIWI or SUSE Studio,
+          initialization code specific to the target cloud is included in that image.
+          </p> <p> Access to the Public Cloud Module is included in your SUSE Linux
+          Enterprise Server subscription. The module has a different lifecycle than
+          SUSE Linux Enterprise Server itself; please check the Release Notes for
+          further details. </p>"
+        :eula_url: ''
+        :repositories:
+        - id: 1995
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/x86_64/product_source
+          name: SLE-Module-Public-Cloud12-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Public-Cloud12-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 1703
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/x86_64/product_debug
+          name: SLE-Module-Public-Cloud12-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Public-Cloud12-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 1702
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/12/x86_64/product
+          name: SLE-Module-Public-Cloud12-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Public-Cloud12-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 1701
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/x86_64/update_debug
+          name: SLE-Module-Public-Cloud12-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Public-Cloud12-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 1700
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/12/x86_64/update
+          name: SLE-Module-Public-Cloud12-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Public-Cloud12-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: module
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1526
+        :name: SUSE Enterprise Storage
+        :identifier: ses
+        :former_identifier: ses
+        :version: '5'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Enterprise Storage 5 x86_64
+        :product_class: SES
+        :cpe: cpe:/o:suse:ses:5
+        :free: false
+        :description: SUSE Enterprise Storage 5 for SUSE Linux Enterprise Server 12-SP3,
+          powered by Ceph.
+        :eula_url: https://updates.suse.com/SUSE/Products/Storage/5/x86_64/product.license/
+        :repositories:
+        - id: 2436
+          url: https://updates.suse.com/SUSE/Products/Storage/5/x86_64/product_source
+          name: SUSE-Enterprise-Storage-5-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Enterprise-Storage-5-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2435
+          url: https://updates.suse.com/SUSE/Products/Storage/5/x86_64/product_debug
+          name: SUSE-Enterprise-Storage-5-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Enterprise-Storage-5-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2434
+          url: https://updates.suse.com/SUSE/Products/Storage/5/x86_64/product
+          name: SUSE-Enterprise-Storage-5-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Enterprise-Storage-5-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2433
+          url: https://updates.suse.com/SUSE/Updates/Storage/5/x86_64/update_debug
+          name: SUSE-Enterprise-Storage-5-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Enterprise-Storage-5-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2432
+          url: https://updates.suse.com/SUSE/Updates/Storage/5/x86_64/update
+          name: SUSE-Enterprise-Storage-5-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Enterprise-Storage-5-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1529
+        :name: SUSE Package Hub
+        :identifier: PackageHub
+        :former_identifier: PackageHub
+        :version: '12.3'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Package Hub 12 SP3 x86_64
+        :product_class: MODULE
+        :cpe: cpe:/o:suse:packagehub:12:sp3
+        :free: true
+        :description: SUSE Package Hub is a free of charge extension providing access
+          to community maintained packages built to run on SUSE Linux Enterprise Server.
+          Built from the same sources used in the openSUSE distributions, these quality
+          packages provide additional software to what is found in the SUSE Linux
+          Enterprise Server product. Packages from the Package Hub are delivered without
+          L3 support from SUSE. General updates and fixes to the packages in SUSE
+          Package Hub are provided by the openSUSE community based on their discretion
+          though SUSE will monitor and ensure that any known critical security issues
+          will be addressed. Packages in the Package Hub are approved by SUSE for
+          use with SUSE Linux Enterprise Server 12 and to not interfere with the supportability
+          of SUSE Linux Enterprise Server it's modules and extensions. For more information
+          about SUSE Package Hub please visit https://packagehub.suse.com.
+        :eula_url: ''
+        :repositories:
+        - id: 2447
+          url: https://updates.suse.com/SUSE/Backports/SLE-12-SP3_x86_64/product
+          name: SUSE-PackageHub-12-SP3-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-PackageHub-12-SP3-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2446
+          url: https://updates.suse.com/SUSE/Backports/SLE-12-SP3_x86_64/standard_debug
+          name: SUSE-PackageHub-12-SP3-Debuginfo
+          distro_target: sle-12-x86_64
+          description: SUSE-PackageHub-12-SP3-Debuginfo for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2445
+          url: https://updates.suse.com/SUSE/Backports/SLE-12-SP3_x86_64/standard
+          name: SUSE-PackageHub-12-SP3
+          distro_target: sle-12-x86_64
+          description: SUSE-PackageHub-12-SP3 for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1725
+        :name: SUSE Manager Proxy
+        :identifier: SUSE-Manager-Proxy
+        :former_identifier: SUSE-Manager-Proxy
+        :version: '3.2'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Manager Proxy 3.2 x86_64 (BETA)
+        :product_class: SMP-BETA
+        :cpe: cpe:/o:suse:suse-manager-proxy:3.2
+        :free: false
+        :description: SUSE Manager Proxies extend large and/or geographically dispersed
+          SUSE Manager environments to reduce load on the SUSE Manager Server, lower
+          bandwidth needs, and provide faster local updates.
+        :eula_url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Proxy/3.2/x86_64/product.license/
+        :repositories:
+        - id: 2996
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Proxy/3.2/x86_64/product_source
+          name: SUSE-Manager-Proxy-3.2-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Proxy-3.2-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2995
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Proxy/3.2/x86_64/product_debug
+          name: SUSE-Manager-Proxy-3.2-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Proxy-3.2-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2994
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Proxy/3.2/x86_64/product
+          name: SUSE-Manager-Proxy-3.2-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Proxy-3.2-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2993
+          url: https://updates.suse.com/SUSE/Updates/SUSE-Manager-Proxy/3.2/x86_64/update_debug
+          name: SUSE-Manager-Proxy-3.2-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Proxy-3.2-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2992
+          url: https://updates.suse.com/SUSE/Updates/SUSE-Manager-Proxy/3.2/x86_64/update
+          name: SUSE-Manager-Proxy-3.2-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Proxy-3.2-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1729
+        :name: SUSE OpenStack Cloud Crowbar
+        :identifier: suse-openstack-cloud-crowbar
+        :former_identifier: suse-openstack-cloud-crowbar
+        :version: '8'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE OpenStack Cloud Crowbar 8 x86_64 (BETA)
+        :product_class: SUSE_CLOUD-BETA
+        :cpe: cpe:/o:suse:suse-openstack-cloud-crowbar:8
+        :free: false
+        :description: SUSE OpenStack Cloud Crowbar 8
+        :eula_url: https://updates.suse.com/SUSE/Products/OpenStack-Cloud-Crowbar/8/x86_64/product.license/
+        :repositories:
+        - id: 3008
+          url: https://updates.suse.com/SUSE/Products/OpenStack-Cloud-Crowbar/8/x86_64/product_source
+          name: SUSE-OpenStack-Cloud-Crowbar-8-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-OpenStack-Cloud-Crowbar-8-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 3007
+          url: https://updates.suse.com/SUSE/Products/OpenStack-Cloud-Crowbar/8/x86_64/product_debug
+          name: SUSE-OpenStack-Cloud-Crowbar-8-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-OpenStack-Cloud-Crowbar-8-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 3006
+          url: https://updates.suse.com/SUSE/Products/OpenStack-Cloud-Crowbar/8/x86_64/product
+          name: SUSE-OpenStack-Cloud-Crowbar-8-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-OpenStack-Cloud-Crowbar-8-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 3005
+          url: https://updates.suse.com/SUSE/Updates/OpenStack-Cloud-Crowbar/8/x86_64/update_debug
+          name: SUSE-OpenStack-Cloud-Crowbar-8-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-OpenStack-Cloud-Crowbar-8-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 3004
+          url: https://updates.suse.com/SUSE/Updates/OpenStack-Cloud-Crowbar/8/x86_64/update
+          name: SUSE-OpenStack-Cloud-Crowbar-8-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-OpenStack-Cloud-Crowbar-8-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1431
+        :name: SUSE Linux Enterprise Workstation Extension
+        :identifier: sle-we
+        :former_identifier: sle-we
+        :version: '12.3'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Linux Enterprise Workstation Extension 12 SP3 x86_64
+        :product_class: SLE-WE
+        :cpe: cpe:/o:suse:sle-we:12:sp3
+        :free: false
+        :description: SUSE Linux Enterprise Workstation Extension extends the functionality
+          of SUSE Linux Enterprise Server with packages of SUSE Linux Enterprise Desktop,
+          like additional desktop applications (office suite, email client, graphical
+          editor ...) and libraries. It allows to combine both products to create
+          a full featured Workstation.
+        :eula_url: https://updates.suse.com/SUSE/Products/SLE-WE/12-SP3/x86_64/product.license/
+        :repositories:
+        - id: 2254
+          url: https://updates.suse.com/SUSE/Products/SLE-WE/12-SP3/x86_64/product_source
+          name: SLE-WE12-SP3-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-WE12-SP3-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2253
+          url: https://updates.suse.com/SUSE/Products/SLE-WE/12-SP3/x86_64/product_debug
+          name: SLE-WE12-SP3-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-WE12-SP3-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2217
+          url: http://download.nvidia.com/suse/sle12sp3
+          name: SLE-12-SP3-GA-Desktop-nVidia-Driver
+          distro_target: 
+          description: 'SLE-12-SP3-GA-Desktop-nVidia-Driver for '
+          enabled: true
+          autorefresh: true
+        - id: 2252
+          url: https://updates.suse.com/SUSE/Products/SLE-WE/12-SP3/x86_64/product
+          name: SLE-WE12-SP3-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-WE12-SP3-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2251
+          url: https://updates.suse.com/SUSE/Updates/SLE-WE/12-SP3/x86_64/update_debug
+          name: SLE-WE12-SP3-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-WE12-SP3-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2250
+          url: https://updates.suse.com/SUSE/Updates/SLE-WE/12-SP3/x86_64/update
+          name: SLE-WE12-SP3-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-WE12-SP3-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1212
+        :name: Advanced Systems Management Module
+        :identifier: sle-module-adv-systems-management
+        :former_identifier: sle-module-adv-systems-management
+        :version: '12'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: Advanced Systems Management Module 12 x86_64
+        :product_class: MODULE
+        :cpe: cpe:/o:suse:sle-module-adv-systems-management:12
+        :free: true
+        :description: "<p>This Module contains current versions of the popular configuration
+          management frameworks Puppet and CFEngine as well as the new systems management
+          toolbox called machinery.</p> <p>The machinery tool will be frequently updated
+          and is SUSE's upcoming systems management toolbox for inspecting and validating
+          systems remotely, storing their system description and creating new systems
+          to deploy them in datacenters and clouds. </p>"
+        :eula_url: ''
+        :repositories:
+        - id: 1998
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Adv-Systems-Management/12/x86_64/product_source
+          name: SLE-Module-Adv-Systems-Management12-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Adv-Systems-Management12-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 1707
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Adv-Systems-Management/12/x86_64/product_debug
+          name: SLE-Module-Adv-Systems-Management12-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Adv-Systems-Management12-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 1706
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Adv-Systems-Management/12/x86_64/product
+          name: SLE-Module-Adv-Systems-Management12-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Adv-Systems-Management12-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 1705
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/x86_64/update_debug
+          name: SLE-Module-Adv-Systems-Management12-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Adv-Systems-Management12-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 1704
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-Adv-Systems-Management/12/x86_64/update
+          name: SLE-Module-Adv-Systems-Management12-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Adv-Systems-Management12-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: module
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1520
+        :name: SUSE Manager Proxy
+        :identifier: SUSE-Manager-Proxy
+        :former_identifier: SUSE-Manager-Proxy
+        :version: '3.1'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Manager Proxy 3.1 x86_64
+        :product_class: SMP
+        :cpe: cpe:/o:suse:suse-manager-proxy:3.1
+        :free: false
+        :description: SUSE Manager Proxies extend large and/or geographically dispersed
+          SUSE Manager environments to reduce load on the SUSE Manager Server, lower
+          bandwidth needs, and provide faster local updates.
+        :eula_url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Proxy/3.1/x86_64/product.license/
+        :repositories:
+        - id: 2414
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Proxy/3.1/x86_64/product_source
+          name: SUSE-Manager-Proxy-3.1-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Proxy-3.1-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2413
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Proxy/3.1/x86_64/product_debug
+          name: SUSE-Manager-Proxy-3.1-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Proxy-3.1-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2412
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Proxy/3.1/x86_64/product
+          name: SUSE-Manager-Proxy-3.1-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Proxy-3.1-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2411
+          url: https://updates.suse.com/SUSE/Updates/SUSE-Manager-Proxy/3.1/x86_64/update_debug
+          name: SUSE-Manager-Proxy-3.1-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Proxy-3.1-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2410
+          url: https://updates.suse.com/SUSE/Updates/SUSE-Manager-Proxy/3.1/x86_64/update
+          name: SUSE-Manager-Proxy-3.1-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Proxy-3.1-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1618
+        :name: SUSE Linux Enterprise Server BCL
+        :identifier: SLES-BCL
+        :former_identifier: SLES-BCL
+        :version: '12.3'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Linux Enterprise Server BCL 12 SP3 x86_64
+        :product_class: BCL-X86
+        :cpe: cpe:/o:suse:sles-bcl:12:sp3
+        :free: false
+        :description: SUSE Linux Enterprise offers a comprehensive suite of products
+          built on a single code base. The platform addresses business needs from
+          the smallest thin-client devices to the world's most powerful high-performance
+          computing and mainframe servers. SUSE Linux Enterprise offers common management
+          tools and technology certifications across the platform, and each product
+          is enterprise-class.
+        :eula_url: ''
+        :repositories:
+        - id: 2700
+          url: https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP3-BCL/x86_64/product_source
+          name: SLES12-SP3-BCL-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SLES12-SP3-BCL-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2699
+          url: https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP3-BCL/x86_64/product_debug
+          name: SLES12-SP3-BCL-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SLES12-SP3-BCL-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2698
+          url: https://updates.suse.com/SUSE/Products/SLE-SERVER/12-SP3-BCL/x86_64/product
+          name: SLES12-SP3-BCL-Pool
+          distro_target: sle-12-x86_64
+          description: SLES12-SP3-BCL-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2697
+          url: https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP3-BCL/x86_64/update_debug
+          name: SLES12-SP3-BCL-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SLES12-SP3-BCL-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2696
+          url: https://updates.suse.com/SUSE/Updates/SLE-SERVER/12-SP3-BCL/x86_64/update
+          name: SLES12-SP3-BCL-Updates
+          distro_target: sle-12-x86_64
+          description: SLES12-SP3-BCL-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1150
+        :name: Legacy Module
+        :identifier: sle-module-legacy
+        :former_identifier: sle-module-legacy
+        :version: '12'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: Legacy Module 12 x86_64
+        :product_class: MODULE
+        :cpe: cpe:/o:suse:sle-module-legacy:12
+        :free: true
+        :description: "<p> The Legacy Module helps you migrating applications from
+          SUSE Linux Enterprise 10 and 11 and other systems to SUSE Linux Enterprise
+          12, by providing packages which are discontinued on SUSE Linux Enterprise
+          Server, such as: sendmail, syslog-ng, IBM Java6, and a number of libraries
+          (for example openssl-0.9.8). </p> <p> Access to the Legacy Module is included
+          in your SUSE Linux Enterprise Server subscription. The module has a different
+          lifecycle than SUSE Linux Enterprise Server itself. Packages in the this
+          module are usually supported for at most three years. Support for Sendmail
+          and IBM Java 6 will end in September 2017 the latest. </p>"
+        :eula_url: https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/x86_64/product.license/
+        :repositories:
+        - id: 1989
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/x86_64/product_source
+          name: SLE-Module-Legacy12-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Legacy12-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 1679
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/x86_64/product_debug
+          name: SLE-Module-Legacy12-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Legacy12-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 1678
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/12/x86_64/product
+          name: SLE-Module-Legacy12-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Legacy12-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 1677
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/12/x86_64/update_debug
+          name: SLE-Module-Legacy12-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Legacy12-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 1676
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/12/x86_64/update
+          name: SLE-Module-Legacy12-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Legacy12-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: module
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1724
+        :name: SUSE Manager Server
+        :identifier: SUSE-Manager-Server
+        :former_identifier: SUSE-Manager-Server
+        :version: '3.2'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Manager Server 3.2 x86_64 (BETA)
+        :product_class: SMS-X86-BETA
+        :cpe: cpe:/o:suse:suse-manager-server:3.2
+        :free: false
+        :description: SUSE Manager lets you efficiently manage physical, virtual,
+          and cloud-based Linux systems. It provides automated and cost-effective
+          configuration and software management, asset management, and system provisioning.
+        :eula_url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Server/3.2/x86_64/product.license/
+        :repositories:
+        - id: 2991
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Server/3.2/x86_64/product_source
+          name: SUSE-Manager-Server-3.2-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Server-3.2-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2990
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Server/3.2/x86_64/product_debug
+          name: SUSE-Manager-Server-3.2-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Server-3.2-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2989
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Server/3.2/x86_64/product
+          name: SUSE-Manager-Server-3.2-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Server-3.2-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2988
+          url: https://updates.suse.com/SUSE/Updates/SUSE-Manager-Server/3.2/x86_64/update_debug
+          name: SUSE-Manager-Server-3.2-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Server-3.2-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2987
+          url: https://updates.suse.com/SUSE/Updates/SUSE-Manager-Server/3.2/x86_64/update
+          name: SUSE-Manager-Server-3.2-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Server-3.2-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1730
+        :name: HPE Helion OpenStack Cloud
+        :identifier: hpe-helion-openstack-cloud
+        :former_identifier: hpe-helion-openstack-cloud
+        :version: '8'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: HPE Helion OpenStack Cloud 8 x86_64 (BETA)
+        :product_class: HPE-OPENSTACK-CLOUD-X86-BETA
+        :cpe: cpe:/o:suse:hpe-helion-openstack-cloud:8
+        :free: false
+        :description: HPE Helion OpenStack Cloud 8
+        :eula_url: https://updates.suse.com/SUSE/Products/HPE-Helion-OpenStack-Cloud/8/x86_64/product.license/
+        :repositories:
+        - id: 3013
+          url: https://updates.suse.com/SUSE/Products/HPE-Helion-OpenStack-Cloud/8/x86_64/product_source
+          name: HPE-Helion-OpenStack-Cloud-8-Source-Pool
+          distro_target: sle-12-x86_64
+          description: HPE-Helion-OpenStack-Cloud-8-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 3012
+          url: https://updates.suse.com/SUSE/Products/HPE-Helion-OpenStack-Cloud/8/x86_64/product_debug
+          name: HPE-Helion-OpenStack-Cloud-8-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: HPE-Helion-OpenStack-Cloud-8-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 3011
+          url: https://updates.suse.com/SUSE/Products/HPE-Helion-OpenStack-Cloud/8/x86_64/product
+          name: HPE-Helion-OpenStack-Cloud-8-Pool
+          distro_target: sle-12-x86_64
+          description: HPE-Helion-OpenStack-Cloud-8-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 3010
+          url: https://updates.suse.com/SUSE/Updates/HPE-Helion-OpenStack-Cloud/8/x86_64/update_debug
+          name: HPE-Helion-OpenStack-Cloud-8-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: HPE-Helion-OpenStack-Cloud-8-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 3009
+          url: https://updates.suse.com/SUSE/Updates/HPE-Helion-OpenStack-Cloud/8/x86_64/update
+          name: HPE-Helion-OpenStack-Cloud-8-Updates
+          distro_target: sle-12-x86_64
+          description: HPE-Helion-OpenStack-Cloud-8-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1432
+        :name: SUSE Linux Enterprise High Availability Extension
+        :identifier: sle-ha
+        :former_identifier: sle-hae
+        :version: '12.3'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Linux Enterprise High Availability Extension 12 SP3 x86_64
+        :product_class: SLE-HAE-X86
+        :cpe: cpe:/o:suse:sle-ha:12:sp3
+        :free: false
+        :description: SUSE Linux Enterprise High Availability Extension.
+        :eula_url: https://updates.suse.com/SUSE/Products/SLE-HA/12-SP3/x86_64/product.license/
+        :repositories:
+        - id: 2229
+          url: https://updates.suse.com/SUSE/Products/SLE-HA/12-SP3/x86_64/product_source
+          name: SLE-HA12-SP3-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-HA12-SP3-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2227
+          url: https://updates.suse.com/SUSE/Products/SLE-HA/12-SP3/x86_64/product_debug
+          name: SLE-HA12-SP3-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-HA12-SP3-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2225
+          url: https://updates.suse.com/SUSE/Products/SLE-HA/12-SP3/x86_64/product
+          name: SLE-HA12-SP3-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-HA12-SP3-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2223
+          url: https://updates.suse.com/SUSE/Updates/SLE-HA/12-SP3/x86_64/update_debug
+          name: SLE-HA12-SP3-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-HA12-SP3-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2221
+          url: https://updates.suse.com/SUSE/Updates/SLE-HA/12-SP3/x86_64/update
+          name: SLE-HA12-SP3-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-HA12-SP3-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions:
+        - !ruby/object:SUSE::Connect::Remote::Product
+          table:
+            :id: 1435
+            :name: SUSE Linux Enterprise High Availability GEO Extension
+            :identifier: sle-ha-geo
+            :former_identifier: sle-hae-geo
+            :version: '12.3'
+            :release_type: 
+            :arch: x86_64
+            :friendly_name: SUSE Linux Enterprise High Availability GEO Extension
+              12 SP3 x86_64
+            :product_class: SLE-HAE-GEO
+            :cpe: cpe:/o:suse:sle-ha-geo:12:sp3
+            :free: false
+            :description: SUSE Linux Enterprise High Availability Geographical Cluster
+              Extension
+            :eula_url: https://updates.suse.com/SUSE/Products/SLE-HA-GEO/12-SP3/x86_64/product.license/
+            :repositories:
+            - id: 2269
+              url: https://updates.suse.com/SUSE/Products/SLE-HA-GEO/12-SP3/x86_64/product_source
+              name: SLE-HA-GEO12-SP3-Source-Pool
+              distro_target: sle-12-x86_64
+              description: SLE-HA-GEO12-SP3-Source-Pool for sle-12-x86_64
+              enabled: false
+              autorefresh: false
+            - id: 2268
+              url: https://updates.suse.com/SUSE/Products/SLE-HA-GEO/12-SP3/x86_64/product_debug
+              name: SLE-HA-GEO12-SP3-Debuginfo-Pool
+              distro_target: sle-12-x86_64
+              description: SLE-HA-GEO12-SP3-Debuginfo-Pool for sle-12-x86_64
+              enabled: false
+              autorefresh: false
+            - id: 2267
+              url: https://updates.suse.com/SUSE/Products/SLE-HA-GEO/12-SP3/x86_64/product
+              name: SLE-HA-GEO12-SP3-Pool
+              distro_target: sle-12-x86_64
+              description: SLE-HA-GEO12-SP3-Pool for sle-12-x86_64
+              enabled: true
+              autorefresh: false
+            - id: 2266
+              url: https://updates.suse.com/SUSE/Updates/SLE-HA-GEO/12-SP3/x86_64/update_debug
+              name: SLE-HA-GEO12-SP3-Debuginfo-Updates
+              distro_target: sle-12-x86_64
+              description: SLE-HA-GEO12-SP3-Debuginfo-Updates for sle-12-x86_64
+              enabled: false
+              autorefresh: true
+            - id: 2265
+              url: https://updates.suse.com/SUSE/Updates/SLE-HA-GEO/12-SP3/x86_64/update
+              name: SLE-HA-GEO12-SP3-Updates
+              distro_target: sle-12-x86_64
+              description: SLE-HA-GEO12-SP3-Updates for sle-12-x86_64
+              enabled: true
+              autorefresh: true
+            :product_type: extension
+            :extensions: []
+          modifiable: true
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1349
+        :name: SUSE Manager Server
+        :identifier: SUSE-Manager-Server
+        :former_identifier: SUSE-Manager-Server
+        :version: '3.0'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Manager Server 3.0 x86_64
+        :product_class: SMS-X86
+        :cpe: cpe:/o:suse:suse-manager-server:3.0
+        :free: false
+        :description: SUSE Manager lets you efficiently manage physical, virtual,
+          and cloud-based Linux systems. It provides automated and cost-effective
+          configuration and software management, asset management, and system provisioning.
+        :eula_url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Server/3.0/x86_64/product.license/
+        :repositories:
+        - id: 2001
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Server/3.0/x86_64/product_source
+          name: SUSE-Manager-Server-3.0-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Server-3.0-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 1952
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Server/3.0/x86_64/product_debug
+          name: SUSE-Manager-Server-3.0-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Server-3.0-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 1951
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Server/3.0/x86_64/product
+          name: SUSE-Manager-Server-3.0-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Server-3.0-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 1950
+          url: https://updates.suse.com/SUSE/Updates/SUSE-Manager-Server/3.0/x86_64/update_debug
+          name: SUSE-Manager-Server-3.0-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Server-3.0-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 1949
+          url: https://updates.suse.com/SUSE/Updates/SUSE-Manager-Server/3.0/x86_64/update
+          name: SUSE-Manager-Server-3.0-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Server-3.0-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1352
+        :name: SUSE Manager Proxy
+        :identifier: SUSE-Manager-Proxy
+        :former_identifier: SUSE-Manager-Proxy
+        :version: '3.0'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Manager Proxy 3.0 x86_64
+        :product_class: SMP
+        :cpe: cpe:/o:suse:suse-manager-proxy:3.0
+        :free: false
+        :description: SUSE Manager Proxies extend large and/or geographically dispersed
+          SUSE Manager environments to reduce load on the SUSE Manager Server, lower
+          bandwidth needs, and provide faster local updates.
+        :eula_url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Proxy/3.0/x86_64/product.license/
+        :repositories:
+        - id: 2002
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Proxy/3.0/x86_64/product_source
+          name: SUSE-Manager-Proxy-3.0-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Proxy-3.0-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 1971
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Proxy/3.0/x86_64/product_debug
+          name: SUSE-Manager-Proxy-3.0-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Proxy-3.0-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 1970
+          url: https://updates.suse.com/SUSE/Products/SUSE-Manager-Proxy/3.0/x86_64/product
+          name: SUSE-Manager-Proxy-3.0-Pool
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Proxy-3.0-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 1969
+          url: https://updates.suse.com/SUSE/Updates/SUSE-Manager-Proxy/3.0/x86_64/update_debug
+          name: SUSE-Manager-Proxy-3.0-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Proxy-3.0-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 1968
+          url: https://updates.suse.com/SUSE/Updates/SUSE-Manager-Proxy/3.0/x86_64/update
+          name: SUSE-Manager-Proxy-3.0-Updates
+          distro_target: sle-12-x86_64
+          description: SUSE-Manager-Proxy-3.0-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1440
+        :name: HPC Module
+        :identifier: sle-module-hpc
+        :former_identifier: sle-module-hpc
+        :version: '12'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: HPC Module 12 x86_64
+        :product_class: MODULE
+        :cpe: cpe:/o:suse:sle-module-hpc:12
+        :free: true
+        :description: The SUSE Linux Enterprise Server High Performance Computing
+          (HPC) module delivers specific tools commonly used for high performance,
+          numerically intensive workloads. SUSE packages these tools in the SLES HPC
+          Module to provide greater flexibility to deliver new versions or new tools
+          more rapidly than the standard SUSE Linux Enterprise lifecycle would permit.
+          Packages in this module are general supported till a newer version of the
+          package is released or the package is dropped from the module.
+        :eula_url: https://updates.suse.com/SUSE/Products/SLE-Module-HPC/12/x86_64/product.license/
+        :repositories:
+        - id: 2298
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-HPC/12/x86_64/product_source
+          name: SLE-Module-HPC12-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-HPC12-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2297
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-HPC/12/x86_64/product_debug
+          name: SLE-Module-HPC12-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-HPC12-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2296
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-HPC/12/x86_64/product
+          name: SLE-Module-HPC12-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-HPC12-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2295
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/12/x86_64/update_debug
+          name: SLE-Module-HPC12-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-HPC12-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2294
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-HPC/12/x86_64/update
+          name: SLE-Module-HPC12-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-HPC12-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: module
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1332
+        :name: Containers Module
+        :identifier: sle-module-containers
+        :former_identifier: sle-module-containers
+        :version: '12'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: Containers Module 12 x86_64
+        :product_class: MODULE
+        :cpe: cpe:/o:suse:sle-module-containers:12
+        :free: true
+        :description: "<p>This Module contains several packages revolving around containers
+          and related tools. </p>"
+        :eula_url: ''
+        :repositories:
+        - id: 1957
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Containers/12/x86_64/product_source
+          name: SLE-Module-Containers12-Source-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Containers12-Source-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 1867
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Containers/12/x86_64/product_debug
+          name: SLE-Module-Containers12-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Containers12-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 1866
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Containers/12/x86_64/product
+          name: SLE-Module-Containers12-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Containers12-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 1865
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/12/x86_64/update_debug
+          name: SLE-Module-Containers12-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Containers12-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 1864
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/12/x86_64/update
+          name: SLE-Module-Containers12-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Containers12-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: module
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1341
+        :name: Toolchain Module
+        :identifier: sle-module-toolchain
+        :former_identifier: sle-module-toolchain
+        :version: '12'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: Toolchain Module 12 x86_64
+        :product_class: MODULE
+        :cpe: cpe:/o:suse:sle-module-toolchain:12
+        :free: true
+        :description: Via this Module you will have access to a more recent GCC and
+          Toolchain in addition to the default compiler of SUSE Linux Enterprise.
+          Access to the Toolchain Module is included in your SUSE Linux Enterprise
+          Server subscription. The module has a different lifecycle than SUSE Linux
+          Enterprise Server itself. Please check the Release Notes for further details.
+        :eula_url: ''
+        :repositories:
+        - id: 1906
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/x86_64/product_debug
+          name: SLE-Module-Toolchain12-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Toolchain12-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 1905
+          url: https://updates.suse.com/SUSE/Products/SLE-Module-Toolchain/12/x86_64/product
+          name: SLE-Module-Toolchain12-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Toolchain12-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 1904
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/x86_64/update_debug
+          name: SLE-Module-Toolchain12-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Toolchain12-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 1903
+          url: https://updates.suse.com/SUSE/Updates/SLE-Module-Toolchain/12/x86_64/update
+          name: SLE-Module-Toolchain12-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-Module-Toolchain12-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: module
+        :extensions: []
+      modifiable: true
+    - !ruby/object:SUSE::Connect::Remote::Product
+      table:
+        :id: 1619
+        :name: SUSE Linux Enterprise Real Time
+        :identifier: SUSE-Linux-Enterprise-RT
+        :former_identifier: SUSE-Linux-Enterprise-RT
+        :version: '12.3'
+        :release_type: 
+        :arch: x86_64
+        :friendly_name: SUSE Linux Enterprise Real Time 12 SP3 x86_64
+        :product_class: SUSE_RT
+        :cpe: cpe:/o:suse:suse-linux-enterprise-rt:12:sp3
+        :free: false
+        :description: SUSE Linux Enterprise Real Time 12 SP3.
+        :eula_url: https://updates.suse.com/SUSE/Products/SLE-RT/12-SP3/x86_64/product.license/
+        :repositories:
+        - id: 2704
+          url: https://updates.suse.com/SUSE/Products/SLE-RT/12-SP3/x86_64/product_debug
+          name: SLE-RT12-SP3-Debuginfo-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-RT12-SP3-Debuginfo-Pool for sle-12-x86_64
+          enabled: false
+          autorefresh: false
+        - id: 2703
+          url: https://updates.suse.com/SUSE/Products/SLE-RT/12-SP3/x86_64/product
+          name: SLE-RT12-SP3-Pool
+          distro_target: sle-12-x86_64
+          description: SLE-RT12-SP3-Pool for sle-12-x86_64
+          enabled: true
+          autorefresh: false
+        - id: 2702
+          url: https://updates.suse.com/SUSE/Updates/SLE-RT/12-SP3/x86_64/update_debug
+          name: SLE-RT12-SP3-Debuginfo-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-RT12-SP3-Debuginfo-Updates for sle-12-x86_64
+          enabled: false
+          autorefresh: true
+        - id: 2701
+          url: https://updates.suse.com/SUSE/Updates/SLE-RT/12-SP3/x86_64/update
+          name: SLE-RT12-SP3-Updates
+          distro_target: sle-12-x86_64
+          description: SLE-RT12-SP3-Updates for sle-12-x86_64
+          enabled: true
+          autorefresh: true
+        :product_type: extension
+        :extensions: []
+      modifiable: true
+  modifiable: true

--- a/test/fixtures/migration_sles15_offline_migrations.yml
+++ b/test/fixtures/migration_sles15_offline_migrations.yml
@@ -1,0 +1,121 @@
+---
+- - !ruby/object:OpenStruct
+    table:
+      :friendly_name: SUSE Linux Enterprise Server 15 x86_64
+      :shortname: SLES15
+      :identifier: SLES
+      :version: '15'
+      :arch: x86_64
+      :release_type: 
+      :base: true
+      :product_type: base
+      :free: false
+      :release_stage: beta
+  - !ruby/object:OpenStruct
+    table:
+      :friendly_name: Basesystem Module 15 x86_64
+      :shortname: Basesystem-Module
+      :identifier: sle-module-basesystem
+      :version: '15'
+      :arch: x86_64
+      :release_type: 
+      :base: false
+      :product_type: module
+      :free: true
+      :release_stage: released
+  - !ruby/object:OpenStruct
+    table:
+      :friendly_name: Containers Module 15 x86_64
+      :shortname: Containers-Module
+      :identifier: sle-module-containers
+      :version: '15'
+      :arch: x86_64
+      :release_type: 
+      :base: false
+      :product_type: module
+      :free: true
+      :release_stage: released
+  - !ruby/object:OpenStruct
+    table:
+      :friendly_name: Desktop Applications Module 15 x86_64
+      :shortname: Desktop-Applications-Module
+      :identifier: sle-module-desktop-applications
+      :version: '15'
+      :arch: x86_64
+      :release_type: 
+      :base: false
+      :product_type: module
+      :free: true
+      :release_stage: released
+  - !ruby/object:OpenStruct
+    table:
+      :friendly_name: Server Applications Module 15 x86_64
+      :shortname: Server-Applications-Module
+      :identifier: sle-module-server-applications
+      :version: '15'
+      :arch: x86_64
+      :release_type: 
+      :base: false
+      :product_type: module
+      :free: true
+      :release_stage: released
+  - !ruby/object:OpenStruct
+    table:
+      :friendly_name: SUSE Cloud Application Platform Tools Module 15 x86_64
+      :shortname: SUSE-CAP-Tools-Module
+      :identifier: sle-module-cap-tools
+      :version: '15'
+      :arch: x86_64
+      :release_type: 
+      :base: false
+      :product_type: module
+      :free: true
+      :release_stage: released
+  - !ruby/object:OpenStruct
+    table:
+      :friendly_name: Development Tools Module 15 x86_64
+      :shortname: Development-Tools-Module
+      :identifier: sle-module-development-tools
+      :version: '15'
+      :arch: x86_64
+      :release_type: 
+      :base: false
+      :product_type: module
+      :free: true
+      :release_stage: released
+  - !ruby/object:OpenStruct
+    table:
+      :friendly_name: Legacy Module 15 x86_64
+      :shortname: Legacy-Module
+      :identifier: sle-module-legacy
+      :version: '15'
+      :arch: x86_64
+      :release_type: 
+      :base: false
+      :product_type: module
+      :free: true
+      :release_stage: released
+  - !ruby/object:OpenStruct
+    table:
+      :friendly_name: Public Cloud Module 15 x86_64
+      :shortname: Public-Cloud-Module
+      :identifier: sle-module-public-cloud
+      :version: '15'
+      :arch: x86_64
+      :release_type: 
+      :base: false
+      :product_type: module
+      :free: true
+      :release_stage: released
+  - !ruby/object:OpenStruct
+    table:
+      :friendly_name: Web and Scripting Module 15 x86_64
+      :shortname: Web-Scripting-Module
+      :identifier: sle-module-web-scripting
+      :version: '15'
+      :arch: x86_64
+      :release_type: 
+      :base: false
+      :product_type: module
+      :free: true
+      :release_stage: released

--- a/test/fixtures/migration_sles15_selected_base.yml
+++ b/test/fixtures/migration_sles15_selected_base.yml
@@ -1,0 +1,10 @@
+--- !ruby/object:Y2Packager::Product
+name: SLES
+short_name: SLES15
+display_name: SUSE Linux Enterprise Server 15 Beta7
+version: 15-0
+arch: :x86_64
+category: :addon
+vendor: SUSE LLC <https://www.suse.com/>
+order: 200
+installation_package: skelcd-control-SLES

--- a/test/fixtures/migration_to_sles15.yml
+++ b/test/fixtures/migration_to_sles15.yml
@@ -1,0 +1,9 @@
+---
+- - !ruby/object:SUSE::Connect::Remote::Product
+    table:
+      :identifier: SLES
+      :version: '15-0'
+      :arch: x86_64
+      :release_type: 
+      :friendly_name: SUSE Linux Enterprise Server 15 x86_64
+      :shortname: SLES15

--- a/test/migration_selection_dialog_test.rb
+++ b/test/migration_selection_dialog_test.rb
@@ -6,7 +6,7 @@ include Yast::UIShortcuts
 describe Registration::UI::MigrationSelectionDialog do
   subject { Registration::UI::MigrationSelectionDialog }
   let(:migration_products) { load_yaml_fixture("migration_to_sles12_sp1.yml") }
-  let(:migration_products_sle15) { load_yaml_fixture("migration_to_sles15.yml") }
+  let(:migration_products_sle15) { load_yaml_fixture("migration_sles15_offline_migrations.yml") }
 
   describe ".run" do
     it "displays the possible migrations and returns the user input" do
@@ -46,6 +46,26 @@ describe Registration::UI::MigrationSelectionDialog do
 
       sles11sp4 = load_yaml_fixture("installed_sles11-sp4_products.yml")
       subject.run(migration_products_sle15, sles11sp4)
+    end
+
+    it "handles product merges in the summary" do
+      # user pressed the "Abort" button, just to get out of the event loop
+      allow(Yast::UI).to receive(:UserInput).and_return(:abort)
+      allow(Yast::Wizard).to receive(:SetContents)
+      # the first migration is selected
+      expect(Yast::UI).to receive(:QueryWidget).with(:migration_targets, :CurrentItem).and_return(0)
+      # check the correct summary
+      expect(Yast::UI).to receive(:ChangeWidget) do |_id, _attr, text|
+        # For SLE15 there are two products (SDK and Toolchain Module) replaced
+        # by single product (Development Tools Module)
+        expect(text).to include("SUSE Linux Enterprise Software Development Kit 12 SP3 "\
+          "<b>will be upgraded to</b> Development Tools Module 15")
+        expect(text).to include("Toolchain Module <b>will be upgraded to</b> " \
+          "Development Tools Module 15")
+      end
+
+      sles12sp3 = load_yaml_fixture("installed_sles12-sp3_products.yml")
+      subject.run(migration_products_sle15, sles12sp3)
     end
 
     it "saves the entered values when clicking Next" do

--- a/test/migration_selection_dialog_test.rb
+++ b/test/migration_selection_dialog_test.rb
@@ -6,6 +6,7 @@ include Yast::UIShortcuts
 describe Registration::UI::MigrationSelectionDialog do
   subject { Registration::UI::MigrationSelectionDialog }
   let(:migration_products) { load_yaml_fixture("migration_to_sles12_sp1.yml") }
+  let(:migration_products_sle15) { load_yaml_fixture("migration_to_sles15.yml") }
 
   describe ".run" do
     it "displays the possible migrations and returns the user input" do
@@ -25,6 +26,26 @@ describe Registration::UI::MigrationSelectionDialog do
       end
 
       expect(subject.run(migration_products, [])).to eq(:abort)
+    end
+
+    it "handles product renames in the summary" do
+      # user pressed the "Abort" button, just to get out of the event loop
+      allow(Yast::UI).to receive(:UserInput).and_return(:abort)
+      allow(Yast::Wizard).to receive(:SetContents)
+      # the first migration is selected
+      expect(Yast::UI).to receive(:QueryWidget).with(:migration_targets, :CurrentItem).and_return(0)
+      # check the correct summary
+      expect(Yast::UI).to receive(:ChangeWidget) do |_id, _attr, text|
+        # SLES11 uses "SUSE_SLES" product identifier while SLES15 uses just "SLES",
+        # the summary needs to mention a product upgrade although technically these
+        # are different products with different statuses ("SUSE_SLES" will be uninstalled,
+        # "SLES" will be installed)
+        expect(text).to include("SUSE Linux Enterprise Server 11 SP4 <b>will be " \
+          "upgraded to</b> SUSE Linux Enterprise Server 15")
+      end
+
+      sles11sp4 = load_yaml_fixture("installed_sles11-sp4_products.yml")
+      subject.run(migration_products_sle15, sles11sp4)
     end
 
     it "saves the entered values when clicking Next" do


### PR DESCRIPTION
# Summary
- https://fate.suse.com/323395
- 4.0.22

## Notes

- Ignore the CodeClimate code complexity error, I do not want to do any unnecessary refactoring just before the RC phase...

## Included Fixes

- Display a hint for a failed migration from SLE11 (NCC<->SCC sync)
- Debugging: log the activated products for easier debugging (to see if the system was really registered and what is active)
- Ask for confirmation if the target product has been already registered (SCC fails when attempting to migrate an already migrated system)
- Remove the obsolete `/etc/zypp/credentials.d/NCCcredentials` file at the end, not needed anymore
- Skipping addon loading at offline upgrade (not needed)
- Fix for product rename (the internal identifier has been changed from `SUSE_SLES` in SLE11 to `SLES` in SLE12/15, also some SLE12 modules have been renamed or merged)


### NCC Hint

When the NCC registration (in SLE11) has not been synchronized yet to SCC then a hint is displayed how to speed up the synchronization:

![sles11_offline_migration_missing_scc_sync](https://user-images.githubusercontent.com/907998/36386948-d115c3e6-1597-11e8-9cdf-81b5888dd461.png)

### Confirmation

Migrating an already migrated machine fails with an SCC error, to prevent from this display a confirmation popup:

![sle11_already_migrated](https://user-images.githubusercontent.com/907998/36493206-589eac7c-172f-11e8-87cc-06453637509c.png)

### Product Rename

The product renames or merges are now handled correctly. Here the SDK and Toolchain Module have been merged into Development Tools (tested in upgrade from SLES12):

![sle15_migration_product_renames](https://user-images.githubusercontent.com/907998/36541754-344ee048-17df-11e8-836a-a0e25e8da1da.png)
