### PR TITLE
Do not crash if a product is not selected

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 13 09:37:14 UTC 2018 - knut.anderssen@suse.com
+
+- Prevent crashing when no product was defined in the profile
+  (bsc#1084820)
+- 4.0.24
+
+-------------------------------------------------------------------
 Mon Mar  5 10:14:28 UTC 2018 - lslezak@suse.cz
 
 - Display additional error details when refreshing a service fails

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.23
+Version:        4.0.24
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -191,6 +191,7 @@ module Registration
     # @see SUSE::Connect::Yast.list_installer_updates
     def get_updates_list
       product = SwMgmt.base_product_to_register
+      return [] unless product
       id = Yast::ProductFeatures.GetStringFeature("globals", "self_update_id")
       if !id.empty?
         log.info "Using self update id from control file #{id.inspect}"

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -162,6 +162,7 @@ module Registration
         Yast.import "AutoinstFunctions"
         # note: AutoinstFunctions.selected_product should never be nil when
         # AY let it pass here
+        return false unless AutoinstFunctions.selected_product
         p["name"] == AutoinstFunctions.selected_product.name
       elsif Stage.initial && !Mode.update
         # during installation the ["type"] value is not valid yet yet

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -239,6 +239,8 @@ module Registration
       # use FAKE_BASE_PRODUCT just for debugging
       base_product = ENV["FAKE_BASE_PRODUCT"] ? FAKE_BASE_PRODUCT : find_base_product
 
+      return unless base_product
+
       # filter out not needed data
       product_info = {
         "name"         => base_product["name"],

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -229,6 +229,11 @@ describe Registration::Registration do
         .and_return(updates)
       expect(subject.get_updates_list).to eq(updates)
     end
+
+    it "returns an empty list if no base product is selected" do
+      allow(Registration::SwMgmt).to receive(:base_product_to_register).and_return(nil)
+      expect(subject.get_updates_list).to eq([])
+    end
   end
 
   describe "#synchronize_products" do

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -106,6 +106,12 @@ describe Registration::SwMgmt do
   end
 
   describe ".base_product_to_register" do
+    it "returns nil if not able to find a product" do
+      expect(subject).to receive(:find_base_product).and_return(nil)
+
+      expect(subject.base_product_to_register).to eq(nil)
+    end
+
     it "returns base product base version and release_type" do
       expect(subject).to(receive(:find_base_product)
         .and_return("name" => "SLES", "arch" => "x86_64",


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1084820

The list of updates will return an empty list avoiding the crash and then an error will be reported during autoinit

![errorshown](https://user-images.githubusercontent.com/7056681/37340063-b7c7799c-26b4-11e8-9549-9de6a8e1a0ef.png)
