### PR TITLE
Fixed unit test (bsc#1144550)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug  6 17:05:32 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed unit test, reset the mocked addons in the
+  addon_eula_dialog_test.rb test (bsc#1144550)
+- 4.2.6
+
+-------------------------------------------------------------------
 Thu Jun 20 14:15:48 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Do not abort when an addon license is refused (bsc#1114018).

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.5
+Version:        4.2.6
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/test/registration/ui/addon_eula_dialog_test.rb
+++ b/test/registration/ui/addon_eula_dialog_test.rb
@@ -37,6 +37,10 @@ describe Registration::UI::AddonEulaDialog do
       registered_addon.registered
     end
 
+    after do
+      Registration::Addon.reset!
+    end
+
     context "when there are no EULA acceptances to show" do
       let(:addons) { [registered_addon, addon_wo_eula] }
 


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1144550
- Reset the mocked addons in the `addon_eula_dialog_test.rb` test
- This caused random failures depending on the order of the tests, to reproduce the issue you need to run this command:  
```
rspec test/registration/ui/addon_eula_dialog_test.rb test/migration_repos_workflow_spec.rb
```
- 4.2.6