### PR TITLE
Online medium: Do not permit going next if no registered

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 27 15:50:10 UTC 2019 - Knut Anderssen <anderssen@suse.com>
+
+- Online medium: Do not permit going next without registering the
+  system (bsc#1155793)
+- 4.2.19
+
+-------------------------------------------------------------------
 Thu Nov 14 16:31:57 UTC 2019 - schubi@suse.de
 
 - Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.17
+Version:        4.2.19
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.18
+Version:        4.2.17
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -596,7 +596,7 @@ module Registration
       end
 
       # Convenience method for disabling / enabling the wizard next button
-      # @param [Boolean] true for disabling, false for enabling
+      # @param status [Boolean] true for disabling, false for enabling
       def disable_next(status)
         status ? Yast::Wizard.DisableNextButton : Yast::Wizard.EnableNextButton
       end

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -417,11 +417,27 @@ module Registration
               "be used to install a working system.") %
             { media_name: media_name, download_url: download_url }
         end
+
+        warning
       end
 
       # TODO: define the warning for online media
       def online_skipping_text
-        default_skipping_text
+        warning = _("This medium does not permit to skip the registration.")
+
+        # TRANSLATORS:
+        # Popup warning the user that skipping the registration is not allowed
+        # %{media_name} is the media name (e.g. SLE-15-Packages),
+        # %{download_url} is an URL link (e.g. https://download.suse.com)
+        if !media_name.empty? && # cannot be nil
+            !download_url.empty? # cannot be nil
+          warning += "\n\n" +
+            _("For installing without registering the system use the\n"\
+              "%{media_name} from %{download_url}.") %
+            { media_name: media_name, download_url: download_url }
+        end
+
+        warning
       end
 
       # UI term for the network configuration button (or empty if not needed)

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -359,6 +359,9 @@ module Registration
       # @return [String] the name or empty string if not set
       #
       def media_name
+        # FIXME: temporal force of name
+        return _("Full media") if Y2Packager::MediumType.online?
+
         ProductFeatures.GetStringFeature(
           "globals",
           "full_system_media_name"

--- a/test/base_system_registration_dialog_test.rb
+++ b/test/base_system_registration_dialog_test.rb
@@ -9,9 +9,11 @@ describe Registration::UI::BaseSystemRegistrationDialog do
   let(:reg_code) { "my-reg-code" }
   let(:custom_url) { "http://smt.example.com/" }
   let(:default_url) { SUSE::Connect::Config.new.url }
+  let(:online?) { false }
 
   before do
     allow(Yast::Packages).to receive(:ImportGPGKeys)
+    allow(Y2Packager::MediumType).to receive(:online?).and_return(online?)
   end
 
   describe ".run" do


### PR DESCRIPTION
## Problem

During installation using the online medium, it is permitted to skip the registration which currently raise an exception as being registered is mandatory.

![error_after_skip_registration](https://user-images.githubusercontent.com/7056681/69733273-02672e00-1125-11ea-9cb7-5897fea6af7c.png)

- https://trello.com/c/Qksn2hIZ/1440-5-p1-installer-registration-handling

## Solution

It has been decided to not permit going next in case of an online medium if not registered. In this case, the next button will be disabled when the skipping registration option is selected.

![Screenshot from 2019-11-27 14-53-08](https://user-images.githubusercontent.com/7056681/69733926-0d6e8e00-1126-11ea-94fd-eeb2b3eec242.png)
![Screenshot from 2019-11-27 14-53-48](https://user-images.githubusercontent.com/7056681/69733946-12334200-1126-11ea-9355-066712057361.png)
![SkipNotAllowed](https://user-images.githubusercontent.com/7056681/69739109-08620c80-112f-11ea-9650-6d8bb7680e06.png)

## Test

- Tested manually

## TODO

- Unit Tests for the new behavior is still pending.
- There is also some re-factorization needed related to the warning error reported, an probably in case of online medium it should be an error instead of a warning.
