### PR TITLE
Fixed SUMA RN in SLES upgrade (bsc#1129029)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Mar 15 18:03:43 UTC 2019 - Ladislav Slezak <lslezak@suse.cz>
+
+- Run the solver to correctly initialize the product statuses
+  (fixes displaying SUMA RN during a SLES upgrade) (bsc#1129029)
+
+-------------------------------------------------------------------
 Sun Mar 10 18:58:40 UTC 2019 - knut.anderssen@suse.com
 
 - Permit to retry the registration in case of a timeout or a json

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -3,6 +3,7 @@ Fri Mar 15 18:03:43 UTC 2019 - Ladislav Slezak <lslezak@suse.cz>
 
 - Run the solver to correctly initialize the product statuses
   (fixes displaying SUMA RN during a SLES upgrade) (bsc#1129029)
+- 4.1.21
 
 -------------------------------------------------------------------
 Sun Mar 10 18:58:40 UTC 2019 - knut.anderssen@suse.com

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.1.20
+Version:        4.1.21
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -589,6 +589,9 @@ module Registration
 
       select_default_product_patterns unless Mode.update
 
+      # run the solver to recalculate the product statuses
+      Pkg.PkgSolve(false)
+
       ret
     end
 

--- a/test/registration/ui/failed_certificate_popup_test.rb
+++ b/test/registration/ui/failed_certificate_popup_test.rb
@@ -34,6 +34,7 @@ describe Registration::UI::FailedCertificatePopup do
   before do
     allow(Yast::Report).to receive(:LongError)
     allow(Yast::Stage).to receive(:initial).and_return(false)
+    allow(Registration::UrlHelpers).to receive(:registration_url)
   end
 
   # the instance method

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -336,6 +336,7 @@ describe Registration::SwMgmt do
       allow(Yast::Pkg).to receive(:ResolvableProperties)
         .and_return(load_yaml_fixture("products_legacy_installation.yml"))
       allow(Yast::Pkg).to receive(:ResolvableInstall).with("sle-module-legacy", :product)
+      allow(Yast::Pkg).to receive(:PkgSolve)
     end
 
     it "selects new addon products for installation" do
@@ -346,6 +347,12 @@ describe Registration::SwMgmt do
 
     it "selects the default patterns for the selected products" do
       expect_any_instance_of(Yast::ProductPatterns).to receive(:select)
+
+      subject.select_addon_products(legacy_services)
+    end
+
+    it "runs the solver to initialize the product statuses" do
+      expect(Yast::Pkg).to receive(:PkgSolve)
 
       subject.select_addon_products(legacy_services)
     end


### PR DESCRIPTION
- Fixes displaying the SUSE Manager release notes during a SLES upgrade
- https://bugzilla.suse.com/show_bug.cgi?id=1129029
- YaST displays the release notes for the products selected for installation. The debugging showed that for some reason the SUSE Manager was really marked as selected by the solver although no solver run was done.
- Calling the solver explicitly fixed the issue and properly initialized the product status
- Tested manually