### PR TITLE
Support for the online installation medium (jsc#SLE-7214)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Sep 20 09:27:04 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Support for the online installation medium (jsc#SLE-7214)
+- 4.2.8
+
+-------------------------------------------------------------------
 Thu Aug 22 16:54:42 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.7
+Version:        4.2.8
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only
@@ -26,20 +26,20 @@ Url:            https://github.com/yast/yast-registration
 
 Source0:        %{name}-%{version}.tar.bz2
 
-# Y2Packager::ProductLicense
 BuildRequires:  update-desktop-files
-BuildRequires:  yast2 >= 4.0.63
+# Y2Packager::ProductControlProduct
+BuildRequires:  yast2 >= 4.2.22
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-slp >= 3.1.9
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:suse-connect) >= 0.3.11
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake) >= 0.2.5
-# updated product renames
-BuildRequires:  yast2-packager >= 4.0.40
+# Y2Packager::MediumType
+BuildRequires:  yast2-packager >= 4.2.27
 BuildRequires:  yast2-update >= 3.1.36
 
-# Y2Packager::ProductLicense
-Requires:       yast2 >= 4.0.63
+# Y2Packager::ProductControlProduct
+Requires:       yast2 >= 4.2.22
 # "dupAllowVendorChange" option in Pkg.SetSolverFlags()
 Requires:       yast2-pkg-bindings >= 3.1.34
 # N_() method
@@ -54,8 +54,8 @@ Requires:       rubygem(%{rb_default_ruby_abi}:suse-connect) >= 0.2.37
 Requires:       SUSEConnect >= 0.2.37
 Requires:       yast2-add-on >= 3.1.8
 Requires:       yast2-slp >= 3.1.9
-# Packager ProductLicense#HandleLicenseDialogRet allowing "refuse" action
-Requires:       yast2-packager >= 4.2.16
+# Y2Packager::MediumType
+Requires:       yast2-packager >= 4.2.27
 Requires:       yast2-update >= 3.1.36
 
 BuildArch:      noarch

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -51,6 +51,7 @@ module Registration
         email: email
       )
 
+      log.info "Announcing system with distro_target: #{distro_target}"
       login, password = SUSE::Connect::YaST.announce_system(settings, distro_target)
       log.info "Global SCC credentials (username): #{login}"
 

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -33,6 +33,8 @@ require "registration/url_helpers"
 require "registration/repo_state"
 
 require "packager/product_patterns"
+require "y2packager/medium_type"
+require "y2packager/product_control_product"
 require "y2packager/product_reader"
 require "yast2/execute"
 
@@ -147,11 +149,28 @@ module Registration
       product_info
     end
 
+    # Product to register for the online installation medium
+    # @return [Hash] The product Hash
+    def self.online_base_product
+      prod = Y2Packager::ProductControlProduct.selected
+      raise "No base product selected from control.xml!" unless prod
+
+      {
+        "name"            => prod.name,
+        "version_version" => prod.version,
+        "arch"            => prod.arch,
+        "display_name"    => prod.label,
+        "register_target" => prod.register_target
+      }
+    end
+
     def self.find_base_product
       # FIXME: refactor the code to use Y2Packager::Product
 
       # just for debugging:
       return FAKE_BASE_PRODUCT if ENV["FAKE_BASE_PRODUCT"]
+
+      return online_base_product if Y2Packager::MediumType.online?
 
       # use the selected product if a product has been already selected
       selected = product_selected? if Stage.initial

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -11,6 +11,7 @@ require "registration/sw_mgmt"
 require "registration/helpers"
 require "registration/url_helpers"
 require "registration/ui/abort_confirmation"
+require "y2packager/medium_type"
 
 module Registration
   module UI
@@ -32,6 +33,7 @@ module Registration
       Yast.import "Popup"
       Yast.import "Report"
       Yast.import "ProductFeatures"
+      Yast.import "Stage"
 
       WIDGETS = {
         register_scc:      [:email, :reg_code],
@@ -443,6 +445,10 @@ module Registration
       # @return [Boolean] true on success
       def register_system_and_base_product
         registration_ui = RegistrationUI.new(registration)
+
+        # ensure the GPG keys from inst-sys are imported to the package manager,
+        # on the online installation medium the package manager is initialized later
+        Yast::Packages.ImportGPGKeys if Yast::Stage.initial && Y2Packager::MediumType.online?
 
         success, product_service = registration_ui.register_system_and_base_product
 

--- a/src/lib/registration/widgets/registration_code.rb
+++ b/src/lib/registration/widgets/registration_code.rb
@@ -35,6 +35,7 @@ module Registration
       end
 
       def label
+        # TRANSLATORS: input field label
         _("Registration Code or RMT Server URL")
       end
 

--- a/test/base_system_registration_dialog_test.rb
+++ b/test/base_system_registration_dialog_test.rb
@@ -10,6 +10,10 @@ describe Registration::UI::BaseSystemRegistrationDialog do
   let(:custom_url) { "http://smt.example.com/" }
   let(:default_url) { SUSE::Connect::Config.new.url }
 
+  before do
+    allow(Yast::Packages).to receive(:ImportGPGKeys)
+  end
+
   describe ".run" do
     let(:instance) { double("dialog") }
 

--- a/test/inst_scc_test.rb
+++ b/test/inst_scc_test.rb
@@ -16,6 +16,7 @@ describe Yast::InstSccClient do
     allow(Yast::UI).to receive(:ReplaceWidget)
     allow(Yast::Mode).to receive(:update).and_return(false)
     allow(Yast::SlpService).to receive(:all).and_return([])
+    allow(Y2Packager::MediumType).to receive(:online?).and_return(false)
   end
 
   context "the system is already registered" do


### PR DESCRIPTION
- Adjust the registration step for the online medium installation
  - The product to register is read from the `control.xml` file
  - We need to import the GPG keys, on the online medium the registration step is called earlier in the workflow, otherwise libzypp would complain about unknown key for the SCC repositories
- https://jira.suse.com/browse/SLE-7214
- Tested manually
- 4.2.8