### PR TITLE
Use the self update version (if present) to get the available list of updates from SCC

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec  7 09:20:02 UTC 2018 - dgonzalez@suse.com
+
+- Állow the self update without having repositories in the
+  installation media (fate#325482).
+- 4.1.10
+
+-------------------------------------------------------------------
 Mon Nov 26 01:17:32 UTC 2018 - Noah Davis <noahadvs@gmail.com>
 
 - Provide icon with module (boo#1109310)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.1.9
+Version:        4.1.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -183,19 +183,22 @@ module Registration
       migration_paths
     end
 
-    # Get the list of updates for a base product or self_update_id if defined
-    #
-    # @return [Array<String>] List of URLs of updates repositories.
+    # Get the list of updates for a self_update product (if defined) or base product
     #
     # @see SwMgmt.base_product_to_register
     # @see SwMgmt.remote_product
     # @see SUSE::Connect::Yast.list_installer_updates
+    #
+    # @return [Array<String>] List of URLs of updates repositories.
     def get_updates_list
       id = Yast::ProductFeatures.GetStringFeature("globals", "self_update_id")
-      product = SwMgmt.installer_update_base_product(id) || SwMgmt.base_product_to_register
+      version = Yast::ProductFeatures.GetStringFeature("globals", "self_update_version")
+
+      product = SwMgmt.installer_update_base_product(id, version) || SwMgmt.base_product_to_register
       return [] unless product
 
       log.info "Reading available updates for product: #{product["name"]}"
+
       remote_product = SwMgmt.remote_product(product)
       updates = SUSE::Connect::YaST.list_installer_updates(remote_product, connect_params)
 


### PR DESCRIPTION
Allow to use an installation media without repositories/packages for the self update, just using the `self_update_id` and the recently added `self_update_version` to query to SCC for the available list of updates.

Part of https://trello.com/c/BTk1TcxK (fate#325482)

See also related PRs:

- https://github.com/yast/yast-installation-control/pull/74
- https://github.com/yast/skelcd-control-leanos/pull/34