### PR TITLE
Support for AY autoupgrade (bsc#1087206)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 16 11:39:41 UTC 2018 - lslezak@suse.cz
+
+- Reimplemented AutoYaST autoupgrade, use the same API and workflow
+  like in a manual upgrade (bsc#1087206)
+- 4.0.34
+
+-------------------------------------------------------------------
 Tue Apr 10 13:43:12 UTC 2018 - igonzalezsosa@suse.com
 
 - Select wanted release packages during SCC based offline

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.33
+Version:        4.0.34
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/clients/scc_auto.rb
+++ b/src/clients/scc_auto.rb
@@ -219,10 +219,8 @@ module Yast
       old = Dir[File.join(Installation.destdir, "/etc/zypp/repos.d/*")] +
         Dir[File.join(Installation.destdir, "/etc/zypp/services.d/*")]
 
-      old.each do |f|
-        log.info "Removing #{f}"
-        ::FileUtils.rm_rf(f)
-      end
+      log.info "Removing #{old}"
+      ::FileUtils.rm_rf(old)
     end
 
     # finish the registration process

--- a/src/clients/scc_auto.rb
+++ b/src/clients/scc_auto.rb
@@ -26,6 +26,7 @@
 #
 #
 
+require "fileutils"
 require "yast/suse_connect"
 
 require "registration/storage"
@@ -38,6 +39,7 @@ require "registration/connect_helpers"
 require "registration/ssl_certificate"
 require "registration/url_helpers"
 require "registration/ui/autoyast_config_workflow"
+require "registration/ui/offline_migration_workflow"
 require "registration/erb_renderer.rb"
 
 module Yast
@@ -187,9 +189,15 @@ module Yast
 
       # update the registration in AutoUpgrade mode if the old system was registered
       if Mode.update && old_system_registered?
-        updated = update_registration
-        log.info "Registration updated: #{updated}"
-        return updated
+        # drop all obsolete repositories and services (manual upgrade contains a dialog
+        # where the old repositories are deleted, in AY we need to do it automatically here)
+        # Note: the Update module creates automatically a backup which is restored
+        # when upgrade is aborted or crashes.
+        repo_cleanup
+
+        ret = ::Registration::UI::OfflineMigrationWorkflow.new.main
+        log.info "Migration result: #{ret}"
+        return ret == :next
       end
 
       ret = ::Registration::ConnectHelpers.catch_registration_errors do
@@ -202,6 +210,19 @@ module Yast
       finish_registration
 
       true
+    end
+
+    # delete all previous services and repositories
+    def repo_cleanup
+      # we cannot use pkg-bindings here because loading services would trigger
+      # service and repository refresh which we want to avoid (it might easily fail)
+      old = Dir[File.join(Installation.destdir, "/etc/zypp/repos.d/*")] +
+        Dir[File.join(Installation.destdir, "/etc/zypp/services.d/*")]
+
+      old.each do |f|
+        log.info "Removing #{f}"
+        ::FileUtils.rm_rf(f)
+      end
     end
 
     # finish the registration process
@@ -298,10 +319,8 @@ module Yast
     # update the registration (system, the base product, the installed extensions)
     def update_registration
       return false unless update_system_registration
-      return false unless update_base_product
-      return false unless update_addons
 
-      # register additional addons (e.g. originally not present in SLE11)
+      # register additional addons (e.g. originally not present in SLE11/SLE12)
       register_addons
     end
 
@@ -346,12 +365,6 @@ module Yast
       registration_ui.update_system
     end
 
-    # update the base product registration
-    # @return [Boolean] true on success
-    def update_base_product
-      handle_product_service { registration_ui.update_base_product }
-    end
-
     # @yieldreturn [Boolean, SUSE::Connect::Remote::Product] success flag and
     #   remote product pair
     # @return [Boolean] true on success
@@ -363,15 +376,6 @@ module Yast
       return true if @config.install_updates || !product_service
 
       registration_ui.disable_update_repos(product_service)
-    end
-
-    # @return [Boolean] true on success
-    # FIXME: share with inst_scc.rb
-    def update_addons
-      addons = registration_ui.get_available_addons
-
-      failed_addons = registration_ui.update_addons(addons, enable_updates: @config.install_updates)
-      failed_addons.empty?
     end
   end unless defined?(SccAutoClient)
 end

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -374,17 +374,7 @@ module Registration
       # run the migration target selection dialog
       # @return [Symbol] workflow symbol (:next or :abort)
       def select_migration_products
-        if Yast::Mode.auto
-          # TODO: for now simply select the first found migration (bsc#1087206#c7)
-          # later we can improve this (either choose the migration with higher product versions
-          # or allow selecting the migration in the AY profile)
-          self.selected_migration = migrations.first
-          self.manual_repo_selection = false
-          log.warn "More than one migration available, usign the first one" if migrations.size > 1
-          log.info "Selected migration: #{selected_migration}"
-
-          return :next
-        end
+        return select_migration_products_autoyast if Yast::Mode.auto
 
         log.info "Displaying migration target selection dialog"
         dialog = MigrationSelectionDialog.new(migrations, SwMgmt.installed_products)
@@ -397,6 +387,20 @@ module Registration
         end
 
         ret
+      end
+
+      # Select the migration product in the AutoYaST mode
+      # @return [Symbol] workflow symbol (:next)
+      def select_migration_products_autoyast
+        # TODO: for now simply select the first found migration (bsc#1087206#c7)
+        # later we can improve this (either choose the migration with higher product versions
+        # or allow selecting the migration in the AY profile)
+        self.selected_migration = migrations.first
+        self.manual_repo_selection = false
+        log.warn "More than one migration available, using the first one" if migrations.size > 1
+        log.info "Selected migration: #{selected_migration}"
+
+        :next
       end
 
       # collect products to migrate

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -158,11 +158,8 @@ module Registration
       # if the system is not registered
       # @return [Symbol] workflow symbol, :next if registered, :abort when not
       def registration_check
-        # handle system upgrade (fate#323163)
-        if Yast::Stage.initial && Yast::Mode.update
-          log.info "System upgrade mode detected"
-          return system_upgrade_check
-        end
+        ret = registration_check_at_installation
+        return ret if ret
 
         return :next if Registration.is_registered?
 
@@ -176,6 +173,23 @@ module Registration
         return :abort unless register
 
         register_system
+      end
+
+      # check the current registration status
+      # @return [nil, Symbol] the workflow symbol (:next, :skip) or nil if not
+      #   in an installation
+      def registration_check_at_installation
+        # handle system upgrade (fate#323163)
+        return nil unless Yast::Stage.initial
+        # test autoupgrade first, Mode.update covers the autoupgrade as well
+        return registration_check_at_autoupgrade if Yast::Mode.autoupgrade
+        return system_upgrade_check if Yast::Mode.update
+
+        nil
+      end
+
+      def registration_check_at_autoupgrade
+        Registration.is_registered? ? :next : :skip
       end
 
       # run the registration module to register the system
@@ -250,9 +264,11 @@ module Registration
 
         addons =
           Addon.registered_not_installed.each_with_object([]) do |addon, result|
-            if Yast::Popup.YesNoHeadline(addon.friendly_name, (msg % addon.friendly_name))
-              result << SwMgmt.remote_product(addon.to_h)
-            end
+            next unless Yast::Mode.auto || Yast::Popup.YesNoHeadline(
+              addon.friendly_name, (msg % addon.friendly_name)
+            )
+
+            result << SwMgmt.remote_product(addon.to_h)
           end
 
         products.concat(addons)
@@ -311,6 +327,10 @@ module Registration
           release_type: nil
         )
 
+        load_migrations_for_products(products, remote_product)
+      end
+
+      def load_migrations_for_products(products, remote_product)
         log.info "Loading offline migrations for target product: #{remote_product.inspect}"
         log.info "Installed products: #{products.inspect}"
         self.migrations = registration_ui.offline_migration_products(products, remote_product)
@@ -318,7 +338,7 @@ module Registration
         if migrations.empty?
           # TRANSLATORS: Error message
           Yast::Report.Error(_("No migration product found."))
-          return :empty
+          return Yast::Mode.auto ? :abort : :empty
         end
 
         :next
@@ -354,6 +374,18 @@ module Registration
       # run the migration target selection dialog
       # @return [Symbol] workflow symbol (:next or :abort)
       def select_migration_products
+        if Yast::Mode.auto
+          # TODO: for now simply select the first found migration (bsc#1087206#c7)
+          # later we can improve this (either choose the migration with higher product versions
+          # or allow selecting the migration in the AY profile)
+          self.selected_migration = migrations.first
+          self.manual_repo_selection = false
+          log.warn "More than one migration available, usign the first one" if migrations.size > 1
+          log.info "Selected migration: #{selected_migration}"
+
+          return :next
+        end
+
         log.info "Displaying migration target selection dialog"
         dialog = MigrationSelectionDialog.new(migrations, SwMgmt.installed_products)
         ret = dialog.run
@@ -455,7 +487,9 @@ module Registration
           migration_repos.services << service
         end
 
-        if migration_repos.service_with_update_repo?
+        if Yast::Mode.auto
+          migration_repos.install_updates = ::Registration::Storage::Config.instance.install_updates
+        elsif migration_repos.service_with_update_repo?
           migration_repos.install_updates = registration_ui.install_updates?
         end
 
@@ -504,6 +538,7 @@ module Registration
       #   (unregistered system or explicitly requested by user), :next =>
       #   continue with the SCC/SMT based upgrade
       def system_upgrade_check
+        log.info "System upgrade mode detected"
         # media based upgrade requested by user
         if Yast::Linuxrc.InstallInf("MediaUpgrade") == "1"
           explicit_media_upgrade

--- a/test/migration_repos_workflow_spec.rb
+++ b/test/migration_repos_workflow_spec.rb
@@ -247,6 +247,23 @@ describe Registration::UI::MigrationReposWorkflow do
       allow(Registration::UrlHelpers).to receive(:registration_url)
     end
 
+    context "no migration product found" do
+      before do
+        expect(Y2Packager::ProductUpgrade).to receive(:new_base_product).and_return(nil)
+        allow(Yast::Report).to receive(:Error)
+      end
+
+      it "displays a warning popup" do
+        expect(Yast::Report).to receive(:Error).with(/Cannot find a base product/)
+        subject.send(:load_migration_products_offline, activated_products)
+      end
+
+      it "returns :empty" do
+        ret = subject.send(:load_migration_products_offline, activated_products)
+        expect(ret).to eq(:empty)
+      end
+    end
+
     it "loads the possible migrations from the server" do
       subject.send(:load_migration_products_offline, activated_products)
       expect(subject.send(:migrations)).to_not be_empty


### PR DESCRIPTION
- The old approach from SLE12 cannot add new SCC modules ([bsc#1087206](https://bugzilla.suse.com/show_bug.cgi?id=1087206))
- Reimplemented AutoYaST autoupgrade, use the same API and workflow like in a manual upgrade 
  - Adapted the _auto client to call the offline migration client (the same as used in an interactive upgrade)
  - The offline migration has been adapted to support also the AutoYaST autoupgrade mode (usually just skipping the interactive parts)
- Tested manually
- 4.0.34

## Screenshot

Tested manually with the `<confirm config:type="boolean">true</confirm>` option in the XML profile:
![sles12_autoupgrade_proposal](https://user-images.githubusercontent.com/907998/38809378-8cee5ec2-4183-11e8-9cae-723ea6f283ea.png)
