### PR TITLE
Filter all development versions when selecting addons

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 14 13:10:04 UTC 2018 - knut.anderssen@suse.com
+
+- Modified addon selection filter for filtering all the development
+  versions (bsc#1104450)
+- 4.1.0
+
+-------------------------------------------------------------------
 Wed Jul 18 10:45:15 CEST 2018 - schubi@suse.de
 
 - Do not crash if getting zypp lock failed. (bnc#1043125)

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
 Tue Aug 14 13:10:04 UTC 2018 - knut.anderssen@suse.com
 
-- Modified addon selection filter for filtering all the development
-  versions (bsc#1104450)
+- Modified addon selection filter for filtering all the testing
+  (not released) versions (bsc#1104450)
 - 4.1.0
 
 -------------------------------------------------------------------

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.43
+Version:        4.1.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -266,8 +266,10 @@ module Registration
       Addon.registered.delete(self) if registered?
     end
 
-    def beta_release?
-      release_stage == "beta"
+    DEVELOPMENT_STAGES = ["alpha", "beta"].freeze
+
+    def supported_release?
+      !DEVELOPMENT_STAGES.include?(release_stage)
     end
 
     # get a product printable name (long name if present, fallbacks to the short name)

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -268,8 +268,8 @@ module Registration
 
     DEVELOPMENT_STAGES = ["alpha", "beta"].freeze
 
-    def supported_release?
-      !DEVELOPMENT_STAGES.include?(release_stage)
+    def released?
+      release_stage == "released"
     end
 
     # get a product printable name (long name if present, fallbacks to the short name)

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -70,7 +70,7 @@ module Registration
         if enable
           @addons = @all_addons.select do |a|
             a.registered? || a.selected? || a.auto_selected? ||
-              !a.beta_release?
+              a.supported_release?
           end
         else
           @addons = @all_addons
@@ -92,9 +92,9 @@ module Registration
         vbox_elements = [Left(Heading(heading))]
         available_addons = @all_addons.reject(&:registered?)
 
-        unless available_addons.empty? || available_addons.select(&:beta_release?).empty?
+        unless available_addons.empty? || available_addons.all?(&:supported_release?)
           vbox_elements.push(Left(CheckBox(Id(:filter_beta), Opt(:notify),
-            _("&Hide Beta Versions"), check_filter)))
+            _("&Hide Development Versions"), check_filter)))
         end
 
         vbox_elements.concat([addons_box, Left(Label(_("Details (English only)"))), details_widget])

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -95,7 +95,7 @@ module Registration
         unless available_addons.empty? || available_addons.all?(&:released?)
           vbox_elements.push(Left(CheckBox(Id(:filter_devel), Opt(:notify),
             # TRANSLATORS: Checkbox label, hides alpha or beta versions (not released yet)
-            _("&Hide Testing Versions"), check_filter)))
+            _("&Hide Development Versions"), check_filter)))
         end
 
         vbox_elements.concat([addons_box, Left(Label(_("Details (English only)"))), details_widget])

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -70,7 +70,7 @@ module Registration
         if enable
           @addons = @all_addons.select do |a|
             a.registered? || a.selected? || a.auto_selected? ||
-              a.supported_release?
+              a.released?
           end
         else
           @addons = @all_addons
@@ -92,9 +92,10 @@ module Registration
         vbox_elements = [Left(Heading(heading))]
         available_addons = @all_addons.reject(&:registered?)
 
-        unless available_addons.empty? || available_addons.all?(&:supported_release?)
+        unless available_addons.empty? || available_addons.all?(&:released?)
           vbox_elements.push(Left(CheckBox(Id(:filter_beta), Opt(:notify),
-            _("&Hide Development Versions"), check_filter)))
+            # TRANSLATORS: Checkbox label, hides alpha or beta versions (not released yet)
+            _("&Hide Testing Versions"), check_filter)))
         end
 
         vbox_elements.concat([addons_box, Left(Label(_("Details (English only)"))), details_widget])

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -24,10 +24,10 @@ module Registration
       Yast.import "Arch"
 
       class << self
-        attr_accessor :filter_beta
+        attr_accessor :filter_devel
       end
 
