### PR TITLE
Replace SMT occurrences by RMT or SMT/RMT

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jun  3 09:26:29 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Update labels and help texts related to registration server,
+  replacing SMT by RMT since the former is not longer supported
+  (bsc#1129206, bsc#1136433).
+- 4.2.2
+
+-------------------------------------------------------------------
 Thu May 30 13:37:19 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Properly display the openSUSE Leap to SLES migration summary

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -309,12 +309,12 @@ module Registration
       }
     end
 
-    # is the addon available? SMT may have mirrored only some extensions,
+    # is the addon available? SMT/RMT may have mirrored only some extensions,
     # the not mirrored extensions are marked as not available
     # @return [Boolean] true if the addon is available to register
     def available?
       # explicitly check for false, undefined (nil) means it is available,
-      # it's only reported by SMT
+      # it's only reported by SMT/RMT
       @pure_addon.available != false
     end
 

--- a/src/lib/registration/clients/inst_migration_repos.rb
+++ b/src/lib/registration/clients/inst_migration_repos.rb
@@ -45,7 +45,7 @@ module Registration
         # copy the old NCC/SCC credentials to inst-sys
         SwMgmt.copy_old_credentials(destdir)
 
-        # import the SMT certificate to inst-sys
+        # import the SMT/RMT certificate to inst-sys
         import_ssl_certificates
       end
 

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -98,7 +98,7 @@ module Registration
           report_error(message_prefix + _("Connection to registration server failed."),
             error_code_message + error_msg)
         when 404
-          # update the message when an old SMT server is found
+          # update the message when an old SMT/RMT server is found
           check_smt_api(error_msg)
           report_error(message_prefix + _("Connection to registration server failed."),
             error_code_message + error_msg)
@@ -139,7 +139,7 @@ module Registration
         false
       rescue JSON::ParserError => e
         log.error "JSON parse error"
-        # update the message when an old SMT server is found
+        # update the message when an old SMT/RMT server is found
         check_smt_api(e.message)
         details_error(message_prefix + _("Cannot parse the data from server."), e.message)
         false
@@ -287,10 +287,10 @@ module Registration
     # @param error_msg [String] the received error message, the content might be replaced
     def self.check_smt_api(error_msg)
       url = UrlHelpers.registration_url
-      # no SMT/custom server used
+      # no SMT/RMT/custom server used
       return if url == SUSE::Connect::YaST::DEFAULT_URL
 
-      # test old SMT instance
+      # test old SMT/RMT instance
       smt_status = SmtStatus.new(url, insecure: Helpers.insecure_registration)
       return unless smt_status.ncc_api_present?
 
@@ -335,7 +335,7 @@ module Registration
       # TRANSLATORS: additional hint for an error message
       msg = _("Check that this system is known to the registration server.")
 
-      # probably missing NCC->SCC sync, display a hint unless SMT is used
+      # probably missing NCC->SCC sync, display a hint unless SMT/RMT is used
       if [nil, SUSE::Connect::YaST::DEFAULT_URL].include?(UrlHelpers.registration_url)
 
         msg += "\n\n"

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -486,7 +486,7 @@ module Registration
       log.info "Copying the old credentials from previous installation"
       log.info "Copying #{file} to #{new_file}"
 
-      # SMT uses extra ACL permissions, make sure they are kept in the copied file,
+      # SMT/RMT uses extra ACL permissions, make sure they are kept in the copied file,
       # (use "cp -a ", ::FileUtils.cp(..., preserve: true) cannot be used as it preserves only
       # the traditional Unix file permissions, the extended ACLs are NOT copied!)
       Yast::Execute.locally!("cp", "-a", file, new_file)

--- a/src/lib/registration/ui/autoyast_config_dialog.rb
+++ b/src/lib/registration/ui/autoyast_config_dialog.rb
@@ -62,8 +62,8 @@ module Registration
         )
         help_text += _(
           "<p>If your network deploys a custom registration server, set the " \
-          "correct URL of the server\nand the location of the SMT " \
-          "certificate in <b>SMT Server Settings</b>. Refer\nto your SMT " \
+          "correct URL of the server\nand the location of the RMT " \
+          "certificate in <b>RMT Server Settings</b>. Refer\nto your RMT " \
           "manual for further assistance.</p>"
         )
 

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -142,7 +142,7 @@ module Registration
         self.action = :register_scc
       end
 
-      # Handle selection the 'Register System via local SMT/RMT Server' option
+      # Handle selection the 'Register System via local RMT Server' option
       #
       # Set the dialog's action to :register_local
       def register_local_handler
@@ -282,7 +282,7 @@ module Registration
       end
 
       # Example URL to be used in the :register_local UI
-      EXAMPLE_SMT_URL = "https://smt.example.com".freeze
+      EXAMPLE_RMT_URL = "https://rmt.example.com".freeze
 
       # Widgets for :register_local action
       #
@@ -294,7 +294,7 @@ module Registration
               Id(:register_local),
               Opt(:notify),
               # TRANSLATORS: radio button
-              _("Register System via local SMT/RMT Server"),
+              _("Register System via local RMT Server"),
               action == :register_local
             )
           ),
