### PR TITLE
Display more error details (related to bsc#1083503)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar  5 10:14:28 UTC 2018 - lslezak@suse.cz
+
+- Display additional error details when refreshing a service fails
+  (related to bsc#1083503)
+- 4.0.23
+
+-------------------------------------------------------------------
 Mon Feb 19 13:08:55 UTC 2018 - lslezak@suse.cz
 
 - Support for offline migration from SLE11 to SLE15 (fate#323395)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.22
+Version:        4.0.23
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -121,11 +121,11 @@ module Registration
         false
       rescue ::Registration::ServiceError => e
         log.error("Service error: #{e.message % e.service}")
-        Yast::Report.Error(_(e.message) % e.service)
+        report_pkg_error(_(e.message) % e.service)
         false
       rescue ::Registration::PkgError => e
         log.error("Pkg error: #{e.message}")
-        Yast::Report.Error(_(e.message))
+        report_pkg_error(_(e.message))
         false
       rescue OpenSSL::SSL::SSLError => e
         log.error "OpenSSL error: #{e}"
@@ -153,6 +153,13 @@ module Registration
 
     def self.report_error(msg, error_message)
       Yast::Report.Error(error_with_details(msg, error_message))
+    end
+
+    # Report a pkg-bindings error. Display a message with error details from
+    # libzypp.
+    # @param msg [String] error message (translated)
+    def self.report_pkg_error(msg)
+      report_error(msg, Yast::Pkg.LastError)
     end
 
     def self.error_with_details(error, details)

--- a/test/connect_helpers_spec.rb
+++ b/test/connect_helpers_spec.rb
@@ -169,6 +169,20 @@ describe Registration::ConnectHelpers do
     exceptions.each do |exception|
       context "exception #{exception} is raised" do
         include_examples "reports error and returns false", exception
+
+        it "reports an error with Pkg details" do
+          expect(Yast::Pkg).to receive(:LastError).and_return("PkgLastError")
+          expect(Yast::Report).to receive(:Error).with(/Details: PkgLastError/)
+
+          helpers.catch_registration_errors { raise exception }
+        end
+
+        it "reports an error without Pkg details if it is empty" do
+          expect(Yast::Pkg).to receive(:LastError).and_return("")
+          expect(Yast::Report).to_not receive(:Error).with(/Details:/)
+
+          helpers.catch_registration_errors { raise exception }
+        end
       end
     end
 


### PR DESCRIPTION
- Display more details when a service refresh fails
- For easier debugging to see where the error is (SMT, SCC or SCC proxy)
- We can easily detect non-YaST issues and reassign bugs quicker
- See the screen in openQA: https://openqa.suse.de/tests/1513698#step/scc_registration/8

### The old error was just
```
Refreshing service 'SUSE_Linux_Enterprise_Server_15_ppc64le' failed.
```
### The new error message will also contain details from libzypp
```
Refreshing service 'SUSE_Linux_Enterprise_Server_15_ppc64le' failed.
      
Details: Download (curl) error for 'http://all-489.1.proxy.scc.suse.de/access/services/1570/repo/repoi
ndex.xml?cookies=0&credentials=SUSE_Linux_Enterprise_Server_15_ppc64le':
Error code: HTTP response: 500
Error message: The requested URL returned error: 500 Internal Server Error
```

So the user will see which URL failed and in this case we can reassign the bug to the SCC Proxy maintainers.