### PR TITLE
Update the "Register System via local SMT Server" label

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 29 14:34:42 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Update the  label used for the option to register the system
+  via local server (bsc#1129206).
+- 4.2.0
+
+-------------------------------------------------------------------
 Fri Mar 15 18:03:43 UTC 2019 - Ladislav Slezak <lslezak@suse.cz>
 
 - Run the solver to correctly initialize the product statuses

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.1.21
+Version:        4.2.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -142,7 +142,7 @@ module Registration
         self.action = :register_scc
       end
 
-      # Handle selection the 'Register System via local SMT Server' option
+      # Handle selection the 'Register System via local SMT/RMT Server' option
       #
       # Set the dialog's action to :register_local
       def register_local_handler
@@ -294,7 +294,7 @@ module Registration
               Id(:register_local),
               Opt(:notify),
               # TRANSLATORS: radio button
-              _("Register System via local SMT Server"),
+              _("Register System via local SMT/RMT Server"),
               action == :register_local
             )
           ),
@@ -608,7 +608,7 @@ module Registration
 
       VALID_CUSTOM_URL_SCHEMES = ["http", "https"].freeze
 
-      # Determine whether an URL is valid and suitable to be used as local SMT server
+      # Determine whether an URL is valid and suitable to be used as local SMT/RMT server
       #
       # @return [Boolean] true if it's valid; false otherwise.
       def valid_custom_url?(custom_url)


### PR DESCRIPTION
## Problem

The label _Register System via local SMT Server_ seems to be outdated.

- https://bugzilla.suse.com/show_bug.cgi?id=1129206
- https://trello.com/c/FrMIOlJp/2976-sles15-p3-1129206-yast-registration-module-shows-option-as-register-system-via-local-smt-server

## Solution

Update it to _Register System via local SMT/RMT Server_

## Testing

_Not needed_


## Screenshots

![register_system_via_local_server_sle15sp2_label_fixed](https://user-images.githubusercontent.com/1691872/55295806-66f0b280-5409-11e9-9108-8c471d3a81e9.png)