@@ -608,7 +608,7 @@ module Registration
 
       VALID_CUSTOM_URL_SCHEMES = ["http", "https"].freeze
 
-      # Determine whether an URL is valid and suitable to be used as local SMT/RMT server
+      # Determine whether an URL is valid and suitable to be used as local RMT server
       #
       # @return [Boolean] true if it's valid; false otherwise.
       def valid_custom_url?(custom_url)
@@ -630,7 +630,7 @@ module Registration
 
         # use an example URL if no server was found via SLP
         urls = slp_urls
-        urls.empty? ? [EXAMPLE_SMT_URL] : urls
+        urls.empty? ? [EXAMPLE_RMT_URL] : urls
       end
     end
   end

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -541,16 +541,16 @@ module Registration
       end
 
       # check the system status at upgrade and return the symbol for the next step
-      # @return [Symabol] workflow symbol, :skip => do not use the SCC/SMT upgrade
+      # @return [Symabol] workflow symbol, :skip => do not use the SCC/SMT/RMT upgrade
       #   (unregistered system or explicitly requested by user), :next =>
-      #   continue with the SCC/SMT based upgrade
+      #   continue with the SCC/SMT/RMT based upgrade
       def system_upgrade_check
         log.info "System upgrade mode detected"
         # media based upgrade requested by user
         if Yast::Linuxrc.InstallInf("MediaUpgrade") == "1"
           explicit_media_upgrade
           return :skip
-        # the system is registered, continue with the SCC/SMT based upgrade
+        # the system is registered, continue with the SCC/SMT/RMT based upgrade
         elsif Registration.is_registered?
           log.info "The system is registered, using the registration server for upgrade"
           return :next
@@ -611,7 +611,7 @@ module Registration
       # @return [String] translated message
       def media_upgrade(registered)
         # TRANSLATORS: Media based upgrade requested by user (1/3)
