### PR TITLE
Prefer the SCC credentials at upgrade (bsc#1096813)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun 13 14:00:30 UTC 2018 - lslezak@suse.cz
+
+- Prefer the SCC credentials at upgrade when both NCC and SCC
+  credentials are present in the system (bsc#1096813)
+- 4.0.40
+
+-------------------------------------------------------------------
 Wed Jun  6 07:33:07 UTC 2018 - lslezak@suse.cz
 
 - Fixed also the another places detecting the installed product

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.39
+Version:        4.0.40
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -451,7 +451,12 @@ module Registration
         ::FileUtils.mkdir_p(dir)
       end
 
-      Dir[File.join(source_dir, dir, "*")].each do |path|
+      # if the system contains both NCC and SCC credentials then the SCC ones
+      # should be preferred (bsc#1096813)
+      # take advantage that "NCCcredentials" is alphabetically before
+      # "SCCcredentials" so it is enough to just sort the files and then the
+      # SCC credentials will simply overwrite the NCC credentials
+      Dir[File.join(source_dir, dir, "*")].sort.each do |path|
         # skip non-files
         next unless File.file?(path)
 

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -241,7 +241,7 @@ describe Registration::SwMgmt do
       expect(Dir).to receive(:[]).with(File.join(root_dir, target_dir, "*"))
         .and_return([scc_credentials, ncc_credentials])
 
-      # copy the credentials in the NCC, SCC order
+      # copy the credentials in the NCC, SCC order (bsc#1096813)
       expect(subject).to receive(:`).with("cp -a " + ncc_credentials + " " +
         File.join(target_dir, "SCCcredentials")).ordered
       expect(subject).to receive(:`).with("cp -a " + scc_credentials + " " +

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -207,6 +207,7 @@ describe Registration::SwMgmt do
     let(:root_dir) { "/mnt" }
     let(:target_dir) { SUSE::Connect::YaST::DEFAULT_CREDENTIALS_DIR }
     let(:ncc_credentials) { File.join(root_dir, target_dir, "NCCcredentials") }
+    let(:scc_credentials) { File.join(root_dir, target_dir, "SCCcredentials") }
 
     before do
       expect(File).to receive(:exist?).with(target_dir).and_return(false)
@@ -232,11 +233,26 @@ describe Registration::SwMgmt do
         File.join(target_dir, "SCCcredentials"))
       expect(SUSE::Connect::YaST).to receive(:credentials).and_return(OpenStruct.new)
 
-      expect { subject.copy_old_credentials(root_dir) }.to_not raise_error
+      subject.copy_old_credentials(root_dir)
+    end
+
+    it "prefers the SCC credentials if both NCC and SCC credentials are present" do
+      # deliberately return the SCC credentials first here
+      expect(Dir).to receive(:[]).with(File.join(root_dir, target_dir, "*"))
+        .and_return([scc_credentials, ncc_credentials])
+
+      # copy the credentials in the NCC, SCC order
+      expect(subject).to receive(:`).with("cp -a " + ncc_credentials + " " +
+        File.join(target_dir, "SCCcredentials")).ordered
+      expect(subject).to receive(:`).with("cp -a " + scc_credentials + " " +
+        File.join(target_dir, "SCCcredentials")).ordered
+
+      allow(SUSE::Connect::YaST).to receive(:credentials).and_return(OpenStruct.new)
+
+      subject.copy_old_credentials(root_dir)
     end
 
     it "copies old SCC credentials at upgrade" do
-      scc_credentials = File.join(root_dir, target_dir, "SCCcredentials")
       expect(Dir).to receive(:[]).with(File.join(root_dir, target_dir, "*"))
         .and_return([scc_credentials])
 
@@ -244,7 +260,7 @@ describe Registration::SwMgmt do
         File.join(target_dir, "SCCcredentials"))
       expect(SUSE::Connect::YaST).to receive(:credentials).and_return(OpenStruct.new)
 
-      expect { subject.copy_old_credentials(root_dir) }.to_not raise_error
+      subject.copy_old_credentials(root_dir)
     end
 
     it "copies old SMT credentials at upgrade" do


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1096813
- The SCC credentials were overwritten by the NCC credentials because the order returned by `Dir[]` is undefined (very likely it depends on the order on the disk)
- Fixed by simply calling `#sort` to have a defined guaranteed order
- 4.0.40