### PR TITLE
Fixed "can't modify frozen String" crash (bsc#1125006)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 18 13:11:12 UTC 2019 - lslezak@suse.cz
+
+- Fixed "can't modify frozen String" crash (bsc#1125006)
+- 3.2.17
+
+-------------------------------------------------------------------
 Fri Oct 19 10:52:05 UTC 2018 - knut.anderssen@suse.com
 
 - RegistrationCode widget: Use always the custom url instead of the

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.2.16
+Version:        3.2.17
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/not_installed_products_dialog.rb
+++ b/src/lib/registration/ui/not_installed_products_dialog.rb
@@ -44,8 +44,6 @@ module Registration
 
       REGISTRATION_CHECK_MSG = N_("Checking registration status")
 
-      attr_accessor :registration, :registration_ui
-
       def self.run
         dialog = NotInstalledProductsDialog.new
         dialog.run
@@ -53,9 +51,6 @@ module Registration
 
       def initialize
         textdomain "registration"
-
-        self.registration = Registration.new(UrlHelpers.registration_url)
-        self.registration_ui = RegistrationUI.new(registration)
       end
 
       def run
@@ -73,6 +68,14 @@ module Registration
       end
 
     private
+
+      def registration
+        @registration ||= Registration.new(UrlHelpers.registration_url)
+      end
+
+      def registration_ui
+        @registration_ui ||= RegistrationUI.new(registration)
+      end
 
       def content
         VBox(
@@ -152,11 +155,11 @@ module Registration
         #   not installed. (1/2)
         summary = _("<p>The addons listed below are registered but not installed: </p>")
 
-        summary << "<ul>#{not_installed_addon_names.map { |a| "<li>#{a}</li>" }.join("")}</ul>"
+        summary += "<ul>#{not_installed_addon_names.map { |a| "<li>#{a}</li>" }.join("")}</ul>"
 
         # TRANSLATORS: A RichText warning about all the products registered but
         #   not installed. (2/2)
-        summary << _("<p>It's preferable to <b>deactivate</b> your products at your " \
+        summary += _("<p>It's preferable to <b>deactivate</b> your products at your " \
                      "registration server if you don't plan to use them anymore.</p>")
 
         summary

--- a/test/registration/ui/not_installed_products_dialog.rb
+++ b/test/registration/ui/not_installed_products_dialog.rb
@@ -28,7 +28,7 @@ describe Registration::UI::NotInstalledProductsDialog do
       allow(subject).to receive(:_), &:freeze
     end
 
-    context "when the there is an registered but not installed product" do
+    context "when there is a registered but not installed product" do
       before do
         allow(Registration::Addon).to receive(:registered_not_installed).and_return(
           [

--- a/test/registration/ui/not_installed_products_dialog.rb
+++ b/test/registration/ui/not_installed_products_dialog.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env rspec
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require_relative "../../spec_helper"
+require "registration/ui/not_installed_products_dialog"
+
+describe Registration::UI::NotInstalledProductsDialog do
+  describe "#run" do
+    before do
+      allow(Yast::UI).to receive(:OpenDialog)
+      allow(Yast::UI).to receive(:CloseDialog)
+      allow(Yast::UI).to receive(:SetFocus)
+
+      allow(Yast::Popup).to receive(:Feedback).and_yield
+      allow(subject).to receive(:handle_dialog)
+
+      # the translated strings are frozen
+      allow(subject).to receive(:_), &:freeze
+    end
+
+    context "when the there is an registered but not installed product" do
+      before do
+        allow(Registration::Addon).to receive(:registered_not_installed).and_return(
+          [
+            double(name: "not_installed_product")
+          ]
+        )
+      end
+
+      it "displays a product summary popup" do
+        expect(Yast::UI).to receive(:OpenDialog) do |_opts, content|
+          # find the RichText widget in the content
+          term = content.nested_find do |t|
+            t.respond_to?(:value) && t.value == :RichText
+          end
+
+          expect(term.params[1]).to match(/registered but not installed: .*not_installed_product/)
+        end
+
+        subject.run
+      end
+    end
+  end
+end


### PR DESCRIPTION
- The `String` returned from gettext is frozen and cannot be modified
- Lazy initialization to make testing easier
- 3.2.17