### PR TITLE
Forbid using CRLF in the reg. code (bsc#1111419)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct 11 14:55:15 UTC 2018 - lslezak@suse.cz
+
+- CRLF control characters cannot be included in the registration
+  code, added validation check (bsc#1111419)
+- 3.2.17
+
+-------------------------------------------------------------------
 Fri Aug 31 10:12:16 UTC 2018 - lslezak@suse.cz
 
 - Better check the not installed addon products, some specific

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.2.16
+Version:        3.2.17
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -539,6 +539,19 @@ module Registration
         end
       end
 
+      def validate_register_scc
+        reg_code = Yast::UI.QueryWidget(:reg_code, :Value)
+
+        # no CR or LF control characters, they cannot be used in HTTP header fields
+        if reg_code.include?("\n") || reg_code.include?("\r")
+          # TRANSLATORS: error message, the entered registration code is not valid.
+          Yast::Report.Error(_("Invalid registration code.\nCRLF characters are not allowed."))
+          false
+        else
+          true
+        end
+      end
+
       VALID_CUSTOM_URL_SCHEMES = ["http", "https"].freeze
 
       # Determine whether an URL is valid and suitable to be used as local SMT server

--- a/test/base_system_registration_dialog_test.rb
+++ b/test/base_system_registration_dialog_test.rb
@@ -72,8 +72,8 @@ describe Registration::UI::BaseSystemRegistrationDialog do
         it "does not register the system" do
           expect(Yast::UI).to receive(:QueryWidget).with(:email, :Value)
             .and_return(email)
-          expect(Yast::UI).to receive(:QueryWidget).with(:reg_code, :Value)
-            .and_return(reg_code).twice
+          allow(Yast::UI).to receive(:QueryWidget).with(:reg_code, :Value)
+            .and_return(reg_code)
           expect(Yast::UI).to receive(:UserInput).and_return(:next, :abort)
           expect(Registration::UI::AbortConfirmation).to receive(:run).and_return(true)
 
@@ -94,16 +94,15 @@ describe Registration::UI::BaseSystemRegistrationDialog do
         # include CRLF characters which are not allowed
         let(:reg_code) { "\nmy-reg-code\r" }
         it "displays error popup and does not register the system" do
-          expect(Yast::UI).to receive(:QueryWidget).with(:reg_code, :Value)
+          allow(Yast::UI).to receive(:QueryWidget).with(:reg_code, :Value)
             .and_return(reg_code)
-
-          expect(Yast::UI).to receive(:UserInput).and_return(:next, :abort)
-          expect(Registration::UI::AbortConfirmation).to receive(:run).and_return(true)
+          allow(Yast::UI).to receive(:UserInput).and_return(:next, :abort)
+          allow(Registration::UI::AbortConfirmation).to receive(:run).and_return(true)
 
           expect(Yast::Report).to receive(:Error).with(/Invalid registration code/)
           expect(registration_ui).to_not receive(:register_system_and_base_product)
 
-          expect(subject.run).to eq(:abort)
+          subject.run
         end
       end
 
@@ -117,8 +116,8 @@ describe Registration::UI::BaseSystemRegistrationDialog do
         it "uses the given URL to register the system" do
           expect(Yast::UI).to receive(:QueryWidget).with(:email, :Value)
             .and_return(email)
-          expect(Yast::UI).to receive(:QueryWidget).with(:reg_code, :Value)
-            .and_return(reg_code).twice
+          allow(Yast::UI).to receive(:QueryWidget).with(:reg_code, :Value)
+            .and_return(reg_code)
           expect(Yast::UI).to receive(:UserInput).and_return(:next)
 
           options = Registration::Storage::InstallationOptions.instance


### PR DESCRIPTION
- Forbid using CRLF in the reg. code they cannot be included in the registration code
- The code is sent in the HTTP header which does not allow using CRLF, it is used as header field separator.
- Normally you cannot enter a new line character into the input field but you can copy & paste it by mistake with the registration code
- 3.2.17

![registration-crlf](https://user-images.githubusercontent.com/907998/46814271-a0106a00-cd78-11e8-8f8f-74b7d6e846b6.png)
