### PR TITLE
Fixed medium type detection (bsc#1152694)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct  8 10:29:07 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Detect the installation medium type only during installation,
+  it crashes in an installed system (bsc#1152694)
+- 4.2.11
+
+-------------------------------------------------------------------
 Thu Oct  3 09:41:19 UTC 2019 - Michal Filka <mfilka@suse.com>
 
 - bnc#1140474

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.10
+Version:        4.2.11
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -170,7 +170,7 @@ module Registration
       # just for debugging:
       return FAKE_BASE_PRODUCT if ENV["FAKE_BASE_PRODUCT"]
 
-      return online_base_product if Y2Packager::MediumType.online?
+      return online_base_product if Stage.initial && Y2Packager::MediumType.online?
 
       # use the selected product if a product has been already selected
       selected = product_selected? if Stage.initial


### PR DESCRIPTION
- Detect the installation medium type only during installation
- It crashes in an installed system
- https://bugzilla.suse.com/show_bug.cgi?id=1152694
- Related to PR #444 
- 4.2.11