### PR TITLE
Decreasing required memory

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct 31 17:32:48 CET 2019 - schubi@suse.de
+
+- Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find
+  in order to decrease the required memory (bsc#1132650).
+- 4.2.14
+
+-------------------------------------------------------------------
 Fri Oct 18 10:14:56 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - AutoYaST support for the OnlineOnly installation medium

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.13
+Version:        4.2.14
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -319,7 +319,7 @@ module Registration
     end
 
     # Checks whether this addon updates an old addon
-    # @param [Hash] old_addon addon received from pkg-bindings
+    # @param [Hash] old_addon Hash addon received from pkg-bindings
     # @return [Boolean] true if it updates the old addon, false otherwise
     def updates_addon?(old_addon)
       old_addon["name"] == identifier || old_addon["name"] == @pure_addon.former_identifier

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -319,10 +319,10 @@ module Registration
     end
 
     # Checks whether this addon updates an old addon
-    # @param [Hash] old_addon addon Hash received from pkg-bindings
+    # @param [Y2Packager::Resolvable] old_addon addon received from pkg-bindings
     # @return [Boolean] true if it updates the old addon, false otherwise
     def updates_addon?(old_addon)
-      old_addon["name"] == identifier || old_addon["name"] == @pure_addon.former_identifier
+      old_addon.name == identifier || old_addon.name == @pure_addon.former_identifier
     end
 
     def matches_remote_product?(remote_product)

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -23,6 +23,7 @@ require "yast"
 require "forwardable"
 require "set"
 require "registration/sw_mgmt"
+require "y2packager/resolvable"
 
 module Registration
   # this is a wrapper class around SUSE::Connect::Product object
@@ -81,9 +82,8 @@ module Registration
               product["arch"] == addon.arch
           end
 
-          available = Yast::Pkg.ResolvableProperties(addon.identifier, :product, "").find do |p|
-            p["status"] == :available
-          end
+          available = Y2Packager::Resolvable.any?(kind: :product,
+            name: addon.identifier, status: :available)
 
           !installed && available
         end

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -319,7 +319,7 @@ module Registration
     end
 
     # Checks whether this addon updates an old addon
-    # @param [Hash] old_addon Hash addon received from pkg-bindings
+    # @param [Hash] old_addon addon Hash received from pkg-bindings
     # @return [Boolean] true if it updates the old addon, false otherwise
     def updates_addon?(old_addon)
       old_addon["name"] == identifier || old_addon["name"] == @pure_addon.former_identifier

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -319,10 +319,10 @@ module Registration
     end
 
     # Checks whether this addon updates an old addon
-    # @param [Y2Packager::Resolvable] old_addon addon received from pkg-bindings
+    # @param [Hash] old_addon addon received from pkg-bindings
     # @return [Boolean] true if it updates the old addon, false otherwise
     def updates_addon?(old_addon)
-      old_addon.name == identifier || old_addon.name == @pure_addon.former_identifier
+      old_addon["name"] == identifier || old_addon["name"] == @pure_addon.former_identifier
     end
 
     def matches_remote_product?(remote_product)

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -260,14 +260,14 @@ module Registration
     # Any product selected to install?
     # @return [Boolean] true if at least one product is selected to install
     def self.product_selected?
-      Y2Packager::Resolvable.any?(kind: :product, :status :selected)
+      Y2Packager::Resolvable.any?(kind: :product, status: :selected)
     end
 
     # Any product installed? (e.g. during upgrade)
     # @return [Boolean] true if at least one product is installed
     def self.product_installed?
-      Y2Packager::Resolvable.any?(kind: :product, :status :installed) ||
-      Y2Packager::Resolvable.any?(kind: :product, :status :removed)
+      Y2Packager::Resolvable.any?(kind: :product, status: :installed) ||
+      Y2Packager::Resolvable.any?(kind: :product, status: :removed)
     end
 
     def self.installed_products

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -668,9 +668,7 @@ module Registration
     # find the product resolvables from the specified repository
     def self.products_from_repo(repo_id)
       # TODO: only installed products??
-      Y2Packager::Resolvable.find(kind: :product).select do |product|
-        product.source == repo_id
-      end
+      Y2Packager::Resolvable.find(kind: :product, source: repo_id)
     end
 
     def self.get_release_type(product)

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -692,7 +692,7 @@ module Registration
     def self.products_from_repo(repo_id)
       # TODO: only installed products??
       products = Y2Packager::Resolvable.find(kind: :product, source: repo_id)
-      prodcuts.map { |p| resolvable_to_h(p) }
+      products.map { |p| resolvable_to_h(p) }
     end
 
     # Return release type

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -163,7 +163,7 @@ module Registration
         "version_version"  => product.version_version,
         "version"          => product.version,
         "arch"             => product.arch,
-        "display_name"     => product.label,
+        "display_name"     => product.display_name,
         "register_target"  => product.register_target,
         "register_release" => product.register_release,
         "product_line"     => product.product_line,
@@ -339,11 +339,11 @@ module Registration
     end
 
     # Find base product to register
-    # @return [Hash] base product
+    # @return [Hash] base product or nil if not found
     def self.base_product_to_register
       base_product = find_base_product
 
-      return unless base_product.empty?
+      return if !base_product || base_product.empty?
 
       # filter out not needed data
       product_info = {

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -260,15 +260,14 @@ module Registration
     # Any product selected to install?
     # @return [Boolean] true if at least one product is selected to install
     def self.product_selected?
-      Y2Packager::Resolvable.find(kind: :product).any? { |p| p.status == :selected }
+      Y2Packager::Resolvable.any?(kind: :product, :status :selected)
     end
 
     # Any product installed? (e.g. during upgrade)
     # @return [Boolean] true if at least one product is installed
     def self.product_installed?
-      Y2Packager::Resolvable.find(kind: :product).any? do |p|
-        p.status == :installed || p.status == :removed
-      end
+      Y2Packager::Resolvable.any?(kind: :product, :status :installed) ||
+      Y2Packager::Resolvable.any?(kind: :product, :status :removed)
     end
 
     def self.installed_products

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -204,6 +204,7 @@ module Registration
           log.info("Skipping product #{p.name}, no system-installation() provides")
           next false
         end
+
         evaluate_product(p, selected, installed)
       end
 
@@ -556,6 +557,7 @@ module Registration
         (product.status == :installed || product.status == :removed) &&
           product.type != "base"
       end
+
       product_names = installed_addons.map { |a| "#{a.name}-#{a.version}" }
       log.info "Installed addons: #{product_names}"
 

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -561,7 +561,7 @@ module Registration
 
       ret = addons.select do |addon|
         installed_addons.any? do |installed_addon|
-          addon.updates_addon?(installed_addon)
+          addon.updates_addon?({"name" => installed_addon.name})
         end
       end
 

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -204,12 +204,11 @@ module Registration
           log.info("Skipping product #{p.name}, no system-installation() provides")
           next false
         end
-
         evaluate_product(p, selected, installed)
       end
 
       log.debug "Found base products: #{products}"
-      log.info "Found base products: #{products.map { |p| p["name"] }}"
+      log.info "Found base products: #{products.map { |p| p.name }}"
       log.warn "More than one base product found!" if products.size > 1
 
       products.first
@@ -557,8 +556,7 @@ module Registration
         (product.status == :installed || product.status == :removed) &&
           product.type != "base"
       end
-
-      product_names = installed_addons.map { |a| "#{a.name}-#{a.version}-#{a.release}" }
+      product_names = installed_addons.map { |a| "#{a.name}-#{a.version}" }
       log.info "Installed addons: #{product_names}"
 
       ret = addons.select do |addon|
@@ -646,20 +644,19 @@ module Registration
       addons.each do |addon|
         log.info "Found remote addon: #{addon.identifier}-#{addon.version}-#{addon.arch}"
       end
-
       # select a remote addon for each product
       products.each do |product|
         remote_addon = addons.find do |addon|
-          product["name"] == addon.identifier &&
-            product["version_version"] == addon.version &&
-            product["arch"] == addon.arch
+          product.name == addon.identifier &&
+            product.version_version == addon.version &&
+            product.arch == addon.arch
         end
 
         if remote_addon
           remote_addon.selected
         else
-          product_label = "#{product["display_name"]} (#{product["name"]}" \
-            "-#{product["version_version"]}-#{product["arch"]})"
+          product_label = "#{product.display_name} (#{product.name}" \
+            "-#{product.version_version}-#{product.arch})"
 
           # TRANSLATORS: %s is a product name
           Report.Error(_("Cannot find remote product %s.\n" \

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -208,7 +208,7 @@ module Registration
       end
 
       log.debug "Found base products: #{products}"
-      log.info "Found base products: #{products.map { |p| p.name }}"
+      log.info "Found base products: #{products.map(&:name)}"
       log.warn "More than one base product found!" if products.size > 1
 
       products.first
@@ -266,7 +266,7 @@ module Registration
     # @return [Boolean] true if at least one product is installed
     def self.product_installed?
       Y2Packager::Resolvable.any?(kind: :product, status: :installed) ||
-      Y2Packager::Resolvable.any?(kind: :product, status: :removed)
+        Y2Packager::Resolvable.any?(kind: :product, status: :removed)
     end
 
     def self.installed_products
@@ -281,7 +281,7 @@ module Registration
         p.status == :installed || p.status == :removed
       end
 
-      log.info "Found installed products: #{products.map { |p| p.name }}"
+      log.info "Found installed products: #{products.map(&:name)}"
       products
     end
 
@@ -561,7 +561,7 @@ module Registration
 
       ret = addons.select do |addon|
         installed_addons.any? do |installed_addon|
-          addon.updates_addon?({"name" => installed_addon.name})
+          addon.updates_addon?("name" => installed_addon.name)
         end
       end
 
@@ -616,7 +616,7 @@ module Registration
         product.status == :available &&
           new_repos.any? { |new_repo| product.source == new_repo["SrcId"] }
       end
-      products.map! { |product| product.name }
+      products.map!(&:name)
 
       log.info "Products to install: #{products}"
 

--- a/src/lib/registration/ui/not_installed_products_dialog.rb
+++ b/src/lib/registration/ui/not_installed_products_dialog.rb
@@ -22,6 +22,7 @@
 require "yast"
 require "registration/sw_mgmt"
 require "registration/helpers"
+require "y2packager/resolvable"
 require "uri"
 
 module Registration
@@ -208,10 +209,10 @@ module Registration
       # @param addon [Registration::Addon]
       # @return [Hash] product which repository url match with addon ones
       def product_from_addon_repos(addon)
-        Yast::Pkg.ResolvableProperties("", :product, "").find do |product|
-          return false if product["status"] != :available
+        Y2Packager::Resolvable.find(kind: :product).find do |product|
+          return false if product.status != :available
 
-          product_url = SwMgmt.repository_data(product["source"]).fetch("url", "")
+          product_url = SwMgmt.repository_data(product.source).fetch("url", "")
 
           addon.repositories.any? { |r| no_query_uri(product_url) == no_query_uri(r["url"]) }
         end

--- a/src/lib/registration/ui/not_installed_products_dialog.rb
+++ b/src/lib/registration/ui/not_installed_products_dialog.rb
@@ -194,7 +194,7 @@ module Registration
       # @return [Boolean] true if the given addon is installable
       def addon_product_installable?(addon)
         product = product_from_addon_repos(addon)
-        return false if !product || !Yast::Pkg.ResolvableInstall(product["name"], :product)
+        return false if !product || !Yast::Pkg.ResolvableInstall(product.name, :product)
 
         if !Yast::Pkg.PkgSolve(true)
           return false if Yast::PackagesUI.RunPackageSelector("mode" => :summaryMode) != :accept
@@ -207,7 +207,7 @@ module Registration
       # ones.
       #
       # @param addon [Registration::Addon]
-      # @return [Hash] product which repository url match with addon ones
+      # @return [Y2Packager::Resolvable] product which repository url match with addon ones
       def product_from_addon_repos(addon)
         Y2Packager::Resolvable.find(kind: :product).find do |product|
           return false if product.status != :available

--- a/test/addon_spec.rb
+++ b/test/addon_spec.rb
@@ -139,7 +139,7 @@ describe Registration::Addon do
 
       expect(Registration::SwMgmt).to receive(:installed_products).and_return([])
       expect(Y2Packager::Resolvable).to receive(:any?).with(kind: :product,
-        name: prod2.identifier, status: :available)
+        name: prod.identifier, status: :available)
         .and_return(false)
 
       expect(Registration::Addon.registered_not_installed).to be_empty

--- a/test/addon_spec.rb
+++ b/test/addon_spec.rb
@@ -119,8 +119,9 @@ describe Registration::Addon do
       addon2 = addons.find { |addon| addon.name == "prod2" }
 
       expect(Registration::SwMgmt).to receive(:installed_products).and_return([])
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with(prod2.identifier, :product, "")
-        .and_return(["status" => :available])
+      expect(Y2Packager::Resolvable).to receive(:any?).with(kind: :product,
+        name: prod2.identifier, status: :available)
+        .and_return(true)
       reg_not_installed_addons = Registration::Addon.registered_not_installed
 
       expect(reg_not_installed_addons.size).to eql(1)
@@ -137,8 +138,9 @@ describe Registration::Addon do
       Registration::Addon.find_all(registration)
 
       expect(Registration::SwMgmt).to receive(:installed_products).and_return([])
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with(prod.identifier, :product, "")
-        .and_return([])
+      expect(Y2Packager::Resolvable).to receive(:any?).with(kind: :product,
+        name: prod2.identifier, status: :available)
+        .and_return(false)
 
       expect(Registration::Addon.registered_not_installed).to be_empty
     end

--- a/test/fixtures/products_legacy_installation.yml
+++ b/test/fixtures/products_legacy_installation.yml
@@ -35,6 +35,7 @@
   version_epoch:
   version_version: '12'
   version_release: '0'
+  product_line: product_line
 - arch: x86_64
   category: base
   description: |-
@@ -75,6 +76,7 @@
   version_epoch:
   version_version: '12'
   version_release: '0'
+  product_line: product_line
 - arch: x86_64
   category: addon
   description: |-
@@ -115,3 +117,4 @@
   version_epoch:
   version_version: '12'
   version_release: '0'
+  product_line: product_line

--- a/test/fixtures/products_sp2_update.yml
+++ b/test/fixtures/products_sp2_update.yml
@@ -1,6 +1,7 @@
 ---
 - arch: x86_64
   category: base
+  kind: :product
   description: |-
     SUSE Linux Enterprise offers a comprehensive
             suite of products built on a single code base.
@@ -41,6 +42,7 @@
   version: 11.2-1.513
 - arch: x86_64
   category: addon
+  kind: :product  
   description: WebYaST for SLE-11-SP2
   display_name: WebYaST for SLE-11-SP2
   download_size: 0
@@ -68,6 +70,7 @@
   version: 1.2-1.4
 - arch: x86_64
   category: addon
+  kind: :product  
   description: This is the SUSE Linux Enterprise Software Development Kit
   display_name: SUSE Linux Enterprise Software Development Kit 11 SP2
   download_size: 0
@@ -93,6 +96,7 @@
   version: 11.2-1.66
 - arch: x86_64
   category: addon
+  kind: :product  
   description: |-
     SUSE Linux Enterprise offers a comprehensive
             suite of products built on a single code base.

--- a/test/fixtures/products_sp2_update.yml
+++ b/test/fixtures/products_sp2_update.yml
@@ -40,6 +40,8 @@
   upgrades: []
   vendor: SUSE LINUX Products GmbH, Nuernberg, Germany
   version: 11.2-1.513
+  version_version: 11.2
+  product_line: product_line
 - arch: x86_64
   category: addon
   kind: :product  
@@ -68,6 +70,8 @@
   upgrades: []
   vendor: SUSE LINUX Products GmbH, Nuernberg, Germany
   version: 1.2-1.4
+  version_version: 1.2
+  product_line: product_line  
 - arch: x86_64
   category: addon
   kind: :product  
@@ -94,6 +98,8 @@
   upgrades: []
   vendor: SUSE LINUX Products GmbH, Nuernberg, Germany
   version: 11.2-1.66
+  version_version: 11.2
+  product_line: product_line  
 - arch: x86_64
   category: addon
   kind: :product  
@@ -134,3 +140,5 @@
   update_urls: []
   vendor: SUSE LLC <https://www.suse.com/>
   version: 12-0
+  version_version: 12
+  product_line: product_line

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -81,7 +81,7 @@ end
 
 require "y2packager/resolvable"
 def load_resolvable(filename)
-  load_yaml_fixture(filename).map { |p| Y2Packager::Resolvable.new(p) }  
+  load_yaml_fixture(filename).map { |p| Y2Packager::Resolvable.new(p) }
 end
 
 stub_product_selection

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -79,6 +79,11 @@ def stub_product_selection
   }
 end
 
+require "y2packager/resolvable"
+def load_resolvable(filename)
+  load_yaml_fixture(filename).map { |p| Y2Packager::Resolvable.new(p) }  
+end
+
 stub_product_selection
 
 # stub module to prevent its Import

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -386,16 +386,17 @@ describe Registration::SwMgmt do
   end
 
   describe ".products_from_repo" do
-    before do
-      expect(Y2Packager::Resolvable).to receive(:find)
-        .and_return(load_resolvable("products_legacy_installation.yml"))
-    end
-
     it "Returns product resolvables from the specified repository" do
+      expect(Y2Packager::Resolvable).to receive(:find)
+        .with(kind: :product, source: 5)
+        .and_return([load_resolvable("products_legacy_installation.yml").first])
       expect(subject.products_from_repo(5).size).to eq 1
     end
 
     it "Returns empty list if not product is found" do
+      expect(Y2Packager::Resolvable).to receive(:find)
+        .with(kind: :product, source: 255)
+        .and_return([])
       expect(subject.products_from_repo(255)).to be_empty
     end
   end

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -455,19 +455,19 @@ describe Registration::SwMgmt do
 
       before do
         allow(Yast::Stage).to receive(:initial).and_return(true)
-        allow(Y2Packager::Resolvable).to receive(:any?).
-          with(kind: :product, status: :removed).                                            
-          and_return(false)
-        allow(Y2Packager::Resolvable).to receive(:any?).
-          with(kind: :product, status: :installed).                                            
-          and_return(true)
+        allow(Y2Packager::Resolvable).to receive(:any?)
+          .with(kind: :product, status: :removed)
+          .and_return(false)
+        allow(Y2Packager::Resolvable).to receive(:any?)
+          .with(kind: :product, status: :installed)
+          .and_return(true)
       end
 
       it "returns the selected product if a product is selected" do
         expect(Y2Packager::Resolvable).to receive(:find).and_return(products).at_least(:once)
-        expect(Y2Packager::Resolvable).to receive(:any?).
-          with(kind: :product, status: :selected).                                            
-          and_return(true).at_least(:once)
+        expect(Y2Packager::Resolvable).to receive(:any?)
+          .with(kind: :product, status: :selected)
+          .and_return(true).at_least(:once)
 
         # the SLES product in the list is installed
         expect(subject.find_base_product.name).to eq(products[3].name)
@@ -479,11 +479,11 @@ describe Registration::SwMgmt do
         products2_hash[3]["status"] = :available
         products2 = products2_hash.map { |p| Y2Packager::Resolvable.new(p) }
 
-        # all products are not selected        
-        expect(Y2Packager::Resolvable).to receive(:any?).
-          with(kind: :product, status: :selected).                                            
-          and_return(false).at_least(:once)
-        
+        # all products are not selected
+        expect(Y2Packager::Resolvable).to receive(:any?)
+          .with(kind: :product, status: :selected)
+          .and_return(false).at_least(:once)
+
         expect(Y2Packager::Resolvable).to receive(:find).and_return(products2).at_least(:once)
         # the SLES product in the list is installed
         expect(subject.find_base_product.name).to eq(products[3].name)
@@ -500,7 +500,7 @@ describe Registration::SwMgmt do
             "flavor"          => "DVD",
             "status"          => :selected,
             "source"          => 1
-          ),          
+          ),
           Y2Packager::Resolvable.new(
             "name"            => "SLES",
             "arch"            => "x86_64",
@@ -514,14 +514,14 @@ describe Registration::SwMgmt do
         ]
 
         # All products are selected
