### PR TITLE
Do not build on 32-bit archs (bsc#1088552)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 26 09:25:16 UTC 2018 - lslezak@suse.cz
+
+- Do not build on 32-bit archs, SUSEConnect is not available
+  there (bsc#1088552)
+- 3.2.15
+
+-------------------------------------------------------------------
 Wed Jul 25 11:58:13 UTC 2018 - lslezak@suse.com
 
 - Updated the unit test to pass with the latest SUSEConnect

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.2.14
+Version:        3.2.15
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -60,6 +60,9 @@ BuildRequires:  yast2-packager >= 3.1.95
 BuildRequires:  yast2-update >= 3.1.36
 
 BuildArch:      noarch
+# SUSEConnect does not build for i586 and s390 and is not supported on those architectures
+# bsc#1088552
+ExcludeArch:    %ix86 s390
 
 # FIXME: it seems can we cannot move it to macros.yast, the yast-rake-ci is not
 # installed into the chroot, the build fails...


### PR DESCRIPTION
- SUSEConnect has been updated in SP3 with the new `ExcludeArch` from SLE15
- Update YaST as well so it does not fail in OBS
- 3.2.15