-        #   User requested media based upgrade which does not use SCC/SMT
+        #   User requested media based upgrade which does not use SCC/SMT/RMT
         #   but the downloaded media (physical DVD or shared repo on a local server).
         ret = _("<h2>Media Based Upgrade</h2><p>The media based upgrade is requested. " \
           "In this mode YaST will not contact the registration server to obtain " \

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -273,17 +273,17 @@ module Registration
         product_name = CGI.escapeHTML(product.friendly_name)
 
         # explicitly check for false, the flag is not returned by SCC, this is
-        # a SMT specific check (in SCC all products are implicitly available)
+        # a SMT/RMT specific check (in SCC all products are implicitly available)
         if product.available == false
-          # a product can be unavailable only when using SMT, the default
+          # a product can be unavailable only when using SMT/RMT, the default
           # SCC URL should be never used
           url = UrlHelpers.registration_url || SUSE::Connect::YaST::DEFAULT_URL
 
           # TRANSLATORS: An error message displayed in the migration details.
-          # The product has not been mirrored to the SMT server and cannot be used
-          # for migration. The SMT admin has to mirror the product to allow
+          # The product has not been mirrored to the SMT/RMT server and cannot be used
+          # for migration. The SMT/RMT admin has to mirror the product to allow
           # using the selected migration.
-          # %{url} is the URL of the registration server (SMT)
+          # %{url} is the URL of the SMT/RMT registration server
           # %{product} is a full product name, e.g. "SUSE Linux Enterprise Server 12"
           return Yast::HTML.Colorize(
             _("ERROR: Product <b>%{product}</b> is not available at the " \

--- a/src/lib/registration/ui/regservice_selection_dialog.rb
+++ b/src/lib/registration/ui/regservice_selection_dialog.rb
@@ -18,7 +18,7 @@ require "slp/dialogs/service_selection"
 
 module Registration
   module UI
-    # This class implements a SCC/SMT service selection dialog.
+    # This class implements a SCC/RMT service selection dialog.
     class RegserviceSelectionDialog < Yast::Dialogs::ServiceSelection
       Yast.import "UI"
       Yast.import "Label"
@@ -27,14 +27,14 @@ module Registration
       # Run dialog
       #
       # The return value will be:
-      # * A service in case one SMT server was selected
+      # * A service in case one RMT server was selected
       # * :scc symbol if default SCC was selected
       # * :cancel symbol if the SCC was canceled (pressing the 'cancel' button)
       #
       # @example Select the default SCC service
       #   Registration::UI::SelectionServiceDialog.run(services) #=> :scc
       #
-      # @example Select some SMT service
+      # @example Select some RMT service
       #   Registration::UI::SelectionServiceDialog.run(services)
       #     #=> #<Yast::SlpServiceClass::Service...>
       #

--- a/src/lib/registration/widgets/registration_code.rb
+++ b/src/lib/registration/widgets/registration_code.rb
@@ -35,7 +35,7 @@ module Registration
       end
 
       def label
-        _("Registration Code or SMT Server URL")
+        _("Registration Code or RMT Server URL")
       end
 
       # Initialize the widget with stored values
@@ -59,7 +59,7 @@ module Registration
         register
       end
 
-      # Try to register the system against SCC or a custom SMT depending on if
+      # Try to register the system against SCC or a custom RMT depending on if
       # the value is an URL or not.
       #
       # @return [Boolean] false if not attempted or failed and true if success
@@ -95,7 +95,7 @@ module Registration
       def help
         _(
           "<p>\n" \
-          "The SMT Server URL must use http or https protocol, " \
+          "The RMT Server URL must use http or https protocol, " \
           "other schemes are not supported." \
           "</p>\n"
         )

--- a/test/base_system_registration_dialog_test.rb
+++ b/test/base_system_registration_dialog_test.rb
@@ -145,8 +145,8 @@ describe Registration::UI::BaseSystemRegistrationDialog do
         end
       end
 
-      context "when user enters a local SMT server" do
-        it "registers the system via local SMT server" do
+      context "when user enters a local RMT server" do
+        it "registers the system via local RMT server" do
           allow(Yast::UI).to receive(:QueryWidget).with(:custom_url, :Value)
             .and_return(custom_url)
           expect(Yast::UI).to receive(:UserInput).and_return(:register_local, :next)
@@ -165,10 +165,10 @@ describe Registration::UI::BaseSystemRegistrationDialog do
         end
       end
 
-      context "when user enters an invalid local SMT server" do
+      context "when user enters an invalid local RMT server" do
         it "shows an error and does not try to register the system" do
           allow(Yast::UI).to receive(:QueryWidget).with(:custom_url, :Value)
-            .and_return("ftp://smt.suse.com")
+            .and_return("ftp://rmt.suse.com")
           expect(Yast::UI).to receive(:UserInput).and_return(:register_local, :next, :abort)
           expect(Registration::UI::AbortConfirmation).to receive(:run).and_return(true)
           expect(Yast::Report).to receive(:Error).with(_("Invalid URL.")).and_return(true)

--- a/test/regservice_selection_dialog_spec.rb
+++ b/test/regservice_selection_dialog_spec.rb
@@ -30,7 +30,7 @@ describe Registration::UI::RegserviceSelectionDialog do
     allow(Yast::SlpServiceClass::DnsCache).to receive(:resolve)
       .and_return("somehost")
     allow(Yast::SLP).to receive(:GetUnicastAttrMap)
-      .and_return(type: "server", description: "SMT")
+      .and_return(type: "server", description: "RMT")
   end
 
   describe "#run" do

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -294,15 +294,15 @@ describe Registration::SwMgmt do
       subject.copy_old_credentials(root_dir)
     end
 
-    it "copies old SMT credentials at upgrade" do
-      smt_credentials = File.join(root_dir, target_dir, "SMT-http_smt_example_com")
+    it "copies old SMT/RMT credentials at upgrade" do
+      credentials = File.join(root_dir, target_dir, "RMT-http_example_com")
       allow(Dir).to receive(:[]).with(File.join(root_dir, target_dir, "*"))
-        .and_return([smt_credentials])
+        .and_return([credentials])
 
       allow(SUSE::Connect::YaST).to receive(:credentials).and_return(OpenStruct.new)
 
       expect(Yast::Execute).to receive(:locally!)
-        .with("cp", "-a", smt_credentials, File.join(target_dir, "SMT-http_smt_example_com"))
+        .with("cp", "-a", credentials, File.join(target_dir, "RMT-http_example_com"))
 
       subject.copy_old_credentials(root_dir)
     end

--- a/test/url_helpers_spec.rb
+++ b/test/url_helpers_spec.rb
@@ -158,13 +158,13 @@ describe "Registration::UrlHelpers" do
         end
       end
 
-      context " when the system has been already registered with SMT server" do
+      context "when the system has been already registered with RMT server" do
         before do
           allow(File).to receive(:exist?)
             .with("/mnt/etc/SUSEConnect").and_return(true)
         end
 
-        it "returns URL of SMT server" do
+        it "returns URL of RMT server" do
           expect(File).to receive(:exist?).with(fixtures_file("SUSEConnect")).and_return(true)
           expect(SUSE::Connect::Config).to receive(:new).with(suse_connect)
             .and_return(SUSE::Connect::Config.new(fixtures_file("SUSEConnect")))


### PR DESCRIPTION
## Problem

* https://bugzilla.suse.com/show_bug.cgi?id=1136433
* https://trello.com/c/O1hyJX01/
* Related to #431

Although from SLE-15 onward [only RMT is offered](https://github.com/SUSE/rmt), there are some parts that still referring to [SMT](https://github.com/SUSE/smt). Namely, 

* in [widget labels](https://github.com/yast/yast-registration/blob/0944ebf458ee04517bc3441ad96357a3c8115c62/src/lib/registration/widgets/registration_code.rb#L38)
* in [help texts](https://github.com/yast/yast-registration/blob/0944ebf458ee04517bc3441ad96357a3c8115c62/src/lib/registration/widgets/registration_code.rb#L38)
* in comments

## Solution

Replace `SMT` by `RMT`. Or simply add `RMT` (mostly in comments).

## Other considerations

Read the comments below, regarding to `Yast::Registration::SmtStatus` class.