### PR TITLE
[RFC] request system migrations individually

### DIFF
--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -181,14 +181,19 @@ module Registration
     def offline_migration_products(installed_products, target_base_product)
       log.info "Offline migration for: #{target_base_product}."
       migration_paths = []
-      ConnectHelpers.catch_registration_errors(show_update_hint: true) do
-        migration_paths = SUSE::Connect::YaST
-                          .system_offline_migrations(installed_products,
-                            target_base_product, connect_params)
+
+      installed_products.each do |product|
+        ConnectHelpers.catch_registration_errors(show_update_hint: true) do
+          migration_paths << SUSE::Connect::YaST.system_offline_migrations(
+            [product],
+            target_base_product,
+            connect_params
+          )
+        end
       end
 
       log.info "Received possible migrations paths: #{migration_paths}"
-      migration_paths
+      migration_paths.flatten(1)
     end
 
     # Get the list of updates for a base product or self_update_id if defined


### PR DESCRIPTION
:warning: **Just a WIP request for comments** :warning: 

---

## Reported problem

The installer gets stuck in a loop during migration when there is some not activated product.

<details>
<summary>Show/hide more details</summary>

> Then it hit an error for registration server failed. Details:
> The requested products 'SUSE Linux Enterprise Software Development Kit 12 SP3 ppc64le' have not  been activated in the system.

> This is correct.
> Then I got Error: no migration product found. This is not clear here. So click on OK. It goes back to page Select for Update. This becomes a loop.
> It cannot go further with installation and it doesn't ask me for registering SDK at first.
</details>

https://bugzilla.suse.com/show_bug.cgi?id=1078739

## THE Problem

When the registration server raises an error (422 in this case), the [`Registration#offline_migration_products`](https://github.com/yast/yast-registration/blob/27c184503d6d70cb42bbeeef389ab466b6129339/src/lib/registration/registration.rb#L181) ends up returning none migration paths. 

Just as a side note, the error is actually handled by the [`ConnectHelpers.catch_registration_errors`](https://github.com/yast/yast-registration/blob/27c184503d6d70cb42bbeeef389ab466b6129339/src/lib/registration/connect_helpers.rb#L63), which is responsible to show the details message.

It seems (**to me**) that **the problem** is in the `SUSEConnect Client`, because instead of returning a collection with valid migration paths, it is raising an exception when found a not activated product, probably in `SUSE::Connect::Connection#post`:

* [`Registration#offline_migration_products`](https://github.com/yast/yast-registration/blob/27c184503d6d70cb42bbeeef389ab466b6129339/src/lib/registration/registration.rb#L181)
  * [`SUSE::Connect::YaST#system_offline_migrations`](https://github.com/SUSE/connect/blob/14aeaf689622d4f6a9279c91b56a9b3547e75084/lib/suse/connect/yast.rb#L174) 
     * [`SUSE::Connect::Client#system_migrations`](https://github.com/SUSE/connect/blob/14aeaf689622d4f6a9279c91b56a9b3547e75084/lib/suse/connect/client.rb#L192) 
       * [`SUSE::Connect::Api#system_migrations`](https://github.com/SUSE/connect/blob/14aeaf689622d4f6a9279c91b56a9b3547e75084/lib/suse/connect/api.rb#L224) 
         * [`SUSE::Connect::Connection#post`](https://github.com/SUSE/connect/blob/14aeaf689622d4f6a9279c91b56a9b3547e75084/lib/suse/connect/connection.rb#L49)

## A workaround (NOT A SOLUTION)

To test this, I "tweak" the `Registration#offline_migration_products` to request the migrations paths per installed product. Obviously, **is not a solution** but allow us to see how looks the migration proposal/summary if the original code worked as expected, _simply excluding_ unregistered products from the migration :question: .

![Screenshot_openSUSE-Leap_2019-06-11_14:12:55](https://user-images.githubusercontent.com/1691872/59285026-33ca6b00-8c65-11e9-97e7-8f7b47569906.png)


## Questions

Is there a way to know the unregistered products in advance and to not include them as a "installed_product" at the time to request the migration paths?




