### PR TITLE
[master] Forbid using CRLF in the reg. code (bsc#1111419)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct 11 14:55:15 UTC 2018 - lslezak@suse.cz
+
+- CRLF control characters cannot be included in the registration
+  code, added validation check (bsc#1111419)
+- 4.1.4
+
+-------------------------------------------------------------------
 Mon Sep 17 08:54:19 UTC 2018 - lslezak@suse.cz
 
 - Suggest downloading the "SLE-15-SP1-Packages" medium instead of

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.1.3
+Version:        4.1.4
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -548,6 +548,19 @@ module Registration
         end
       end
 
+      def validate_register_scc
+        reg_code = Yast::UI.QueryWidget(:reg_code, :Value)
+
+        # no CR or LF control characters, they cannot be used in HTTP header fields
+        if reg_code.include?("\n") || reg_code.include?("\r")
+          # TRANSLATORS: error message, the entered registration code is not valid.
+          Yast::Report.Error(_("Invalid registration code.\nCRLF characters are not allowed."))
+          false
+        else
+          true
+        end
+      end
+
       VALID_CUSTOM_URL_SCHEMES = ["http", "https"].freeze
 
       # Determine whether an URL is valid and suitable to be used as local SMT server

--- a/test/base_system_registration_dialog_test.rb
+++ b/test/base_system_registration_dialog_test.rb
@@ -57,7 +57,7 @@ describe Registration::UI::BaseSystemRegistrationDialog do
         it "registers the base system with provided email and reg. code" do
           expect(Yast::UI).to receive(:QueryWidget).with(:email, :Value)
             .and_return(email)
-          expect(Yast::UI).to receive(:QueryWidget).with(:reg_code, :Value)
+          allow(Yast::UI).to receive(:QueryWidget).with(:reg_code, :Value)
             .and_return(reg_code)
           expect(Yast::UI).to receive(:UserInput).and_return(:next)
 
@@ -81,7 +81,7 @@ describe Registration::UI::BaseSystemRegistrationDialog do
         it "does not register the system" do
           expect(Yast::UI).to receive(:QueryWidget).with(:email, :Value)
             .and_return(email)
-          expect(Yast::UI).to receive(:QueryWidget).with(:reg_code, :Value)
+          allow(Yast::UI).to receive(:QueryWidget).with(:reg_code, :Value)
             .and_return(reg_code)
           expect(Yast::UI).to receive(:UserInput).and_return(:next, :abort)
           expect(Registration::UI::AbortConfirmation).to receive(:run).and_return(true)
@@ -99,6 +99,22 @@ describe Registration::UI::BaseSystemRegistrationDialog do
         end
       end
 
+      context "when user enters an invalid regcode" do
+        # include CRLF characters which are not allowed
+        let(:reg_code) { "\nmy-reg-code\r" }
+        it "displays error popup and does not register the system" do
+          allow(Yast::UI).to receive(:QueryWidget).with(:reg_code, :Value)
+            .and_return(reg_code)
+          allow(Yast::UI).to receive(:UserInput).and_return(:next, :abort)
+          allow(Registration::UI::AbortConfirmation).to receive(:run).and_return(true)
+
+          expect(Yast::Report).to receive(:Error).with(/Invalid registration code/)
+          expect(registration_ui).to_not receive(:register_system_and_base_product)
+
+          subject.run
+        end
+      end
+
       context "when user sets a registration URL through regurl= parameter" do
         let(:regurl) { "https://example.suse.net" }
 
@@ -109,7 +125,7 @@ describe Registration::UI::BaseSystemRegistrationDialog do
         it "uses the given URL to register the system" do
           expect(Yast::UI).to receive(:QueryWidget).with(:email, :Value)
             .and_return(email)
-          expect(Yast::UI).to receive(:QueryWidget).with(:reg_code, :Value)
+          allow(Yast::UI).to receive(:QueryWidget).with(:reg_code, :Value)
             .and_return(reg_code)
           expect(Yast::UI).to receive(:UserInput).and_return(:next)
 


### PR DESCRIPTION
Just port of #400 to `master`.