### PR TITLE
[master] Keep the addons EULA workflow synced 

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 20 14:15:48 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Do not abort when an addon license is refused (bsc#1114018).
+- 4.2.5
+
+-------------------------------------------------------------------
 Wed Jun 12 12:00:17 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Improve error message when migration products could not be found

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.4
+Version:        4.2.5
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only
@@ -54,8 +54,8 @@ Requires:       rubygem(suse-connect) >= 0.2.37
 Requires:       SUSEConnect >= 0.2.37
 Requires:       yast2-add-on >= 3.1.8
 Requires:       yast2-slp >= 3.1.9
-# packager/product_patterns.rb
-Requires:       yast2-packager >= 3.1.95
+# Packager ProductLicense#HandleLicenseDialogRet allowing "refuse" action
+Requires:       yast2-packager >= 4.2.16
 Requires:       yast2-update >= 3.1.36
 
 BuildArch:      noarch

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -331,6 +331,13 @@ module Registration
       end
     end
 
+    # Whether the EULA acceptance is required
+    #
+    # @return [Boolean] true if a not empty EULA url is present; false otherwise
+    def eula_acceptance_needed?
+      !eula_url.to_s.strip.empty?
+    end
+
     def self.dump_addons
       # dump the downloaded data to a file for easier debugging,
       # avoid write failures when running as an unprivileged user (rspec tests)

--- a/test/registration/ui/addon_eula_dialog_test.rb
+++ b/test/registration/ui/addon_eula_dialog_test.rb
@@ -15,13 +15,129 @@ require_relative "../../spec_helper"
 require "registration/ui/addon_eula_dialog"
 
 describe Registration::UI::AddonEulaDialog do
-  subject(:dialog) { described_class.new([addon]) }
+  subject(:dialog) { described_class.new(addons) }
 
-  let(:addon) do
-    addon_generator("name" => "SLES", "eula_url" => "https://suse.com/download/SLES/eula")
+  let(:params) { { "eula_url" => "http://example.addon-eula.url" } }
+  let(:addons) { [registered_addon, addon_wo_eula, addon_with_eula] }
+
+  let(:addon_wo_eula) { Registration::Addon.new(addon_generator) }
+  let(:addon_with_eula) { Registration::Addon.new(addon_generator(params)) }
+  let(:second_addon_with_eula) { Registration::Addon.new(addon_generator(params)) }
+  let(:registered_addon) { Registration::Addon.new(addon_generator(params)) }
+
+  let(:product_license) do
+    instance_double(Y2Packager::ProductLicense, accepted?: false, accept!: true)
+  end
+
+  describe "#run" do
+    before do
+      allow(Yast::Wizard).to receive(:SetContents)
+      allow(dialog).to receive(:find_license).and_return(product_license)
+      allow(dialog).to receive(:download_eula).and_return(true)
+      registered_addon.registered
+    end
+
+    context "when there are no EULA acceptances to show" do
+      let(:addons) { [registered_addon, addon_wo_eula] }
+
+      it "does not display the EULA dialog" do
+        expect(Yast::ProductLicense).to_not receive(:DisplayLicenseDialogWithTitle)
+
+        dialog.run
+      end
+
+      it "returns :next" do
+        expect(dialog.run).to eq(:next)
+      end
+    end
+
+    context "when there are EULA acceptances pending" do
+      let(:addons) { [addon_with_eula, second_addon_with_eula] }
+      let(:first_dialog_response) { :refused }
+      let(:second_dialog_response) { :accepted }
+
+      before do
+        allow(Yast::ProductLicense).to receive(:HandleLicenseDialogRet)
+          .and_return(first_dialog_response, second_dialog_response)
+      end
+
+      context "and the user wants to go back" do
+        let(:first_dialog_response) { :back }
+
+        it "returns :back" do
+          expect(subject.run).to eq(:back)
+        end
+      end
+
+      context "and the user wants to abort" do
+        let(:first_dialog_response) { :abort }
+
+        it "returns :abort" do
+          expect(subject.run).to eq(:abort)
+        end
+      end
+
+      context "but an EULA cannot be downloaded" do
+        before do
+          allow(dialog).to receive(:download_eula).and_return(false)
+        end
+
+        it "does not display the eula dialog" do
+          expect(Yast::ProductLicense).to_not receive(:DisplayLicenseDialogWithTitle)
+
+          dialog.run
+        end
+
+        it "returns :back" do
+          expect(dialog.run).to eq(:back)
+        end
+      end
+    end
+
+    context "when EULA is accepted" do
+      let(:addons) { [addon_with_eula] }
+
+      before do
+        allow(Yast::ProductLicense).to receive(:HandleLicenseDialogRet)
+          .and_return(:accepted)
+      end
+
+      it "sets it as accepted" do
+        expect(product_license).to receive(:accept!)
+
+        subject.run
+      end
+
+      it "returns :next" do
+        expect(dialog.run).to eq(:next)
+
+        subject.run
+      end
+    end
+
+    context "when EULA is refused" do
+      let(:addons) { [addon_with_eula] }
+
+      before do
+        allow(Yast::ProductLicense).to receive(:HandleLicenseDialogRet)
+          .and_return(:refused)
+      end
+
+      it "does not set it as accepted" do
+        expect(product_license).to_not receive(:accept!)
+      end
+
+      it "returns :next" do
+        expect(dialog.run).to eq(:next)
+      end
+    end
   end
 
   describe "#accept_eula" do
+    let(:addon) do
+      addon_generator("name" => "SLES", "eula_url" => "https://suse.com/download/SLES/eula")
+    end
+    let(:addons) { [addon] }
     let(:eula_downloader) { instance_double(Registration::EulaDownloader, download: true) }
     let(:eula_reader) { instance_double(Registration::EulaReader, licenses: licenses_files) }
     let(:licenses_files) do
@@ -78,8 +194,8 @@ describe Registration::UI::AddonEulaDialog do
     context "when the license was previously accepted" do
       let(:accepted?) { true }
 
-      it "returns :accepted" do
-        expect(dialog.send(:accept_eula, addon)).to eq(:accepted)
+      it "returns :next" do
+        expect(dialog.send(:accept_eula, addon)).to eq(:next)
       end
 
       it "does not show the eula" do


### PR DESCRIPTION
### :warning: Similar to https://github.com/yast/yast-registration/pull/440, but for `master` (aka SLE-15-SP2) :warning: ###

This is a request for comments just to know if we must/should submit changes "synced" with those introduced in #439 for SLE-12-SP5.

The thing is that the _same_ fix for SLE-15 does not need these changes. Instead, the `yast2-addon` module has been updated (see yast/yast-add-on#78). So, it could be said/it seems to me that this is a dead code in SLE-15 branches, but I'm not 100% sure.

That's why I'm requesting to, at least, keep it "updated". Although any suggestion or clarification is, of course, **very** welcome.
