### PR TITLE
Use the old message when skipping registration (bsc#1122608)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Feb  1 12:18:35 UTC 2019 - lslezak@suse.cz
+
+- Use the old message when skipping registration, the new tags are
+  not present in SLE15-GA and it also broke the translations
+  (bsc#1122608, reverts 4.0.45)
+- 4.0.49
+
+-------------------------------------------------------------------
 Fri Jan 25 10:52:15 CET 2019 - schubi@suse.de
 
 - Do not try to remove services which have already been deleted.

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.0.48
+Version:        4.0.49
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -31,7 +31,6 @@ module Registration
       Yast.import "Wizard"
       Yast.import "Popup"
       Yast.import "Report"
-      Yast.import "ProductFeatures"
 
       WIDGETS = {
         register_scc:      [:email, :reg_code],
@@ -359,31 +358,17 @@ module Registration
       #
       # @return [Boolean] true when skipping has been confirmed
       def show_skipping_warning
-        media_name = ProductFeatures.GetStringFeature(
-          "globals",
-          "full_system_media_name"
-        )
-        download_url = ProductFeatures.GetStringFeature(
-          "globals",
-          "full_system_download_url"
-        )
-
-        warning = _("Without registration, update channels will not be\n" \
-          "configured. This disables updates and security fixes.")
-
         # Popup question: confirm skipping the registration
         # TRANSLATORS:
         # %{media_name} is the media name (e.g. SLE-15-Packages),
         # %{download_url} is an URL link (e.g. https://download.suse.com)
-        if !media_name.empty? && # cannot be nil
-            !download_url.empty? # cannot be nil
-          warning += "\n\n" +
-            _("A full system can be installed using the\n" \
-              "%{media_name} media from %{download_url}.\n" \
-              "Without these media only a minimum system is available\n" \
-             "in this installation.") %
-            { media_name: media_name, download_url: download_url }
-        end
+        warning = _("Without registration, update channels will not be\n" \
+          "configured. This disables updates and security fixes.\n\n" \
+          "A full system can be installed using the\n" \
+          "%{media_name} media from %{download_url}.\n" \
+          "Without these media only a minimum system is available\n" \
+          "in this installation.") %
+          { media_name: "SLE-15-Packages", download_url: "https://download.suse.com" }
 
         Yast::Popup.Warning(warning)
       end

--- a/test/base_system_registration_dialog_test.rb
+++ b/test/base_system_registration_dialog_test.rb
@@ -154,40 +154,11 @@ describe Registration::UI::BaseSystemRegistrationDialog do
       end
 
       context "when user skips registration" do
-        before do
-          allow(Yast::UI).to receive(:UserInput).and_return(:skip_registration, :next)
-        end
-
         it "does not try to register the system and close the dialog" do
+          allow(Yast::UI).to receive(:UserInput).and_return(:skip_registration, :next)
           expect(Yast::Popup).to receive(:Warning).with(/Without registration/)
             .and_return(true)
           expect(subject.run).to eq(:skip)
-        end
-
-        context "when full_system_media_name and full_system_download_url" \
-                " is defined in control.xml" do
-          it "reports the media name and the regarding download url to the user" do
-            expect(Yast::ProductFeatures).to receive(:GetStringFeature)
-              .with("globals", "full_system_media_name").and_return("SLE-15-Packages")
-            expect(Yast::ProductFeatures).to receive(:GetStringFeature)
-              .with("globals", "full_system_download_url").and_return("https://download.suse.com")
-            expect(Yast::Popup).to receive(:Warning).with(/SLE-15-Packages.*download.suse.com/)
-            expect(subject.run).to eq(:skip)
-          end
-        end
-
-        context "when full_system_media_name and full_system_download_url" \
-                " is NOT defined in control.xml" do
-          it "does not mention any media information" do
-            expect(Yast::ProductFeatures).to receive(:GetStringFeature)
-              .with("globals", "full_system_media_name").and_return("")
-            expect(Yast::ProductFeatures).to receive(:GetStringFeature)
-              .with("globals", "full_system_download_url").and_return("")
-            expect(Yast::Popup).to receive(:Warning).with(/Without registration/)
-              .and_return(true)
-            expect(Yast::Popup).not_to receive(:Warning).with(/Without these media only/)
-            expect(subject.run).to eq(:skip)
-          end
         end
       end
     end


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1122608
- This basically reverts https://github.com/yast/yast-registration/pull/402
- That was released as an installer update but the message is displayed wrongly (the expected data in contol.xml are missing, it also broke the translations)
- 4.0.49