### PR TITLE
Added option to retry the block given

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Sun Mar 10 18:58:40 UTC 2019 - knut.anderssen@suse.com
+
+- Permit to retry the registration in case of a timeout or a json
+  parse error and hide the error details which will be accesible
+  through the 'details' button (bsc#1058375, bsc#1126045).
+- 4.1.20
+
+-------------------------------------------------------------------
 Fri Mar  1 09:50:20 UTC 2019 - lslezak@suse.cz
 
 - Skip SLP discovery when going back after registering the system,

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.1.19
+Version:        4.1.20
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -157,10 +157,15 @@ module Registration
     end
 
     def self.details_error(msg, error_message, retry_button: false)
-      if Yast::Mode.autoinst || Yast::Mode.autoupgrade
+      if Yast::Mode.auto
         report_error(msg, error_message)
       else
-        buttons = retry_button ? { retry: _("Retry"), cancel: _("Cancel") } : :ok
+        buttons =
+          if retry_button
+            { retry: Yast::Label.RetryButton, cancel: Yast::Label.CancelButton }
+          else
+            :ok
+          end
         Yast2::Popup.show(msg, details: error_message, headline: :error, buttons: buttons)
       end
     end
@@ -307,7 +312,7 @@ module Registration
       if Yast::NetworkService.isNetworkRunning
         # FIXME: use a better message, this one has been reused after the text freeze
         report_error(message_prefix + _("Invalid URL."), e.message)
-      elsif Helpers.network_configurable && !(Yast::Mode.autoinst || Yast::Mode.autoupgrade)
+      elsif Helpers.network_configurable && !Yast::Mode.auto
         if Yast::Popup.YesNo(
           # Error popup
           _("Network is not configured, the registration server cannot be reached.\n" \

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -142,6 +142,7 @@ module Registration
         # update the message when an old SMT server is found
         check_smt_api(e.message)
         details_error(message_prefix + _("Cannot parse the data from server."), e.message)
+        false
       rescue StandardError => e
         log.error("SCC registration failed: #{e.class}: #{e}, #{e.backtrace}")
         Yast::Report.Error(

--- a/src/lib/registration/registration_ui.rb
+++ b/src/lib/registration/registration_ui.rb
@@ -55,7 +55,7 @@ module Registration
     def register_system_and_base_product
       product_service = nil
       # TRANSLATORS: Popup error message prefix
-      error_options = { message_prefix: _("Registration failed.") }
+      error_options = { message_prefix: _("Registration failed.") + "\n\n" }
 
       success = ConnectHelpers.catch_registration_errors(error_options) do
         register_system if !Registration.is_registered?

--- a/src/lib/registration/registration_ui.rb
+++ b/src/lib/registration/registration_ui.rb
@@ -54,7 +54,8 @@ module Registration
     #   items: boolean (true on success), remote service (or nil)
     def register_system_and_base_product
       product_service = nil
-      error_options = { message_prefix: "The registration failed.", retry_block: true }
+      # TRANSLATORS: Popup error message prefix
+      error_options = { message_prefix: _("Registration failed.") }
 
       success = ConnectHelpers.catch_registration_errors(error_options) do
         register_system if !Registration.is_registered?

--- a/src/lib/registration/registration_ui.rb
+++ b/src/lib/registration/registration_ui.rb
@@ -54,8 +54,9 @@ module Registration
     #   items: boolean (true on success), remote service (or nil)
     def register_system_and_base_product
       product_service = nil
+      error_options = { message_prefix: "The registration failed.", retry_block: true }
 
-      success = ConnectHelpers.catch_registration_errors do
+      success = ConnectHelpers.catch_registration_errors(error_options) do
         register_system if !Registration.is_registered?
 
         # then register the product(s)


### PR DESCRIPTION
## Problem

When an exception or error occurs in the qa SCC proxy, the shown description is not user friendly, it shows all the text in the dialog and only permits to accept it.

- https://trello.com/c/G5X7kbBy/750-3-5-sles15-p2-1058375-build-2311-openqa-test-fails-in-sccregistration-connection-time-out-on-scc-registration
- https://bugzilla.suse.com/show_bug.cgi?id=1058375 
- https://bugzilla.suse.com/show_bug.cgi?id=1126045

## Solution

- Added an option to connection_helper for retrying the given blockn when some exception occurs.
- Added a details button to show the details of the occurred error in the retry dialog.

## Testing

- *Added uni test*
- *Tested manually*

## Screenshots

![Screenshot_testing_2019-03-13_09:06:14](https://user-images.githubusercontent.com/7056681/54266409-3c7ca980-456f-11e9-8783-47a5ba8ae230.png)

![Screenshot_testing_2019-03-11_00:08:39](https://user-images.githubusercontent.com/7056681/54094006-611d2980-4395-11e9-84b8-2efb88945a65.png)
