### PR TITLE
Suggest downloading "SLE-15-SP1-Packages" (bsc#1108620)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 17 08:54:19 UTC 2018 - lslezak@suse.cz
+
+- Suggest downloading the "SLE-15-SP1-Packages" medium instead of
+  the old "SLE-15-Packages" (bsc#1108620)
+- 4.1.3
+
+-------------------------------------------------------------------
 Tue Sep  4 08:34:31 UTC 2018 - dgonzalez@suse.com
 
 - Limit the registration code size to 512 characters (bsc#1098576)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.1.2
+Version:        4.1.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -371,7 +371,7 @@ module Registration
           "%{media_name} media from %{download_url}.\n" \
           "Without these media only a minimum system is available\n" \
           "in this installation.") %
-          { media_name: "SLE-15-Packages", download_url: "https://download.suse.com" }
+          { media_name: "SLE-15-SP1-Packages", download_url: "https://download.suse.com" }
         Yast::Popup.Warning(warning)
       end
 


### PR DESCRIPTION
- Suggest downloading `SLE-15-SP1-Packages` instead of the old `SLE-15-Packages` medium.
- https://bugzilla.suse.com/show_bug.cgi?id=1108620
- The latest medium has name `SLE-15-SP1-Packages-x86_64-Build41.4-Media1.iso`, hopefully they won't change it later. :wink: 
- 4.1.3