### PR TITLE
Properly remove the old repositories during migration (bsc#1159433)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jan 10 14:16:55 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Load the old repositories before running the migration
+  so the code can properly detect the old and the new repositories
+  and remove the obsoleted services from the system (bsc#1159433)
+- 4.2.24
+
+-------------------------------------------------------------------
 Fri Dec  6 13:12:59 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Improve messages when auto upgrading unregistered system with 

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.23
+Version:        4.2.24
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/ui/offline_migration_workflow.rb
+++ b/src/lib/registration/ui/offline_migration_workflow.rb
@@ -77,7 +77,7 @@ module Registration
     private
 
       # force reloading of the old repositories so we can detect and remove the obsoleted
-      # services during migration
+      # services during migration (bsc#1159433)
       def reinit_repos
         Yast::Pkg.SourceFinishAll
         Yast::Pkg.SourceRestore

--- a/src/lib/registration/ui/offline_migration_workflow.rb
+++ b/src/lib/registration/ui/offline_migration_workflow.rb
@@ -53,6 +53,8 @@ module Registration
           return :back
         end
 
+        reinit_repos
+
         # run the main registration migration
         ui = migration_repos
 
@@ -73,6 +75,13 @@ module Registration
       end
 
     private
+
+      # force reloading of the old repositories so we can detect and remove the obsoleted
+      # services during migration
+      def reinit_repos
+        Yast::Pkg.SourceFinishAll
+        Yast::Pkg.SourceRestore
+      end
 
       def going_back
         log.info("Going back")

--- a/test/offline_migration_workflow_test.rb
+++ b/test/offline_migration_workflow_test.rb
@@ -13,6 +13,8 @@ describe Registration::UI::OfflineMigrationWorkflow do
       allow(File).to receive(:exist?)
       allow(Yast::WFM).to receive(:CallFunction)
       allow(Yast::Stage).to receive(:initial).and_return(true)
+      allow(Yast::Pkg).to receive(:SourceFinishAll)
+      allow(Yast::Pkg).to receive(:SourceRestore)
     end
 
     shared_examples "certificate cleanup" do
@@ -80,6 +82,13 @@ describe Registration::UI::OfflineMigrationWorkflow do
 
     it "runs the 'inst_migration_repos' client" do
       expect(Yast::WFM).to receive(:CallFunction).with("inst_migration_repos", anything)
+      subject.main
+    end
+
+    it "loads the libzypp repositories" do
+      expect(Yast::Pkg).to receive(:SourceFinishAll)
+      expect(Yast::Pkg).to receive(:SourceRestore)
+
       subject.main
     end
 


### PR DESCRIPTION
## The Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1159433
- The old SP1 repositories were not removed from the system when upgrading to SP2

## The Solution

- It turned out that the SCC correctly returned the obsoleted SP1 service for removal, but YaST did not find it in the system so no removal was actually done.
- The problem was a missing repository initialization, the `Pkg.ServiceAliases` returned an empty list for the current services.

## The Fix

- Just (re)load the repositories from the system, then the old services are properly detected and removed.

## Testing

- Tested manually, works fine, see the screenshot below

## Screenshots

There are no SP1 repositories displayed later:

![migration_old_repos](https://user-images.githubusercontent.com/907998/72161683-dc3dda80-33c0-11ea-9e93-c5b97905f98e.png)


*Note: There is still a problem that it offers the new SP2 repositories to remove. But that's another separate problem which will be solved in a separate PR in a different package...*