-        expect(Y2Packager::Resolvable).to receive(:any?).
-          with(kind: :product, status: :selected).                                            
-          and_return(true).at_least(:once)
+        expect(Y2Packager::Resolvable).to receive(:any?)
+          .with(kind: :product, status: :selected)
+          .and_return(true).at_least(:once)
         # None product is installed
-        expect(Y2Packager::Resolvable).to receive(:any?).
-          with(kind: :product, status: :installed).                                            
-          and_return(false).at_least(:once)        
-        
+        expect(Y2Packager::Resolvable).to receive(:any?)
+          .with(kind: :product, status: :installed)
+          .and_return(false).at_least(:once)
+
         expect(Y2Packager::Resolvable).to receive(:find).and_return(products3).at_least(:once)
         # the selected product is ignored, the result is nil
         expect(subject.find_base_product.name).to eq(products3[1].name)

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -556,8 +556,7 @@ describe Registration::SwMgmt do
 
         expect(Y2Packager::ProductControlProduct).to receive(:selected)
           .and_return(selected)
-
-        expect(subject.find_base_product).to eq(data)
+        expect(subject.find_base_product.name).to eq(data["name"])
       end
     end
   end

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -403,7 +403,7 @@ describe Registration::SwMgmt do
 
   describe ".select_product_addons" do
     # just the sle-module-legacy product
