### PR TITLE
Do not crash when no base product to register is found (bsc#1122011)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 16 08:53:13 UTC 2019 - lslezak@suse.cz
+
+- Do not crash when no base product to register is found
+  (bsc#1122011)
+- 4.1.13
+
+-------------------------------------------------------------------
 Thu Jan 10 09:58:10 UTC 2019 - lslezak@suse.cz
 
 - Properly restart the package management to avoid using a possibly

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.1.12
+Version:        4.1.13
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -134,6 +134,11 @@ module Registration
       # extensions for base product
       base_product = ::Registration::SwMgmt.base_product_to_register
 
+      if !base_product
+        log.warn "No base product, skipping addons"
+        return
+      end
+
       log.info "Reading available addons for product: #{base_product["name"]}"
 
       remote_product = SwMgmt.remote_product(base_product)

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -130,13 +130,15 @@ module Registration
       ret
     end
 
+    # Get the list of addons
+    # @return [Array<Addon>] List of addons, empty if no base product is found
     def get_addon_list
       # extensions for base product
       base_product = ::Registration::SwMgmt.base_product_to_register
 
       if !base_product
         log.warn "No base product, skipping addons"
-        return
+        return []
       end
 
       log.info "Reading available addons for product: #{base_product["name"]}"

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -131,6 +131,7 @@ module Registration
     end
 
     # Get the list of addons
+    #
     # @return [Array<Addon>] List of addons, empty if no base product is found
     def get_addon_list
       # extensions for base product

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -127,15 +127,19 @@ describe Registration::Registration do
       }
     end
     before do
-      expect(Registration::SwMgmt).to receive(:base_product_to_register).and_return(base_product)
+      remote_product = load_yaml_fixture("remote_product.yml")
+      allow(SUSE::Connect::YaST).to receive(:show_product).and_return(remote_product)
+      # no product renames defined
+      allow(Registration::SwMgmt).to receive(:update_product_renames).with({})
+    end
+
+    it "returns empty list if no base product is found" do
+      expect(Registration::SwMgmt).to receive(:base_product_to_register).and_return(nil)
+      expect(Registration::Registration.new.get_addon_list).to eq([])
     end
 
     it "downloads available extensions" do
-      remote_product = load_yaml_fixture("remote_product.yml")
-      expect(SUSE::Connect::YaST).to receive(:show_product).and_return(remote_product)
-      # no product renames defined
-      expect(Registration::SwMgmt).to receive(:update_product_renames).with({})
-
+      expect(Registration::SwMgmt).to receive(:base_product_to_register).and_return(base_product)
       addons = Registration::Registration.new.get_addon_list
 
       # HA-GEO is extension for HA so it's not included in the list

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -118,35 +118,41 @@ describe Registration::Registration do
   end
 
   describe "#get_addon_list" do
-    let(:base_product) do
-      {
-        "name"         => "SLES",
-        "version"      => "12",
-        "arch"         => "x86_64",
-        "release_type" => "DVD"
-      }
-    end
     before do
       remote_product = load_yaml_fixture("remote_product.yml")
       allow(SUSE::Connect::YaST).to receive(:show_product).and_return(remote_product)
       # no product renames defined
       allow(Registration::SwMgmt).to receive(:update_product_renames).with({})
+      allow(Registration::SwMgmt).to receive(:base_product_to_register).and_return(base_product)
     end
 
-    it "returns empty list if no base product is found" do
-      expect(Registration::SwMgmt).to receive(:base_product_to_register).and_return(nil)
-      expect(Registration::Registration.new.get_addon_list).to eq([])
+    context "no base product found" do
+      let(:base_product) { nil }
+
+      it "returns empty list if no base product is found" do
+        expect(Registration::Registration.new.get_addon_list).to eq([])
+      end
     end
 
-    it "downloads available extensions" do
-      expect(Registration::SwMgmt).to receive(:base_product_to_register).and_return(base_product)
-      addons = Registration::Registration.new.get_addon_list
+    context "a base product is found" do
+      let(:base_product) do
+        {
+          "name"         => "SLES",
+          "version"      => "12",
+          "arch"         => "x86_64",
+          "release_type" => "DVD"
+        }
+      end
 
-      # HA-GEO is extension for HA so it's not included in the list
-      # also the base product must not be included in the list
-      expect(addons.map(&:identifier)).to include("sle-we", "sle-sdk",
-        "sle-module-legacy", "sle-module-web-scripting", "sle-module-public-cloud",
-        "sle-module-adv-systems-management", "sle-hae")
+      it "downloads available extensions" do
+        addons = Registration::Registration.new.get_addon_list
+
+        # HA-GEO is extension for HA so it's not included in the list
+        # also the base product must not be included in the list
+        expect(addons.map(&:identifier)).to include("sle-we", "sle-sdk",
+          "sle-module-legacy", "sle-module-web-scripting", "sle-module-public-cloud",
+          "sle-module-adv-systems-management", "sle-hae")
+      end
     end
   end
 


### PR DESCRIPTION
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1122011
- There is very likely some other issue, the base product to register should not be `nil`
- Anyway, YaST should not crash in that situation
- 4.1.13