### PR TITLE
Fixed evaluating the installed product (bsc#1095702)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun  5 10:12:07 UTC 2018 - lslezak@suse.cz
+
+- Fixed evaluating the installed product (the installed upgraded
+  products are marked as "removed") (bsc#1095702)
+- 4.0.38
+
+-------------------------------------------------------------------
 Wed May 30 12:26:23 UTC 2018 - lslezak@suse.cz
 
 - Fixes for upgrade via SMT (bsc#1094865):

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.37
+Version:        4.0.38
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -231,7 +231,10 @@ module Registration
       # just for testing/debugging
       return [FAKE_BASE_PRODUCT] if ENV["FAKE_BASE_PRODUCT"]
 
-      products = Pkg.ResolvableProperties("", :product, "").select do |p|
+      all_products = Pkg.ResolvableProperties("", :product, "")
+      log.info("Evaluating products: #{all_products}")
+
+      products = all_products.select do |p|
         # installed or installed marked for removal (at upgrade)
         p["status"] == :installed || p["status"] == :removed
       end

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -232,7 +232,8 @@ module Registration
       return [FAKE_BASE_PRODUCT] if ENV["FAKE_BASE_PRODUCT"]
 
       products = Pkg.ResolvableProperties("", :product, "").select do |p|
-        p["status"] == :installed
+        # installed or installed marked for removal (at upgrade)
+        p["status"] == :installed || p["status"] == :removed
       end
 
       log.info "Found installed products: #{products.map { |p| p["name"] }}"


### PR DESCRIPTION
- During upgrade the installed products are not only marked as `:installed` but the products selected to upgrade might have status `:removed` as they will be removed from the system and replaced by a new version
- Fix for https://bugzilla.suse.com/show_bug.cgi?id=1095702
- Version 4.0.38