### PR TITLE
Mock the "Profile" in the tests

### DIFF
--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -81,6 +81,15 @@ end
 
 stub_product_selection
 
+# stub module to prevent its Import
+# Useful for modules from different yast packages, to avoid build dependencies
+def stub_module(name)
+  Yast.const_set name.to_sym, Class.new { def self.fake_method; end }
+end
+
+# stub classes from other modules to avoid build dependencies
+stub_module("Profile")
+
 # load data generators
 require_relative "factories"
 


### PR DESCRIPTION
- Related to #452 
- The `Profile` module is now needed, to avoid adding the AutoYaST build dependencies mock the module completely