-    let(:products) { [load_resolvable("products_legacy_installation.yml").first] }
+    let(:products) { [load_yaml_fixture("products_legacy_installation.yml").first] }
 
     it "selects remote addons matching the product resolvables" do
       available_addons = load_yaml_fixture("available_addons.yml")
@@ -427,7 +427,7 @@ describe Registration::SwMgmt do
     it "returns installed products" do
       expect(Y2Packager::Resolvable).to receive(:find).and_return(products)
       # only the SLES product in the list is installed
-      expect(subject.installed_products).to eq([products[1]])
+      expect(subject.installed_products.first["name"]).to eq(products[1].name)
     end
   end
 
@@ -447,7 +447,7 @@ describe Registration::SwMgmt do
         allow(Yast::Stage).to receive(:initial).and_return(false)
         expect(Y2Packager::Resolvable).to receive(:find).and_return(products)
         # the SLES product in the list is installed
-        expect(subject.find_base_product).to eq(products[1])
+        expect(subject.find_base_product["name"]).to eq(products[1].name)
       end
     end
 
@@ -471,7 +471,7 @@ describe Registration::SwMgmt do
           .and_return(true).at_least(:once)
 
         # the SLES product in the list is installed
-        expect(subject.find_base_product.name).to eq(products[3].name)
+        expect(subject.find_base_product["name"]).to eq(products[3].name)
       end
 
       it "returns the product from the installation medium if no product is selected" do
