### PR TITLE
Skip SLP discovery when going back (related to bsc#1071887)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar  1 09:50:20 UTC 2019 - lslezak@suse.cz
+
+- Skip SLP discovery when going back after registering the system,
+  the server cannot be changed anyway (related to bsc#1071887)
+- 4.1.19
+
+-------------------------------------------------------------------
 Mon Feb 25 12:32:35 UTC 2019 - lslezak@suse.cz
 
 - Better handle the SSL certificates signed by an uknown CA

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.1.18
+Version:        4.1.19
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -290,8 +290,9 @@ module Registration
       def register_local_option
         # If not special URL is used, probe with SLP
         if using_default_url?
-          services = UrlHelpers.slp_discovery_feedback
-          urls = services.map { |svc| UrlHelpers.service_url(svc.slp_url) }
+          # skip SLP discovery if the system is already registered
+          # during installation (the user is just going back)
+          urls = (Registration.is_registered? && !Yast::Mode.normal) ? [] : slp_urls
           urls = [EXAMPLE_SMT_URL] if urls.empty?
         else
           urls = [reg_options[:custom_url]]
@@ -555,6 +556,16 @@ module Registration
       # @return [Boolean] True if the default URL is used; false otherwise.
       def using_default_url?
         reg_options[:custom_url] == default_url
+      end
+
+      #
+      # Scan the network for SLP registration servers
+      #
+      # @return [Array<String>] The list of found URLs
+      #
+      def slp_urls
+        services = UrlHelpers.slp_discovery_feedback
+        services.map { |svc| UrlHelpers.service_url(svc.slp_url) }
       end
 
       # This method check whether the input is valid

--- a/test/base_system_registration_dialog_test.rb
+++ b/test/base_system_registration_dialog_test.rb
@@ -220,11 +220,19 @@ describe Registration::UI::BaseSystemRegistrationDialog do
     context "when system is already registered" do
       let(:registered?) { true }
 
+      before do
+        allow(subject).to receive(:event_loop).and_return(nil)
+      end
+
       context "in installation mode" do
         it "disables widgets" do
           expect(Yast::UI).to receive(:ChangeWidget).with(Id(:action), :Enabled, false)
           allow(Yast::UI).to receive(:ChangeWidget).and_call_original
-          allow(subject).to receive(:event_loop).and_return(nil)
+          subject.run
+        end
+
+        it "skips the SLP discovery" do
+          expect(Registration::UrlHelpers).to_not receive(:slp_discovery_feedback)
           subject.run
         end
       end


### PR DESCRIPTION
- Skip SLP discovery when going back
- After registering the system the server cannot be changed anyway
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1071887
- 4.1.19

## Screenshot

After going back you will see this dialog

![registered_system_going_back](https://user-images.githubusercontent.com/907998/53630525-86c96680-3c10-11e9-87ae-d4ea9d7b13eb.png)

Originally there was displayed a "SLP Scanning" pop up for several seconds which is useless.