### PR TITLE
Use the first available product for installer update

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Mar 16 13:22:35 UTC 2018 - knut.anderssen@suse.com
+
+- Just use the first product availble from the media When a self
+  update id is defined in the control file (bsc#1084820)
+- 4.0.25
+
+
+-------------------------------------------------------------------
 Tue Mar 13 09:37:14 UTC 2018 - knut.anderssen@suse.com
 
 - Prevent crashing when no product was defined in the profile

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,10 +1,9 @@
 -------------------------------------------------------------------
 Fri Mar 16 13:22:35 UTC 2018 - knut.anderssen@suse.com
 
-- Just use the first product availble from the media When a self
+- Just use the first product available from the media When a self
   update id is defined in the control file (bsc#1084820)
 - 4.0.25
-
 
 -------------------------------------------------------------------
 Tue Mar 13 09:37:14 UTC 2018 - knut.anderssen@suse.com

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.24
+Version:        4.0.25
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -190,17 +190,9 @@ module Registration
     # @see SwMgmt.remote_product
     # @see SUSE::Connect::Yast.list_installer_updates
     def get_updates_list
-      product = SwMgmt.base_product_to_register
-      return [] unless product
       id = Yast::ProductFeatures.GetStringFeature("globals", "self_update_id")
-      if !id.empty?
-        log.info "Using self update id from control file #{id.inspect}"
-        # It replaces only name of product. It keeps version and arch of base product.
-        # For arch we are sure it is safe. For version it can be issue if media contain products
-        # in different versions, but we do not expect it as it share same installer and should be
-        # based on same base system and service pack.
-        product["name"] = id
-      end
+      product = SwMgmt.installer_update_base_product(id) || SwMgmt.base_product_to_register
+      return [] unless product
 
       log.info "Reading available updates for product: #{product["name"]}"
       remote_product = SwMgmt.remote_product(product)

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -116,6 +116,33 @@ module Registration
       true
     end
 
+    # Prepare a pkg-binding product hash using the first base product available
+    # as a template and with the given self_update_id as the product name.
+    #
+    # With a media containing multiple products it is expected that all the
+    # products use the same version and arch.
+    #
+    # @param self_update_id [String] product name to be used for get the installer updates
+    # @return product [Hash,nil] with pkg-binding format; return nil if the
+    # given self_update_id is empty or there is no base product available
+    def self.installer_update_base_product(self_update_id)
+      return if self_update_id.empty?
+      base_product = Y2Packager::Product.available_base_products.first
+      return unless base_product
+
+      # filter out not needed data
+      product_info = {
+        "name"         => selt_update_id,
+        "arch"         => base_product.arch,
+        "version"      => base_product.version,
+        "release_type" => nil
+      }
+
+      log.info("Base product for installer update: #{product_info}")
+
+      product_info
+    end
+
     def self.find_base_product
       # FIXME: refactor the code to use Y2Packager::Product
 

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -132,7 +132,7 @@ module Registration
 
       # filter out not needed data
       product_info = {
-        "name"         => selt_update_id,
+        "name"         => self_update_id,
         "arch"         => base_product.arch,
         "version"      => base_product.version,
         "release_type" => nil

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -200,18 +200,15 @@ describe Registration::Registration do
   end
 
   describe "#get_updates_list" do
+    let(:self_update_id) { "SLES" }
     let(:base_product) { { "name" => "base" } }
-    let(:installer_update_base_product) { { "name" => "self_update_id" } }
+    let(:installer_update_base_product) { { "name" => self_update_id } }
     let(:remote_product) { { "name" => "base" } }
     let(:updates) { ["http://updates.suse.com/sles12/"] }
     let(:suse_connect) { double("suse_connect") }
-    let(:self_update_id) { "self_update_id" }
 
     before do
       allow(Registration::SwMgmt).to receive(:base_product_to_register).and_return(base_product)
-      allow(Yast::ProductFeatures).to receive(:GetStringFeature)
-        .with("globals", "self_update_id")
-        .and_return(self_update_id)
       stub_const("SUSE::Connect::YaST", suse_connect)
     end
 
@@ -223,20 +220,23 @@ describe Registration::Registration do
 
     context "when the control file defines a self_update_id" do
       it "returns updates list from the server for the self update id" do
+        allow(Yast::ProductFeatures).to receive(:GetStringFeature)
+          .with("globals", "self_update_id").and_return(self_update_id)
         expect(Registration::SwMgmt).to receive(:installer_update_base_product)
           .with(self_update_id).and_return(installer_update_base_product)
-        expect(Registration::SwMgmt).to receive(:remote_product).with("name" => "self_update_id")
-          .and_return("name" => "self_update_id")
+        expect(Registration::SwMgmt).to receive(:remote_product)
+          .with(installer_update_base_product).and_return(installer_update_base_product)
         expect(suse_connect).to receive(:list_installer_updates)
-          .with({ "name" => "self_update_id" }, anything)
+          .with(installer_update_base_product, anything)
           .and_return(updates)
         expect(subject.get_updates_list).to eq(updates)
       end
     end
 
     context "when the control file does not define a self_update_id" do
-      let(:self_update_id) { "" }
       it "returns updates list from the server for the base product" do
+        allow(Yast::ProductFeatures).to receive(:GetStringFeature)
+          .with("globals", "self_update_id").and_return("")
         expect(Registration::SwMgmt).to receive(:remote_product).with(base_product)
           .and_return(remote_product)
         expect(suse_connect).to receive(:list_installer_updates).with(remote_product, anything)

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -201,38 +201,48 @@ describe Registration::Registration do
 
   describe "#get_updates_list" do
     let(:base_product) { { "name" => "base" } }
+    let(:installer_update_base_product) { { "name" => "self_update_id" } }
     let(:remote_product) { { "name" => "base" } }
     let(:updates) { ["http://updates.suse.com/sles12/"] }
     let(:suse_connect) { double("suse_connect") }
+    let(:self_update_id) { "self_update_id" }
 
     before do
       allow(Registration::SwMgmt).to receive(:base_product_to_register).and_return(base_product)
+      allow(Yast::ProductFeatures).to receive(:GetStringFeature)
+        .with("globals", "self_update_id")
+        .and_return(self_update_id)
       stub_const("SUSE::Connect::YaST", suse_connect)
     end
 
-    it "returns updates list from the server for the self update id if defined" do
-      expect(Registration::SwMgmt).to receive(:remote_product).with("name" => "self_update_id")
-        .and_return("name" => "self_update_id")
-      expect(Yast::ProductFeatures).to receive(:GetStringFeature)
-        .with("globals", "self_update_id")
-        .and_return("self_update_id")
-      expect(suse_connect).to receive(:list_installer_updates)
-        .with({ "name" => "self_update_id" }, anything)
-        .and_return(updates)
-      expect(subject.get_updates_list).to eq(updates)
-    end
-
-    it "returns updates list from the server for the base product" do
-      expect(Registration::SwMgmt).to receive(:remote_product).with(base_product)
-        .and_return(remote_product)
-      expect(suse_connect).to receive(:list_installer_updates).with(remote_product, anything)
-        .and_return(updates)
-      expect(subject.get_updates_list).to eq(updates)
-    end
-
-    it "returns an empty list if no base product is selected" do
+    it "returns an empty list if no base product is available or selected" do
       allow(Registration::SwMgmt).to receive(:base_product_to_register).and_return(nil)
+      allow(Registration::SwMgmt).to receive(:installer_update_base_product).and_return(nil)
       expect(subject.get_updates_list).to eq([])
+    end
+
+    context "when the control file defines a self_update_id" do
+      it "returns updates list from the server for the self update id" do
+        expect(Registration::SwMgmt).to receive(:installer_update_base_product)
+          .with(self_update_id).and_return(installer_update_base_product)
+        expect(Registration::SwMgmt).to receive(:remote_product).with("name" => "self_update_id")
+          .and_return("name" => "self_update_id")
+        expect(suse_connect).to receive(:list_installer_updates)
+          .with({ "name" => "self_update_id" }, anything)
+          .and_return(updates)
+        expect(subject.get_updates_list).to eq(updates)
+      end
+    end
+
+    context "when the control file does not define a self_update_id" do
+      let(:self_update_id) { "" }
+      it "returns updates list from the server for the base product" do
+        expect(Registration::SwMgmt).to receive(:remote_product).with(base_product)
+          .and_return(remote_product)
+        expect(suse_connect).to receive(:list_installer_updates).with(remote_product, anything)
+          .and_return(updates)
+        expect(subject.get_updates_list).to eq(updates)
+      end
     end
   end
 

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -105,6 +105,44 @@ describe Registration::SwMgmt do
     end
   end
 
+  describe ".installer_update_base_product" do
+    let(:base_product) do
+      instance_double(Y2Packager::Product, name: "dummy", version: "15.0", arch: "x86_64")
+    end
+    let(:available_products) { [base_product] }
+
+    before do
+      allow(Y2Packager::Product).to receive(:available_base_products).and_return(available_products)
+    end
+
+    it "returns nil if the given self_update_id is empty" do
+      expect(subject.installer_update_base_product("")).to eq(nil)
+    end
+
+    context "when there is no base product available" do
+      let(:available_products) { [] }
+
+      it "returns nil" do
+        allow(Y2Packager::Product).to receive(:available_base_products).and_return([])
+        expect(subject.installer_update_base_product("self_update_id")).to eq(nil)
+      end
+    end
+
+    context "when there is some product available" do
+      it "returns a hash with the product keys 'name', 'version', 'arch' and 'release_type' " do
+        product = subject.installer_update_base_product("self_update_id")
+        expect(product).to be_a(Hash)
+        expect(product.keys.size).to eq(4)
+        expect(product).to include("name", "version", "arch", "release_type")
+      end
+
+      it "uses the given self_update_id as the product name returned" do
+        product = subject.installer_update_base_product("self_update_id")
+        expect(product["name"]).to eq("self_update_id")
+      end
+    end
+  end
+
   describe ".base_product_to_register" do
     it "returns nil if not able to find a product" do
       expect(subject).to receive(:find_base_product).and_return(nil)


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/syNlrXoP/1371-3-p1-1084820-handle-selfupdate-during-autoupgrade-correctly)

If there is a `self_update_id` defined in the control file, the product is not so important at the end as we will replace the product name and will reuse the `version` & `arch` just use the first available product as the template.