@@ -487,30 +487,38 @@ describe Registration::SwMgmt do
 
         expect(Y2Packager::Resolvable).to receive(:find).and_return(products2).at_least(:once)
         # the SLES product in the list is installed
-        expect(subject.find_base_product.name).to eq(products[3].name)
+        expect(subject.find_base_product["name"]).to eq(products[3].name)
       end
 
       it "ignores a selected product not marked by the `system-installation()` provides" do
         products3 = [
           Y2Packager::Resolvable.new(
-            "name"            => "foo",
-            "arch"            => "x86_64",
-            "kind"            => :product,
-            "version"         => "12.1-1.47",
-            "version_version" => "12.1",
-            "flavor"          => "DVD",
-            "status"          => :selected,
-            "source"          => 1
+            "name"             => "foo",
+            "arch"             => "x86_64",
+            "kind"             => :product,
+            "version"          => "12.1-1.47",
+            "version_version"  => "12.1",
+            "flavor"           => "DVD",
+            "status"           => :selected,
+            "display_name"     => "display_name",
+            "register_target"  => "register_target",
+            "register_release" => "register_release",
+            "product_line"     => "product_line",
+            "source"           => 1
           ),
           Y2Packager::Resolvable.new(
-            "name"            => "SLES",
-            "arch"            => "x86_64",
-            "kind"            => :product,
-            "version"         => "12.1-1.47",
-            "version_version" => "12.1",
-            "flavor"          => "DVD",
-            "status"          => :selected,
-            "source"          => 1
+            "name"             => "SLES",
+            "arch"             => "x86_64",
+            "kind"             => :product,
+            "version"          => "12.1-1.47",
+            "version_version"  => "12.1",
+            "flavor"           => "DVD",
+            "status"           => :selected,
+            "display_name"     => "display_name",
+            "register_target"  => "register_target",
+            "register_release" => "register_release",
+            "product_line"     => "product_line",
+            "source"           => 1
           )
         ]
 