-      FILTER_BETAS_INITIALLY = true
+      FILTER_DEVEL_INITIALLY = true
 
       # constructor
       # @param registration [Registration::Registration] use this Registration object for
@@ -39,10 +39,9 @@ module Registration
         # sort the addons
         @all_addons.sort!(&::Registration::ADDON_SORTER)
 
-        self.class.filter_beta = FILTER_BETAS_INITIALLY if self.class.filter_beta.nil?
-
+        self.class.filter_devel = FILTER_DEVEL_INITIALLY if self.class.filter_devel.nil?
         preselect_recommended
-        filter_beta_releases(self.class.filter_beta)
+        filter_devel_releases(self.class.filter_devel)
 
         @old_selection = Addon.selected.dup
       end
@@ -63,10 +62,10 @@ module Registration
         "#{addon.identifier}-#{addon.version}-#{addon.arch}"
       end
 
-      # Enables or disables beta addons filtering
-      # @param [Boolean] enable true for filtering beta releases
-      def filter_beta_releases(enable)
-        self.class.filter_beta = enable
+      # Enables or disables devel addons filtering
+      # @param [Boolean] enable true for filtering devel releases
+      def filter_devel_releases(enable)
+        self.class.filter_devel = enable
         if enable
           @addons = @all_addons.select do |a|
             a.registered? || a.selected? || a.auto_selected? ||
@@ -88,12 +87,13 @@ module Registration
       # create the main dialog definition
       # @return [Yast::Term] the main UI dialog term
       def content
-        check_filter = self.class.filter_beta.nil? ? FILTER_BETAS_INITIALLY : self.class.filter_beta
+        check_filter =
+          self.class.filter_devel.nil? ? FILTER_DEVEL_INITIALLY : self.class.filter_devel
         vbox_elements = [Left(Heading(heading))]
         available_addons = @all_addons.reject(&:registered?)
 
         unless available_addons.empty? || available_addons.all?(&:released?)
