### PR TITLE
Properly restart the package management (bsc#1120568)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 10 09:58:10 UTC 2019 - lslezak@suse.cz
+
+- Properly restart the package management to avoid using a possibly
+  outdated configuration (related to bsc#1120568)
+- 4.1.12
+
+-------------------------------------------------------------------
 Fri Dec 14 13:14:15 UTC 2018 - jlopez@suse.com
 
 - Hardening commands execution (part of bsc#1118291).

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.1.11
+Version:        4.1.12
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1120568
- Properly restart the package management to avoid using a possibly outdated configuration

The code restarts the package manager by calling (see [here](https://github.com/yast/yast-registration/blob/master/src/lib/registration/ui/migration_repos_workflow.rb#L439-L443)):


```ruby
Yast::Pkg.SourceFinishAll
Yast::Pkg.TargetFinish
SwMgmt.init
```

However, the are two problems in that `SwMgmt.init` call.

- It calls `Product.FindBaseProducts` which internally initializes the repositories. But that's wrong without initialized target, the target has been closed by the `Pkg.TargetFinish` call before. The target defines from which directory the repositories are read, we need to be sure it's set to `/mnt`. I guess it works just by accident, because of caching the original repositories, but that has been fixed in https://github.com/yast/yast-pkg-bindings/pull/111.
- The initialized repositories are not unloaded to allow correct reinitialization later. (Pkg bindings do not initialize sources if they have been already initialized so the old values might be used.)

## Fix

- Ensure the target is initialized before calling `Product.FindBaseProducts`
- Close both target and sources after that so they can be initialized later properly