### PR TITLE
On migration test baseproduct link for base product (bsc#1092965)

### DIFF
--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -163,7 +163,7 @@ module Registration
       # The base product must be marked by the "system-installation()" provides
       # by some package.
       products = Pkg.ResolvableProperties("", :product, "").find_all do |p|
-        if Stage.initial && !system_products.include?(p["name"])
+        if Stage.initial && !Mode.update && !system_products.include?(p["name"])
           log.info("Skipping product #{p["name"].inspect}, no system-installation() provides")
           next false
         end


### PR DESCRIPTION
Checking the old product name against the system-installation()
provides will lead to wrong results if the name differs between
migration source and migration target.

Signed-off-by: Egbert Eich <eich@suse.com>