### PR TITLE
Do not abort the installation when an addon EULA is refused

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jun 14 07:15:21 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Do not abort when an addon license is refused (bsc#1114018).
+- 3.3.0
+
+-------------------------------------------------------------------
 Mon Feb 18 13:11:12 UTC 2019 - lslezak@suse.cz
 
 - Fixed "can't modify frozen String" crash (bsc#1125006)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.2.18
+Version:        3.3.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -44,8 +44,8 @@ Requires:       SUSEConnect >= 0.2.37
 
 Requires:       yast2-slp >= 3.1.9
 Requires:       yast2-add-on >= 3.1.8
-# packager/product_patterns.rb
-Requires:       yast2-packager >= 3.1.95
+# Packager ProductLicense#HandleLicenseDialogRet allowing "refuse" action
+Requires:       yast2-packager >= 3.3.1
 Requires:       yast2-update >= 3.1.36
 
 BuildRequires:  yast2 >= 3.1.26

--- a/src/clients/inst_scc.rb
+++ b/src/clients/inst_scc.rb
@@ -204,7 +204,7 @@ module Yast
 
     # display EULAs for the selected addons
     def addon_eula
-      ::Registration::UI::AddonEulaDialog.run(@selected_addons)
+      ::Registration::UI::AddonEulaDialog.run(Registration::Addon.selected)
     end
 
     # remember the user entered values so they can be stored to the AutoYast

--- a/src/clients/inst_scc.rb
+++ b/src/clients/inst_scc.rb
@@ -135,9 +135,6 @@ module Yast
       # FIXME: available_addons is called just to fill cache with popup
       return :cancel if get_available_addons == :cancel
 
-      # FIXME: workaround to reference between old way and new storage in Addon metaclass
-      @selected_addons = Registration::Addon.selected
-      ::Registration::Storage::InstallationOptions.instance.selected_addons = @selected_addons
       Registration::UI::AddonSelectionRegistrationDialog.run(@registration)
     end
 

--- a/src/clients/inst_scc.rb
+++ b/src/clients/inst_scc.rb
@@ -161,7 +161,8 @@ module Yast
     # back returns directly to the extensions selection
     def register_addons
       return false if init_registration == :cancel
-      ret = registration_ui.register_addons(@selected_addons, @known_reg_codes)
+
+      ret = registration_ui.register_addons(Registration::Addon.to_register, @known_reg_codes)
       ret = :extensions if ret == :back
       ret
     end

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -71,6 +71,13 @@ module Registration
         selected.reject(&:eula_refused?)
       end
 
+      # Returns only those selected addons with accepted EULA but pending to be registered
+      #
+      # @return [Array<Addon>]
+      def to_register
+        accepted - registered
+      end
+
       # return add-ons which are registered but not installed in the system
       # and are available to install
       # @return [Array<Addon>] the list of add-ons

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -64,6 +64,13 @@ module Registration
         @selected ||= []
       end
 
+      # Returns only those selected addons with accepted EULA
+      #
+      # @return [Array<Addon>]
+      def accepted
+        selected.reject(&:eula_refused?)
+      end
+
       # return add-ons which are registered but not installed in the system
       # and are available to install
       # @return [Array<Addon>] the list of add-ons

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -122,6 +122,8 @@ module Registration
     attr_reader :children, :eula_accepted
     attr_accessor :depends_on, :regcode
 
+    alias_method :eula_accepted?, :eula_accepted
+
     # delegate methods to underlaying suse connect object
     def_delegators :@pure_addon,
       :arch,
@@ -142,7 +144,7 @@ module Registration
     # @param pure_addon [SUSE::Connect::Product] a pure add-on from the registration server
     def initialize(pure_addon)
       @pure_addon = pure_addon
-      @eula_accepted = nil
+      @eula_accepted = false
       @children = []
     end
 
@@ -250,11 +252,6 @@ module Registration
     # Set the EULA as accepted
     def accept_eula
       @eula_accepted = true
-    end
-
-    # Set the EULA as not accepted
-    def refuse_eula
-      @eula_accepted = false
     end
 
     # Whether the eula has been refused

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -105,7 +105,7 @@ module Registration
 
     extend Forwardable
 
-    attr_reader :children
+    attr_reader :children, :eula_accepted
     attr_accessor :depends_on, :regcode
 
     # delegate methods to underlaying suse connect object
@@ -128,6 +128,7 @@ module Registration
     # @param pure_addon [SUSE::Connect::Product] a pure add-on from the registration server
     def initialize(pure_addon)
       @pure_addon = pure_addon
+      @eula_accepted = nil
       @children = []
     end
 
@@ -230,6 +231,30 @@ module Registration
       [:arch, :identifier, :version, :release_type].all? do |attr|
         send(attr) == remote_product.send(attr)
       end
+    end
+
+    # Set the EULA as accepted
+    def accept_eula
+      @eula_accepted = true
+    end
+
+    # Set the EULA as not accepted
+    def refuse_eula
+      @eula_accepted = false
+    end
+
+    # Whether the eula has been refused
+    #
+    # @return [Boolean] true if EULA acceptance was required but refused; false otherwise
+    def eula_refused?
+      eula_acceptance_needed? && !eula_accepted
+    end
+
+    # Whether the EULA acceptance is required
+    #
+    # @return [Boolean] true if a not empty EULA url is present; false otherwise
+    def eula_acceptance_needed?
+      !eula_url.to_s.strip.empty?
     end
   end
 end

--- a/src/lib/registration/ui/addon_eula_dialog.rb
+++ b/src/lib/registration/ui/addon_eula_dialog.rb
@@ -129,13 +129,18 @@ module Registration
 
           eula_reader = EulaReader.new(tmpdir)
           setup_eula_dialog(addon, eula_reader, tmpdir)
+          result = run_eula_dialog(eula_reader)
 
-          response = run_eula_dialog(eula_reader)
-
-          addon.accept_eula if response == :accepted
-          addon.refuse_eula if response == :refuse
-
-          [:accepted, :refuse].include?(response) ? :next : response
+          case result
+          when :accepted
+            addon.accept_eula
+            :next
+          when :refuse
+            addon.refuse_eula
+            :next
+          else
+            result
+          end
         end
       ensure
         Yast::ProductLicense.CleanUp()

--- a/src/lib/registration/ui/addon_eula_dialog.rb
+++ b/src/lib/registration/ui/addon_eula_dialog.rb
@@ -133,7 +133,7 @@ module Registration
           result = run_eula_dialog(eula_reader)
           addon.accept_eula if result == :accepted
 
-          return :next if [:accepted, :refuse].include?(result)
+          return :next if [:accepted, :refused].include?(result)
           result
         end
       ensure

--- a/src/lib/registration/ui/addon_eula_dialog.rb
+++ b/src/lib/registration/ui/addon_eula_dialog.rb
@@ -35,7 +35,8 @@ module Registration
         @addons = selected_addons
       end
 
-      # display the EULA for each extension and wait for a button click
+      # Display the EULA for each extension and wait for a button click
+      #
       # @return [Symbol] user input (:next, :back, :abort, :halt)
       def run
         Yast::Wizard.SetContents(
@@ -47,22 +48,17 @@ module Registration
           false
         )
 
-        # Default: no EULA specified => accepted
-        eula_ret = :accepted
-
         addons.each do |addon|
-          next unless addon.eula_url && !addon.eula_url.empty?
+          next unless addon.eula_acceptance_needed?
+          next if addon.registered?
 
           log.info "Addon '#{addon.name}' has an EULA at #{addon.eula_url}"
-          eula_ret = accept_eula(addon)
+          result = accept_eula(addon)
 
-          # any declined license needs to be handled separately
-          break if eula_ret != :accepted
+          return result unless result == :next
         end
 
-        # go back or abort if any EULA has not been accepted, let the user
-        # deselect the not accepted extension
-        eula_ret == :accepted ? :next : eula_ret
+        :next
       end
 
     private
@@ -116,23 +112,30 @@ module Registration
       # @return [Symbol] :accepted, :back, :abort, :halt - user input
       def run_eula_dialog(eula_reader)
         base_product = false
-        cancel_action = "abort"
+        cancel_action = "refuse"
         ret = Yast::ProductLicense.HandleLicenseDialogRet(arg_ref(eula_reader.licenses),
           base_product, cancel_action)
         log.debug "EULA dialog result: #{ret}"
+
         ret
       end
 
       # ask user to accept an addon EULA
       # @param [Addon] addon the addon
-      # @return [Symbol] :accepted, :back, :abort, :halt
+      # @return [Symbol] :next, :back, :abort, :halt
       def accept_eula(addon)
         Dir.mktmpdir("extension-eula-") do |tmpdir|
           return :back unless download_eula(addon, tmpdir)
-          eula_reader = EulaReader.new(tmpdir)
 
+          eula_reader = EulaReader.new(tmpdir)
           setup_eula_dialog(addon, eula_reader, tmpdir)
-          run_eula_dialog(eula_reader)
+
+          response = run_eula_dialog(eula_reader)
+
+          addon.accept_eula if response == :accepted
+          addon.refuse_eula if response == :refuse
+
+          [:accepted, :refuse].include?(response) ? :next : response
         end
       ensure
         Yast::ProductLicense.CleanUp()

--- a/src/lib/registration/ui/addon_eula_dialog.rb
+++ b/src/lib/registration/ui/addon_eula_dialog.rb
@@ -129,18 +129,12 @@ module Registration
 
           eula_reader = EulaReader.new(tmpdir)
           setup_eula_dialog(addon, eula_reader, tmpdir)
-          result = run_eula_dialog(eula_reader)
 
-          case result
-          when :accepted
-            addon.accept_eula
-            :next
-          when :refuse
-            addon.refuse_eula
-            :next
-          else
-            result
-          end
+          result = run_eula_dialog(eula_reader)
+          addon.accept_eula if result == :accepted
+
+          return :next if [:accepted, :refuse].include?(result)
+          result
         end
       ensure
         Yast::ProductLicense.CleanUp()

--- a/test/addon_spec.rb
+++ b/test/addon_spec.rb
@@ -130,6 +130,86 @@ describe Registration::Addon do
     end
   end
 
+  describe "#accept_eula" do
+    it "sets EULA as accepted" do
+      addon.accept_eula
+
+      expect(addon.eula_accepted).to eq(true)
+    end
+  end
+
+  describe "#refuse_eula" do
+    it "sets EULA as not accepted" do
+      addon.refuse_eula
+
+      expect(addon.eula_accepted).to eq(false)
+    end
+  end
+
+  describe "#eula_refused?" do
+    context "when EULA acceptance is not required" do
+      before do
+        allow(addon).to receive(:eula_acceptance_needed?).and_return(false)
+      end
+
+      it "returns false" do
+        expect(addon.eula_refused?).to eq(false)
+      end
+    end
+
+    context "when EULA acceptance is required" do
+      before do
+        allow(addon).to receive(:eula_acceptance_needed?).and_return(true)
+      end
+
+      context "and the license was accepted" do
+        it "returns false" do
+          addon.accept_eula
+
+          expect(addon.eula_refused?).to eq(false)
+        end
+      end
+
+      context "and the license was refused" do
+        it "returns true" do
+          addon.refuse_eula
+
+          expect(addon.eula_refused?).to eq(true)
+        end
+      end
+    end
+  end
+
+  context "#eula_acceptance_needed" do
+    let(:eula_url) { nil }
+
+    before do
+      allow(addon).to receive(:eula_url).and_return(eula_url)
+    end
+
+    context "when there is not an EULA url" do
+      it "returns false" do
+        expect(addon.eula_acceptance_needed?).to eq(false)
+      end
+    end
+
+    context "when there is an empty EULA url" do
+      let(:eula_url) { "  " }
+
+      it "returns false" do
+        expect(addon.eula_acceptance_needed?).to eq(false)
+      end
+    end
+
+    context "when there is a NOT empty EULA url" do
+      let(:eula_url) { "http://example.eula.url" }
+
+      it "returns true" do
+        expect(addon.eula_acceptance_needed?).to eq(true)
+      end
+    end
+  end
+
   describe "#unregistered" do
     it "marks addon as unregistered" do
       Registration::Addon.registered << addon

--- a/test/addon_spec.rb
+++ b/test/addon_spec.rb
@@ -140,11 +140,11 @@ describe Registration::Addon do
     let(:registered) { Registration::Addon.new(addon_generator(params)) }
     let(:not_selected) { Registration::Addon.new(addon_generator(params)) }
     let(:available_addons) { [wo_eula, refused, accepted, registered, not_selected] }
-
-    let(:registration) { double(
-      get_addon_list: available_addons
+    let(:registration) do
+      double(
+        get_addon_list: available_addons
       )
-    }
+    end
 
     before do
       available_addons.each(&:selected)

--- a/test/addon_spec.rb
+++ b/test/addon_spec.rb
@@ -282,7 +282,7 @@ describe Registration::Addon do
       allow(addon).to receive(:eula_url).and_return(eula_url)
     end
 
-    context "when there is not an EULA url" do
+    context "when the EULA URL is nil" do
       it "returns false" do
         expect(addon.eula_acceptance_needed?).to eq(false)
       end

--- a/test/addon_spec.rb
+++ b/test/addon_spec.rb
@@ -100,13 +100,10 @@ describe Registration::Addon do
 
     before do
       wo_eula.selected
-
       refused.selected
-      refused.refuse_eula
-
       accepted.selected
-      accepted.accept_eula
 
+      accepted.accept_eula
       not_selected.accept_eula
     end
 
@@ -149,7 +146,6 @@ describe Registration::Addon do
     before do
       available_addons.each(&:selected)
 
-      refused.refuse_eula
       accepted.accept_eula
       registered.accept_eula
       registered.registered
@@ -233,14 +229,6 @@ describe Registration::Addon do
     end
   end
 
-  describe "#refuse_eula" do
-    it "sets EULA as not accepted" do
-      addon.refuse_eula
-
-      expect(addon.eula_accepted).to eq(false)
-    end
-  end
-
   describe "#eula_refused?" do
     context "when EULA acceptance is not required" do
       before do
@@ -265,10 +253,8 @@ describe Registration::Addon do
         end
       end
 
-      context "and the license was refused" do
+      context "and the license was not accepted" do
         it "returns true" do
-          addon.refuse_eula
-
           expect(addon.eula_refused?).to eq(true)
         end
       end

--- a/test/registration/ui/addon_eula_dialog_spec.rb
+++ b/test/registration/ui/addon_eula_dialog_spec.rb
@@ -35,7 +35,7 @@ describe Registration::UI::AddonEulaDialog do
       allow(Yast::Wizard).to receive(:SetContents)
     end
 
-    context "when there are not EULA acceptances to show" do
+    context "when there are no EULA acceptances to show" do
       let(:addons) { [registered_addon, addon_wo_eula] }
 
       it "does not display the eula dialog" do

--- a/test/registration/ui/addon_eula_dialog_spec.rb
+++ b/test/registration/ui/addon_eula_dialog_spec.rb
@@ -51,7 +51,7 @@ describe Registration::UI::AddonEulaDialog do
 
     context "when there are EULA acceptances pending" do
       let(:addons) { [addon_with_eula, second_addon_with_eula] }
-      let(:first_dialog_response) { :refuse }
+      let(:first_dialog_response) { :refused }
       let(:second_dialog_response) { :accepted }
 
       before do
@@ -114,7 +114,7 @@ describe Registration::UI::AddonEulaDialog do
 
       before do
         allow(Yast::ProductLicense).to receive(:HandleLicenseDialogRet)
-          .and_return(:refuse)
+          .and_return(:refused)
       end
 
       it "does not set it as accepted" do

--- a/test/registration/ui/addon_eula_dialog_spec.rb
+++ b/test/registration/ui/addon_eula_dialog_spec.rb
@@ -101,9 +101,7 @@ describe Registration::UI::AddonEulaDialog do
       end
 
       it "sets it as accepted" do
-        expect(addon_with_eula).to receive(:accept_eula)
-
-        eula_dialog.run
+        expect { eula_dialog.run }.to change { addon_with_eula.eula_accepted? }.from(false).to(true)
       end
 
       it "returns :next" do
@@ -119,10 +117,8 @@ describe Registration::UI::AddonEulaDialog do
           .and_return(:refuse)
       end
 
-      it "sets it as not accepted" do
-        expect(addon_with_eula).to receive(:refuse_eula)
-
-        eula_dialog.run
+      it "does not set it as accepted" do
+        expect { eula_dialog.run }.to_not change { addon_with_eula.eula_accepted? }
       end
 
       it "returns :next" do

--- a/test/registration/ui/addon_eula_dialog_spec.rb
+++ b/test/registration/ui/addon_eula_dialog_spec.rb
@@ -1,0 +1,133 @@
+#!/usr/bin/env rspec
+# ------------------------------------------------------------------------------
+# Copyright (c) 2019 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require_relative "../../spec_helper"
+require "registration/ui/addon_eula_dialog"
+
+describe Registration::UI::AddonEulaDialog do
+  subject(:eula_dialog) { described_class.new(addons) }
+
+  let(:params) { { "eula_url" => "http://example.addon-eula.url" } }
+  let(:addons) { [registered_addon, addon_wo_eula, addon_with_eula] }
+
+  let(:addon_wo_eula) { Registration::Addon.new(addon_generator) }
+  let(:addon_with_eula) { Registration::Addon.new(addon_generator(params)) }
+  let(:second_addon_with_eula) { Registration::Addon.new(addon_generator(params)) }
+  let(:registered_addon) { Registration::Addon.new(addon_generator(params)) }
+
+  before do
+    allow(eula_dialog).to receive(:download_eula).and_return(true)
+    registered_addon.registered
+  end
+
+  describe "#run" do
+    before do
+      allow(Yast::Wizard).to receive(:SetContents)
+    end
+
+    context "when there are not EULA acceptances to show" do
+      let(:addons) { [registered_addon, addon_wo_eula] }
+
+      it "does not display the eula dialog" do
+        expect(Yast::ProductLicense).to_not receive(:DisplayLicenseDialogWithTitle)
+
+        eula_dialog.run
+      end
+
+      it "returns :next" do
+        expect(eula_dialog.run).to eq(:next)
+      end
+    end
+
+    context "when there are EULA acceptances pending" do
+      let(:addons) { [addon_with_eula, second_addon_with_eula] }
+      let(:first_dialog_response) { :refuse }
+      let(:second_dialog_response) { :accepted }
+
+      before do
+        allow(Yast::ProductLicense).to receive(:HandleLicenseDialogRet)
+          .and_return(first_dialog_response, second_dialog_response)
+      end
+
+      context "and the user wants to go back" do
+        let(:first_dialog_response) { :back }
+
+        it "returns :back" do
+          expect(subject.run).to eq(:back)
+        end
+      end
+
+      context "and the user wants to abort" do
+        let(:first_dialog_response) { :abort }
+
+        it "returns :abort" do
+          expect(subject.run).to eq(:abort)
+        end
+      end
+
+      context "but an EULA cannot be downloaded" do
+        before do
+          allow(eula_dialog).to receive(:download_eula).and_return(false)
+        end
+
+        it "does not display the eula dialog" do
+          expect(Yast::ProductLicense).to_not receive(:DisplayLicenseDialogWithTitle)
+
+          eula_dialog.run
+        end
+
+        it "returns :back" do
+          expect(eula_dialog.run).to eq(:back)
+        end
+      end
+    end
+
+    context "when EULA is accepted" do
+      let(:addons) { [addon_with_eula] }
+
+      before do
+        allow(Yast::ProductLicense).to receive(:HandleLicenseDialogRet)
+          .and_return(:accepted)
+      end
+
+      it "sets it as accepted" do
+        expect(addon_with_eula).to receive(:accept_eula)
+
+        eula_dialog.run
+      end
+
+      it "returns :next" do
+        expect(eula_dialog.run).to eq(:next)
+      end
+    end
+
+    context "when EULA is refused" do
+      let(:addons) { [addon_with_eula] }
+
+      before do
+        allow(Yast::ProductLicense).to receive(:HandleLicenseDialogRet)
+          .and_return(:refuse)
+      end
+
+      it "sets it as not accepted" do
+        expect(addon_with_eula).to receive(:refuse_eula)
+
+        eula_dialog.run
+      end
+
+      it "returns :next" do
+        expect(eula_dialog.run).to eq(:next)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When user refuses an addon's EULA (doing click in "Next" without check the _I Agree to the License Terms._) the installation is completely aborted.

* https://bugzilla.suse.com/show_bug.cgi?id=1114018
* https://trello.com/c/Kc9mRVpB

## Solution

In spite of in the current code there is an intentional (and broken) behavior to

>  go back or abort if any EULA has not been accepted — [addon_eula_dialog.rb#L63](https://github.com/yast/yast-registration/blob/e25b04d710ff0d2a688dcd6d5a050fbc361b4580/src/lib/registration/ui/addon_eula_dialog.rb#L63)

it seems that the correct behavior should be **just go ahead _refusing_ the license and not installing/registering the addon**, according to the message shown to the user.

<details>
<summary>Show/hide screenshot</summary>

---

![Screenshot_sles12-sp4_2019-06-19_11_28_47](https://user-images.githubusercontent.com/1691872/59758426-d1392680-9285-11e9-914c-e7bca8ebc6af.png)

</details>

To do that, it has been necessary to update `yast2-packager` too (see https://github.com/yast/yast-packager/pull/452), in order to support "refuse" as a cancel action. Otherwise, it is not possible to distinguish when the "abort" means "to refuse the license agreement" or "abort the installation".

## Tests

* Added and updated some unit tests.
* Tested manually via driver update.

## Caveats

The selection is untouched. I.e., when a license is refused but the user goes back to the select extensions dialog, the product is still selected.