-          vbox_elements.push(Left(CheckBox(Id(:filter_beta), Opt(:notify),
+          vbox_elements.push(Left(CheckBox(Id(:filter_devel), Opt(:notify),
             # TRANSLATORS: Checkbox label, hides alpha or beta versions (not released yet)
             _("&Hide Testing Versions"), check_filter)))
         end
@@ -216,8 +216,8 @@ module Registration
             ret = Stage.initial && !AbortConfirmation.run ? nil : :abort
             # when canceled switch to old selection
             Addon.selected.replace(@old_selection) if ret == :abort
-          when :filter_beta
-            filter_beta_releases(Yast::UI.QueryWidget(Id(ret), :Value))
+          when :filter_devel
+            filter_devel_releases(Yast::UI.QueryWidget(Id(ret), :Value))
             show_addons
           else
             handle_addon_selection(ret)

--- a/test/addon_selection_dialog_test.rb
+++ b/test/addon_selection_dialog_test.rb
@@ -18,13 +18,13 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
   end
 
   describe "#initialize" do
-    it "sets the beta filter to the previous state" do
+    it "sets the development filter to the previous state" do
       fake_ref = double.as_null_object
       registration = double(activated_products: [], get_addon_list: [])
       res = described_class.new(registration)
-      res.send(:filter_beta_releases, false)
+      res.send(:filter_devel_releases, false)
 
-      expect_any_instance_of(described_class).to receive(:filter_beta_releases).with(false)
+      expect_any_instance_of(described_class).to receive(:filter_devel_releases).with(false)
       described_class.new(fake_ref)
     end
   end
@@ -33,11 +33,11 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
     subject { Registration::UI::AddonSelectionRegistrationDialog }
 
     let(:registration) { double(activated_products: [], get_addon_list: []) }
-    let(:filter_beta) { false }
+    let(:filter_devel) { false }
     let(:recommended_addon) { addon_generator("recommended" => true) }
 
     before do
-      allow(described_class).to receive(:filter_beta).and_return(filter_beta)
+      allow(described_class).to receive(:filter_devel).and_return(filter_devel)
       allow(Yast::UI).to receive(:TextMode).and_return(false)
       allow(Yast::UI).to receive(:UserInput).and_return(:next)
       allow_any_instance_of(described_class).to receive(:RichText).and_call_original
@@ -142,26 +142,26 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       expect(child.auto_selected?).to eq true
     end
 
-    context "when beta versions are not filtered" do
+    context "when development versions are not filtered" do
       let(:addon) do
         Registration::Addon.new(
           addon_generator
         )
       end
       subject(:dialog) { described_class.new(registration) }
-      let(:filter_beta) { false }
+      let(:filter_devel) { false }
 
       it "sets the filter as not checked in the UI" do
         allow(addon).to receive(:released?).and_return(false)
         allow(addon).to receive(:registered?).and_return(false)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
         expect(dialog).to receive(:CheckBox)
-          .with(Yast::Term.new(:id, :filter_beta), anything, anything, filter_beta)
+          .with(Yast::Term.new(:id, :filter_devel), anything, anything, filter_devel)
           .and_call_original
         dialog.run
       end
 
-      it "displays beta add-ons" do
+      it "displays development add-ons" do
         allow(addon).to receive(:released?).and_return(false)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
         expect(subject).to receive(:RichText).with(Yast::Term.new(:id, :items), /#{addon.name}/)
@@ -170,26 +170,26 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       end
     end
 
-    context "when beta versions are filtered" do
+    context "when development versions are filtered" do
       let(:addon) do
         Registration::Addon.new(
           addon_generator
         )
       end
       subject(:dialog) { described_class.new(registration) }
-      let(:filter_beta) { true }
+      let(:filter_devel) { true }
 
       it "sets the filter as checked in the UI" do
         allow(addon).to receive(:released?).and_return(false)
         allow(addon).to receive(:registered?).and_return(false)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
         expect(dialog).to receive(:CheckBox)
-          .with(Yast::Term.new(:id, :filter_beta), anything, anything, filter_beta)
+          .with(Yast::Term.new(:id, :filter_devel), anything, anything, filter_devel)
           .and_call_original
         dialog.run
       end
 
-      it "does not display beta add-ons that are not registered" do
+      it "does not display development add-ons that are not registered" do
         allow(addon).to receive(:released?).and_return(false)
         allow(addon).to receive(:registered?).and_return(false)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
@@ -198,7 +198,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
         dialog.run
       end
 
-      it "display registered beta add-ons" do
+      it "display registered development add-ons" do
         allow(addon).to receive(:released?).and_return(false)
         allow(addon).to receive(:registered?).and_return(true)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
@@ -207,7 +207,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
         dialog.run
       end
 
-      it "displays recommended beta add-ons" do
+      it "displays recommended development add-ons" do
         allow(addon).to receive(:released?).and_return(false)
         allow(addon).to receive(:registered?).and_return(false)
         allow(addon).to receive(:recommended).and_return(true)
@@ -217,7 +217,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
         dialog.run
       end
 
-      it "displays auto-selected beta add-ons" do
+      it "displays auto-selected development add-ons" do
         allow(addon).to receive(:released?).and_return(false)
         allow(addon).to receive(:registered?).and_return(false)
         allow(addon).to receive(:recommended).and_return(false)
@@ -229,7 +229,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       end
     end
 
-    context "when there is no beta versions to filter" do
+    context "when there is no development versions to filter" do
       subject(:dialog) { described_class.new(registration) }
 
       it "shows no filter in the UI" do
@@ -245,13 +245,13 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       Registration::UI::AddonSelectionRegistrationDialog.new(registration)
     end
 
-    it "filters beta releases" do
-      expect(Yast::UI).to receive(:UserInput).and_return(:filter_beta, :next)
+    it "filters development releases" do
+      expect(Yast::UI).to receive(:UserInput).and_return(:filter_devel, :next)
 
       expect(Yast::UI).to receive(:QueryWidget)
-        .with(Yast::Term.new(:id, :filter_beta), :Value)
+        .with(Yast::Term.new(:id, :filter_devel), :Value)
         .and_return(true)
-      expect(subject).to receive(:filter_beta_releases).with(true)
+      expect(subject).to receive(:filter_devel_releases).with(true)
 
       expect(subject.send(:handle_dialog)).to_not eq :back
     end

--- a/test/addon_selection_dialog_test.rb
+++ b/test/addon_selection_dialog_test.rb
@@ -152,7 +152,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       let(:filter_beta) { false }
 
       it "sets the filter as not checked in the UI" do
-        allow(addon).to receive(:beta_release?).and_return(true)
+        allow(addon).to receive(:supported_release?).and_return(false)
         allow(addon).to receive(:registered?).and_return(false)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
         expect(dialog).to receive(:CheckBox)
@@ -162,7 +162,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       end
 
       it "displays beta add-ons" do
-        allow(addon).to receive(:beta_release?).and_return(true)
+        allow(addon).to receive(:supported_release?).and_return(false)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
         expect(subject).to receive(:RichText).with(Yast::Term.new(:id, :items), /#{addon.name}/)
         allow(subject).to receive(:RichText).and_call_original
@@ -180,7 +180,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       let(:filter_beta) { true }
 
       it "sets the filter as checked in the UI" do
-        allow(addon).to receive(:beta_release?).and_return(true)
+        allow(addon).to receive(:supported_release?).and_return(false)
         allow(addon).to receive(:registered?).and_return(false)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
         expect(dialog).to receive(:CheckBox)
@@ -190,7 +190,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       end
 
       it "does not display beta add-ons that are not registered" do
-        allow(addon).to receive(:beta_release?).and_return(true)
+        allow(addon).to receive(:supported_release?).and_return(false)
         allow(addon).to receive(:registered?).and_return(false)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
         expect(subject).to receive(:RichText).with(Yast::Term.new(:id, :items), "")
@@ -199,7 +199,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       end
 
       it "display registered beta add-ons" do
-        allow(addon).to receive(:beta_release?).and_return(true)
+        allow(addon).to receive(:supported_release?).and_return(false)
         allow(addon).to receive(:registered?).and_return(true)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
         expect(subject).to receive(:RichText).with(Yast::Term.new(:id, :items), /#{addon.name}/)
@@ -208,7 +208,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       end
 
       it "displays recommended beta add-ons" do
-        allow(addon).to receive(:beta_release?).and_return(true)
+        allow(addon).to receive(:supported_release?).and_return(false)
         allow(addon).to receive(:registered?).and_return(false)
         allow(addon).to receive(:recommended).and_return(true)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
@@ -218,7 +218,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       end
 
       it "displays auto-selected beta add-ons" do
-        allow(addon).to receive(:beta_release?).and_return(true)
+        allow(addon).to receive(:supported_release?).and_return(false)
         allow(addon).to receive(:registered?).and_return(false)
         allow(addon).to receive(:recommended).and_return(false)
         allow(addon).to receive(:auto_selected?).and_return(true)

--- a/test/addon_selection_dialog_test.rb
+++ b/test/addon_selection_dialog_test.rb
@@ -152,7 +152,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       let(:filter_beta) { false }
 
       it "sets the filter as not checked in the UI" do
-        allow(addon).to receive(:supported_release?).and_return(false)
+        allow(addon).to receive(:released?).and_return(false)
         allow(addon).to receive(:registered?).and_return(false)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
         expect(dialog).to receive(:CheckBox)
@@ -162,7 +162,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       end
 
       it "displays beta add-ons" do
-        allow(addon).to receive(:supported_release?).and_return(false)
+        allow(addon).to receive(:released?).and_return(false)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
         expect(subject).to receive(:RichText).with(Yast::Term.new(:id, :items), /#{addon.name}/)
         allow(subject).to receive(:RichText).and_call_original
@@ -180,7 +180,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       let(:filter_beta) { true }
 
       it "sets the filter as checked in the UI" do
-        allow(addon).to receive(:supported_release?).and_return(false)
+        allow(addon).to receive(:released?).and_return(false)
         allow(addon).to receive(:registered?).and_return(false)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
         expect(dialog).to receive(:CheckBox)
@@ -190,7 +190,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       end
 
       it "does not display beta add-ons that are not registered" do
-        allow(addon).to receive(:supported_release?).and_return(false)
+        allow(addon).to receive(:released?).and_return(false)
         allow(addon).to receive(:registered?).and_return(false)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
         expect(subject).to receive(:RichText).with(Yast::Term.new(:id, :items), "")
@@ -199,7 +199,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       end
 
       it "display registered beta add-ons" do
-        allow(addon).to receive(:supported_release?).and_return(false)
+        allow(addon).to receive(:released?).and_return(false)
         allow(addon).to receive(:registered?).and_return(true)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
         expect(subject).to receive(:RichText).with(Yast::Term.new(:id, :items), /#{addon.name}/)
@@ -208,7 +208,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       end
 
       it "displays recommended beta add-ons" do
-        allow(addon).to receive(:supported_release?).and_return(false)
+        allow(addon).to receive(:released?).and_return(false)
         allow(addon).to receive(:registered?).and_return(false)
         allow(addon).to receive(:recommended).and_return(true)
         allow(Registration::Addon).to receive(:find_all).and_return([addon])
@@ -218,7 +218,7 @@ describe Registration::UI::AddonSelectionRegistrationDialog do
       end
 
       it "displays auto-selected beta add-ons" do
-        allow(addon).to receive(:supported_release?).and_return(false)
+        allow(addon).to receive(:released?).and_return(false)
         allow(addon).to receive(:registered?).and_return(false)
         allow(addon).to receive(:recommended).and_return(false)
         allow(addon).to receive(:auto_selected?).and_return(true)

--- a/test/addon_spec.rb
+++ b/test/addon_spec.rb
@@ -196,22 +196,22 @@ describe Registration::Addon do
     end
   end
 
-  describe "#supported_release?" do
-    it "returns false if addon is pre production release" do
-      alpha_product = addon_generator("release_stage" => "beta")
+  describe "#released?" do
+    it "returns false if addon is a testing release" do
+      alpha_product = addon_generator("release_stage" => "alpha")
       alpha_addon = Registration::Addon.new(alpha_product)
       beta_product = addon_generator("release_stage" => "beta")
       beta_addon = Registration::Addon.new(beta_product)
 
-      expect(alpha_addon.supported_release?).to eq(false)
-      expect(beta_addon.supported_release?).to eq(false)
+      expect(alpha_addon.released?).to eq(false)
+      expect(beta_addon.released?).to eq(false)
     end
 
     it "returns true if addon is a supported release" do
-      product = addon_generator("release_stage" => "production")
+      product = addon_generator("release_stage" => "released")
       addon = Registration::Addon.new(product)
 
-      expect(addon.supported_release?).to eq(true)
+      expect(addon.released?).to eq(true)
     end
   end
 

--- a/test/addon_spec.rb
+++ b/test/addon_spec.rb
@@ -196,19 +196,22 @@ describe Registration::Addon do
     end
   end
 
-  describe "#beta_release?" do
-    it "returns true if addon is beta release" do
-      product = addon_generator("release_stage" => "beta")
-      addon = Registration::Addon.new(product)
+  describe "#supported_release?" do
+    it "returns false if addon is pre production release" do
+      alpha_product = addon_generator("release_stage" => "beta")
+      alpha_addon = Registration::Addon.new(alpha_product)
+      beta_product = addon_generator("release_stage" => "beta")
+      beta_addon = Registration::Addon.new(beta_product)
 
-      expect(addon.beta_release?).to eq(true)
+      expect(alpha_addon.supported_release?).to eq(false)
+      expect(beta_addon.supported_release?).to eq(false)
     end
 
-    it "returns false if addon is not beta release" do
+    it "returns true if addon is a supported release" do
       product = addon_generator("release_stage" => "production")
       addon = Registration::Addon.new(product)
 
-      expect(addon.beta_release?).to eq(false)
+      expect(addon.supported_release?).to eq(true)
     end
   end
 


### PR DESCRIPTION
- Trello Card: https://trello.com/c/S7syCFlB
- Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1104450

By now I have modified only the more relevant parts using the label proposed by @fcrozat , there are still some methods [1] that could be renamed for removing almost completely any "beta" mention.

## Hide checked

![hidetestingversions](https://user-images.githubusercontent.com/7056681/44107880-a20458f4-9ff0-11e8-9199-4642686281dd.png)


# Hide unchecked

![unhidetestingversions](https://user-images.githubusercontent.com/7056681/44107874-9fa7d69e-9ff0-11e8-978f-32388b2734a2.png)

---

[1] https://github.com/yast/yast-registration/blob/master/src/lib/registration/ui/addon_selection_base_dialog.rb#L27