### PR TITLE
Support base product renames (jsc#SLE-7101)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 14 16:30:57 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Support base product renames when upgrading using the Full
+  medium (allows upgrading from SLES11) (jsc#SLE-7101)
+- 4.2.17
+
+-------------------------------------------------------------------
 Thu Nov  7 12:18:04 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Implement upgrade for Full medium (jsc#SLE-7101)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.16
+Version:        4.2.17
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -685,6 +685,8 @@ module Registration
           p.details && p.details.product == installed_base.name
         end
 
+        log.info("Found upgrade product on the full medium: #{new_base}")
+
         new_base
       end
 


### PR DESCRIPTION
- Support base product renames when upgrading from the Full medium
- This allows correctly upgrading from SLES11, SLES12 + HPC and other renamed/changed products (see [Y2Packager::ProductUpgrade::MAPPING](https://github.com/yast/yast-yast2/blob/master/library/packages/src/lib/y2packager/product_upgrade.rb#L25))
- Tested manually
- 4.2.17

## Screenshots

Original failure when upgrading from SLES11-SP4:

![sles11_upgrade_full_medium_original](https://user-images.githubusercontent.com/907998/68877959-2e3aea80-0707-11ea-9a00-35602320821f.png)

With the fix the upgraded product is found and the SLES11-SP4 system can be upgraded to SLES15-SP2:

![sles11_upgrade_full_medium_fixed](https://user-images.githubusercontent.com/907998/68941447-31d17e80-07a6-11ea-9271-47f8bf796d9c.png)
