### PR TITLE
Import the SMT certificate from the system at upgrade (bsc#1080518)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 21 16:40:25 UTC 2018 - lslezak@suse.cz
+
+- Import the SMT SSL certificate at offline upgrade into
+  the inst-sys so the SMT server can be accessed (bsc#1080518)
+- 4.0.28
+
+-------------------------------------------------------------------
 Mon Mar 19 10:39:30 UTC 2018 - jreidinger@suse.com
 
 - Do not hide beta addons that are preselected (bsc#1066216,

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.27
+Version:        4.0.28
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/clients/inst_migration_repos.rb
+++ b/src/lib/registration/clients/inst_migration_repos.rb
@@ -28,8 +28,8 @@ module Registration
 
         Yast.import "Installation"
 
-        # initialize the target path
-        set_target_path
+        # initialize the inst-sys
+        instsys_init
 
         # call the normal client
         Yast::WFM.call("migration_repos", [{ "enable_back" => true }])
@@ -37,13 +37,36 @@ module Registration
 
     private
 
-      # Pass the target directory to SUSEConnect
-      def set_target_path
+      # activate the configuration from the target system in the current inst-sys
+      def instsys_init
         destdir = Yast::Installation.destdir || "/"
         return if destdir == "/"
 
         # copy the old NCC/SCC credentials to inst-sys
         SwMgmt.copy_old_credentials(destdir)
+
+        # import the SMT certificate to inst-sys
+        import_ssl_certificate
+      end
+
+      # Import the old SSL certificate if present. Tries both SLE12 nad SLE11
+      # file locations.
+      def import_ssl_certificate
+        # SLE12 certificate path
+        cert_file = File.join(Yast::Installation.destdir, SUSE::Connect::YaST::SERVER_CERT_FILE)
+
+        if !File.exist?(cert_file)
+          # try the the SLE11 certificate path as well
+          cert_file = File.join(Yast::Installation.destdir,
+            SslCertificate::SLE11_SERVER_CERT_FILE)
+
+          return unless File.exist?(cert_file)
+        end
+
+        log.info("Importing the SSL certificate from the old system (#{cert_file})...")
+        cert = SslCertificate.load_file(cert_file)
+        # in Stage.initial this imports to the inst-sys
+        cert.import
       end
     end
   end

--- a/src/lib/registration/ssl_certificate.rb
+++ b/src/lib/registration/ssl_certificate.rb
@@ -13,6 +13,9 @@ module Registration
 
     # Path to the registration certificate in the instsys
     INSTSYS_SERVER_CERT_FILE = "/etc/pki/trust/anchors/registration_server.pem".freeze
+    # the SLE11 certificate path, see
+    # https://github.com/yast/yast-registration/blob/Code-11-SP3/src/modules/Register.ycp#L296-L297
+    SLE11_SERVER_CERT_FILE = "/etc/ssl/certs/registration-server.pem".freeze
     # Path to system CA certificates
     CA_CERTS_DIR = "/var/lib/ca-certificates".freeze
 

--- a/test/inst_migration_repos_spec.rb
+++ b/test/inst_migration_repos_spec.rb
@@ -5,13 +5,45 @@ require_relative "spec_helper"
 require "registration/clients/inst_migration_repos"
 
 describe Registration::Clients::InstMigrationRepos do
+  let(:destdir) { "/mnt" }
+  let(:sle12_cert) { File.join(destdir, SUSE::Connect::YaST::SERVER_CERT_FILE) }
+  let(:sle11_cert) { File.join(destdir, Registration::SslCertificate::SLE11_SERVER_CERT_FILE) }
+
   before do
-    allow(Yast::Installation).to receive(:destdir).and_return("/")
     allow(Yast::WFM).to receive(:call)
+    allow(Yast::Installation).to receive(:destdir).and_return(destdir)
+    allow(Registration::SwMgmt).to receive(:copy_old_credentials)
+    allow(File).to receive(:exist?).and_return(false)
   end
 
   it "runs the standard \"migration_repos\" client" do
+    allow(Yast::Installation).to receive(:destdir).and_return("/")
     expect(Yast::WFM).to receive(:call).with("migration_repos", anything)
+    subject.main
+  end
+
+  it "imports the old credentials" do
+    expect(Registration::SwMgmt).to receive(:copy_old_credentials)
+    subject.main
+  end
+
+  it "imports the old SLE12 SSL certificate" do
+    expect(File).to receive(:exist?).with(sle12_cert).and_return(true)
+    expect(File).to receive(:read).with(sle12_cert).and_return(
+      File.read(fixtures_file("test.pem"))
+    )
+    expect_any_instance_of(Registration::SslCertificate).to receive(:import)
+
+    subject.main
+  end
+
+  it "imports the old SLE11 SSL certificate" do
+    expect(File).to receive(:exist?).with(sle11_cert).and_return(true)
+    expect(File).to receive(:read).with(sle11_cert).and_return(
+      File.read(fixtures_file("test.pem"))
+    )
+    expect_any_instance_of(Registration::SslCertificate).to receive(:import)
+
     subject.main
   end
 end


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1080518
- Import the original SMT SSL certificate from the target system to the inst-sys so the SMT server can be properly accessed
- Tested manually with the SMT server mentioned in the bug report (in an upgrade from SLE12-SP3)
- The imported certificate is removed when going back to the partition selection and or when migration fails/is aborted. This avoids leaking the certificate to a different system when a different partition to  upgrade is selected after going back.
- 4.0.28