### PR TITLE
Improve error message for offline upgrade

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun 12 12:00:17 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Improve error message when migration products could not be found
+  during an offline upgrade (bsc#1078739).
+- 4.2.4
+
+-------------------------------------------------------------------
 Tue Jun  4 18:36:37 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -335,11 +335,21 @@ module Registration
       def load_migrations_for_products(products, remote_product)
         log.info "Loading offline migrations for target product: #{remote_product.inspect}"
         log.info "Installed products: #{products.inspect}"
+
         self.migrations = registration_ui.offline_migration_products(products, remote_product)
 
         if migrations.empty?
-          # TRANSLATORS: Error message
-          Yast::Report.Error(_("No migration product found."))
+          msg = [
+            # TRANSLATORS. Error message
+            _("No migration product found."),
+            # TRANSLATORS: Help message
+            _("Please, boot the original system and make sure " \
+              "that it and all registerable products are correctly registered.\n" \
+              "Also check that the installed system is supported for upgrade to this new product.")
+          ]
+
+          Yast::Report.Error(msg.join("\n\n"))
+
           return Yast::Mode.auto ? :abort : :empty
         end
 

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -342,10 +342,11 @@ module Registration
           msg = [
             # TRANSLATORS. Error message
             _("No migration product found."),
-            # TRANSLATORS: Help message
+            # TRANSLATORS: Help message, %{product} is the product name
             _("Please, boot the original system and make sure " \
-              "that it and all registerable products are correctly registered.\n" \
-              "Also check that the installed system is supported for upgrade to this new product.")
+              "that all registerable products are correctly registered.\n" \
+              "Also check that the installed system is supported for upgrade to \n" \
+              "%{product}.") % { product: Y2Packager::ProductUpgrade.new_base_product.display_name }
           ]
 
           Yast::Report.Error(msg.join("\n\n"))


### PR DESCRIPTION
## Problem

During the offline upgrade, the installer **seems to** get stuck in a loop during when there is some product not activated yet.

https://bugzilla.suse.com/show_bug.cgi?id=1078739

## Actually

>  it's not the installer which is looping **but the user insisting on doing an impossible upgrade**
>
> [@lslezak in the 5th comment](https://bugzilla.suse.com/show_bug.cgi?id=1078739#c5)

## Solution

Improve the error message, changing it from simply

> No migration product found.

to 

> No migration product found.
>
> Please, boot the original system and make sure that it and all registerable products are correctly registered.
> Also check that the installed system is supported for upgrade to this _product display_name_.

## Screenshot
![](https://user-images.githubusercontent.com/1691872/59422924-072f6400-8dc9-11e9-88d8-c4995b3b25ec.png)

---

See also https://github.com/yast/yast-registration/pull/437 for a better understanding why there is not a clear and better solution for this

> [quite artificial situation](https://github.com/yast/yast-registration/pull/437)