@@ -525,7 +533,7 @@ describe Registration::SwMgmt do
 
         expect(Y2Packager::Resolvable).to receive(:find).and_return(products3).at_least(:once)
         # the selected product is ignored, the result is nil
-        expect(subject.find_base_product.name).to eq(products3[1].name)
+        expect(subject.find_base_product["name"]).to eq(products3[1].name)
       end
     end
 
@@ -556,7 +564,7 @@ describe Registration::SwMgmt do
 
         expect(Y2Packager::ProductControlProduct).to receive(:selected)
           .and_return(selected)
-        expect(subject.find_base_product.name).to eq(data["name"])
+        expect(subject.find_base_product["name"]).to eq(data["name"])
       end
     end
   end
@@ -709,13 +717,17 @@ describe Registration::SwMgmt do
   describe ".version_without_release" do
     let(:libzypp_product) do
       Y2Packager::Resolvable.new(
-        "name"            => "SLESS",
-        "arch"            => "x86_64",
-        "kind"            => :product,
-        "version"         => "12.1-1.47",
-        "version_version" => "12.1",
-        "flavor"          => "DVD",
-        "source"          => 1
+        "name"             => "SLESS",
+        "arch"             => "x86_64",
+        "kind"             => :product,
+        "version"          => "12.1-1.47",
+        "version_version"  => "12.1",
+        "flavor"           => "DVD",
+        "display_name"     => "display_name",
+        "register_target"  => "register_target",
+        "register_release" => "register_release",
+        "product_line"     => "product_line",
+        "source"           => 1
       )
     end
     let(:base_product) do


### PR DESCRIPTION
Replacing old `Pkg.ResolvableProperties()`and `Pkg.ResolvabeDependencies()` calls by `Y2Packager::Resolvable.any?` and `Y2Packager::Resolvable.find` in order to save memory.