### PR TITLE
Fixed the migration summary in the Leap => SLES migration (bsc#1136325)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 30 13:37:19 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Properly display the openSUSE Leap to SLES migration summary
+  (bsc#1136325)
+- 4.1.22
+
+-------------------------------------------------------------------
 Fri Mar 15 18:03:43 UTC 2019 - Ladislav Slezak <lslezak@suse.cz>
 
 - Run the solver to correctly initialize the product statuses

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.1.21
+Version:        4.1.22
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -312,7 +312,8 @@ module Registration
         new_product_name = CGI.escapeHTML(new_product.friendly_name)
         installed_version = old_product["version_version"]
 
-        if installed_version == new_product.version
+        # check also the product name (when upgrading Leap 15.1 to SLES15-SP1 both are 15.1)
+        if installed_version == new_product.version && new_product.identifier == old_product["name"]
           # TRANSLATORS: Summary message, rich text format
           # %s is a product name, e.g. "SUSE Linux Enterprise Server 12"
           return _("%s <b>stays unchanged.</b>") % new_product_name
@@ -320,8 +321,9 @@ module Registration
 
         old_product_name = SwMgmt.product_label(old_product)
 
-        # use Gem::Version for version compare
-        if Gem::Version.new(installed_version) < Gem::Version.new(new_product.version)
+        # use Gem::Version for version compare, the versions might be the same
+        # if the products are different
+        if Gem::Version.new(installed_version) <= Gem::Version.new(new_product.version)
           # TRANSLATORS: Summary message, rich text format
           # %{old_product} is a product name, e.g. "SUSE Linux Enterprise Server 12"
           # %{new_product} is a product name, e.g. "SUSE Linux Enterprise Server 12 SP1 x86_64"


### PR DESCRIPTION
- Fixes https://bugzilla.suse.com/show_bug.cgi?id=1136325
- Generating the summary needs a small fix to better handle changing the baseproduct but using the same version, that's related to the https://github.com/yast/yast-packager/pull/444 fix.
- Also the rollback for aborted Leap => SLES migration needs to be adapted, the code did not expect changing the base product during online migration.


## Screenshots

#### Before

![Leap_migration_original](https://user-images.githubusercontent.com/907998/58635238-a6def380-82ed-11e9-8fad-108a12c4ad23.png)

#### With the Fix
![Leap_migration_fixed](https://user-images.githubusercontent.com/907998/58635251-af372e80-82ed-11e9-99c2-7562b86c7869.png)
