### PR TITLE
Install a registration rollback script (bsc#1089643)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Apr 27 15:44:43 UTC 2018 - lslezak@suse.cz
+
+- Install a registration rollback script to rollback the
+  registration in case YaST is aborted or crashes during upgrade
+  (bsc#1089643)
+- 4.0.35
+
+-------------------------------------------------------------------
 Mon Apr 16 11:39:41 UTC 2018 - lslezak@suse.cz
 
 - Reimplemented AutoYaST autoupgrade, use the same API and workflow

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.34
+Version:        4.0.35
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/data/registration/registration_rollback.sh
+++ b/src/data/registration/registration_rollback.sh
@@ -1,6 +1,8 @@
 #! /bin/sh
 
 # This script rolls back the registration status on the server
+# You can optionally pass the target chroot directory as a parameter,
+# the default is "/".
 
 ROOT=${1:-/}
 

--- a/src/data/registration/registration_rollback.sh
+++ b/src/data/registration/registration_rollback.sh
@@ -1,0 +1,12 @@
+#! /bin/sh
+
+# This script rolls back the registration status on the server
+
+ROOT=${1:-/}
+
+# print the progress in green so it is better visible
+echo -e "\e[0;32mRestoring the registration status at ${ROOT}, \
+this might take several minutes...\e[0m"
+
+# run the rollback
+chroot "$ROOT" SUSEConnect --rollback

--- a/src/lib/registration/rollback_script.rb
+++ b/src/lib/registration/rollback_script.rb
@@ -1,0 +1,72 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "fileutils"
+
+module Registration
+  # This class handles creating a registration rollback script  which is called
+  # when the upgrade is aborted or YaST crashes. The script body is stored
+  # in the data/registration/registration_rollback.sh file.
+  class RollbackScript
+    include Yast::Logger
+
+    BACKUP_DIR = "var/adm/backup/system-upgrade".freeze
+
+    # use number 0200, the original repositories need to be restored first,
+    # they are stored in script with number 0100
+    DEFAULT_SCRIPT_NAME = "restore-0200-registration.sh".freeze
+
+    SUSE_CONNECT = "/usr/sbin/SUSEConnect".freeze
+
+    attr_reader :name, :root
+
+    # @param name [String] script name
+    # @param root [String] target root
+    def initialize(name: DEFAULT_SCRIPT_NAME, root: "/mnt")
+      @name = name
+      @root = root
+    end
+
+    # create the registration rollback script
+    # @note The script can be created only when the target root is mounted.
+    def create
+      log.info "Creating registration rollback script #{script_path}"
+      src_file = File.expand_path("../../../data/registration/registration_rollback.sh", __FILE__)
+      ::FileUtils.cp(src_file, script_path)
+    end
+
+    # delete the script
+    def delete
+      return unless File.exist?(script_path)
+
+      log.info "Removing the registration rollback script (#{script_path})"
+      File.delete(script_path)
+    end
+
+    # can the rollback script be applied?
+    def applicable?
+      # check if the SUSEConnect tool is present, it might not be installed
+      # or not available at all (when upgrading from SLE11)
+      ret = File.exist?(File.join(root, SUSE_CONNECT))
+      log.info("File #{SUSE_CONNECT} found at #{root}: #{ret}")
+      ret
+    end
+
+    # full path to the script
+    # @return [String] path
+    def script_path
+      @path ||= File.join(root, BACKUP_DIR, name)
+    end
+  end
+end

--- a/src/lib/registration/rollback_script.rb
+++ b/src/lib/registration/rollback_script.rb
@@ -29,12 +29,10 @@ module Registration
 
     SUSE_CONNECT = "/usr/sbin/SUSEConnect".freeze
 
-    attr_reader :name, :root
+    attr_reader :root
 
-    # @param name [String] script name
     # @param root [String] target root
-    def initialize(name: DEFAULT_SCRIPT_NAME, root: "/mnt")
-      @name = name
+    def initialize(root: "/mnt")
       @root = root
     end
 
@@ -66,7 +64,7 @@ module Registration
     # full path to the script
     # @return [String] path
     def script_path
-      @path ||= File.join(root, BACKUP_DIR, name)
+      @path ||= File.join(root, BACKUP_DIR, DEFAULT_SCRIPT_NAME)
     end
   end
 end

--- a/src/lib/registration/storage.rb
+++ b/src/lib/registration/storage.rb
@@ -61,7 +61,7 @@ module Registration
     end
 
     class Cache < Struct.new(:first_run, :addon_services,
-      :reg_url, :reg_url_cached, :upgrade_failed)
+      :reg_url, :reg_url_cached, :rollback, :upgrade_failed)
 
       include Singleton
 

--- a/src/lib/registration/ui/registration_sync_workflow.rb
+++ b/src/lib/registration/ui/registration_sync_workflow.rb
@@ -18,6 +18,7 @@ require "registration/registration"
 require "registration/registration_ui"
 require "registration/releasever"
 require "registration/sw_mgmt"
+require "registration/storage"
 require "registration/url_helpers"
 require "registration/ui/wizard_client"
 
@@ -63,6 +64,7 @@ module Registration
 
         # downgrade all installed products
         return :abort unless downgrade_products(products)
+        remove_rollback_script
 
         reload_repos
 
@@ -106,6 +108,17 @@ module Registration
           success, _service = registration_ui.downgrade_product(product)
           success
         end
+      end
+
+      # remove the rollback script after doing the rollback by YaST
+      # (avoid double rollback)
+      def remove_rollback_script
+        rollback = Storage::Cache.instance.rollback
+        return unless rollback
+
+        # remove the saved script and drop the cache
+        rollback.delete
+        Storage::Cache.instance.rollback = nil
       end
     end
   end

--- a/test/migration_repos_workflow_spec.rb
+++ b/test/migration_repos_workflow_spec.rb
@@ -124,6 +124,7 @@ describe Registration::UI::MigrationReposWorkflow do
       before do
         expect(Registration::SwMgmt).to receive(:init).at_least(1)
         allow_any_instance_of(Registration::RepoStateStorage).to receive(:write)
+        allow_any_instance_of(Registration::RollbackScript).to receive(:create)
       end
 
       let(:set_success_expectations) do


### PR DESCRIPTION
- The script starts automatic rollback of the registration when YaST is aborted or crashes during upgrade.
- Tested manually with DUD and the latest build, tested also the happy path (the testing system was also successfully migrated to SLE15)
- ENOTIME, no unit tests, this is urgent for RC4 :confused: 

## Screenshots


#### Aborting Upgrade

When the upgrade is manually aborted the script restores back the original registration status.
![rollback_abort](https://user-images.githubusercontent.com/907998/39373186-0dc1f268-4a47-11e8-9138-cec03c1e805e.gif)

When YaST crashes hard the rollback script is also called. For the testing purposes I have exited YaST using the embedded debugger, but in reality it would be a hard crash (e.g. segfault, OOM killer,...).
![rollback_crash](https://user-images.githubusercontent.com/907998/39373916-6530d1de-4a49-11e8-9a1e-b8832ce5f53f.gif)

*(Note: the tests were run with `startshell=1`, normally the linuxrc menu would be displayed at the end.)*
