### PR TITLE
[SLE-9109] Packages online search

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 23 11:58:16 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support to perform online package searches through all the
+  available modules/extensions (jsc#SLE-9109).
+- 4.2.28
+
+-------------------------------------------------------------------
 Wed Jan 22 14:57:55 CET 2020 - schubi@suse.de
 - Using tag $os_release_version in the control.xml file
   (entry <full_system_media_name>) which will be replaced by the

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -27,8 +27,8 @@ Url:            https://github.com/yast/yast-registration
 Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  update-desktop-files
-# Yast::OSRelease.ReleaseVersionHumanReadable
-BuildRequires:  yast2 >= 4.2.56
+# Y2Packager::Product#version_version
+BuildRequires:  yast2 >= 4.2.58
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-slp >= 3.1.9
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
@@ -39,8 +39,8 @@ BuildRequires:  yast2-packager >= 4.2.37
 BuildRequires:  yast2-update >= 3.1.36
 
 
-# Yast::OSRelease.ReleaseVersionHumanReadable
-Requires:       yast2 >= 4.2.56
+# Y2Packager::Product#version_version
+Requires:       yast2 >= 4.2.58
 # "dupAllowVendorChange" option in Pkg.SetSolverFlags()
 Requires:       yast2-pkg-bindings >= 3.1.34
 # N_() method

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.27
+Version:        4.2.28
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -28,7 +28,7 @@ Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  update-desktop-files
 # Y2Packager::Product#version_version
-BuildRequires:  yast2 >= 4.2.58
+BuildRequires:  yast2 >= 4.2.59
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-slp >= 3.1.9
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
@@ -40,7 +40,7 @@ BuildRequires:  yast2-update >= 3.1.36
 
 
 # Y2Packager::Product#version_version
-Requires:       yast2 >= 4.2.58
+Requires:       yast2 >= 4.2.59
 # "dupAllowVendorChange" option in Pkg.SetSolverFlags()
 Requires:       yast2-pkg-bindings >= 3.1.34
 # N_() method

--- a/src/clients/online_search.rb
+++ b/src/clients/online_search.rb
@@ -1,0 +1,22 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "registration/clients/online_search"
+
+Registration::Clients::OnlineSearch.new.run

--- a/src/lib/registration.rb
+++ b/src/lib/registration.rb
@@ -1,0 +1,30 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+# @!macro [new] seeAbstractWidget
+#   @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FAbstractWidget:${0}
+# @!macro [new] seeCustomWidget
+#   @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FCustomWidget:${0}
+# @!macro [new] seeDialog
+#   @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FDialog:${0}
+# @!macro [new] seeTable
+#   @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FTable:${0}
+
+module Registration
+end

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -28,6 +28,9 @@ require "y2packager/resolvable"
 module Registration
   # this is a wrapper class around SUSE::Connect::Product object
   class Addon
+    extend Yast::I18n
+    include Yast::I18n
+
     # The list of addons has not been loaded
     class AddonsNotLoaded < StandardError; end
 
@@ -350,6 +353,22 @@ module Registration
     # @return [Boolean] true if a not empty EULA url is present; false otherwise
     def eula_acceptance_needed?
       !eula_url.to_s.strip.empty?
+    end
+
+    STATUS_TRANSLATIONS = {
+      registered:    N_("registered"),
+      selected:      N_("to be registered"),
+      auto_selected: N_("to be registered"),
+      available:     N_("not registered yet"),
+      unknown:       N_("unknown")
+    }.freeze
+    private_constant :STATUS_TRANSLATIONS
+
+    # Translates the status into a translated and human readable string
+    #
+    # @return [String]
+    def status_to_human
+      _(STATUS_TRANSLATIONS[status])
     end
 
     def self.dump_addons

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -356,22 +356,6 @@ module Registration
       !eula_url.to_s.strip.empty?
     end
 
-    STATUS_TRANSLATIONS = {
-      registered:    N_("registered"),
-      selected:      N_("to be registered"),
-      auto_selected: N_("to be registered"),
-      available:     N_("not registered yet"),
-      unknown:       N_("unknown")
-    }.freeze
-    private_constant :STATUS_TRANSLATIONS
-
-    # Translates the status into a translated and human readable string
-    #
-    # @return [String]
-    def status_to_human
-      _(STATUS_TRANSLATIONS[status])
-    end
-
     def self.dump_addons
       # dump the downloaded data to a file for easier debugging,
       # avoid write failures when running as an unprivileged user (rspec tests)

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -28,6 +28,9 @@ require "y2packager/resolvable"
 module Registration
   # this is a wrapper class around SUSE::Connect::Product object
   class Addon
+    # The list of addons has not been loaded
+    class AddonsNotLoaded < StandardError; end
+
     class << self
       # read the remote add-on from the registration server
       # @param registration [Registration::Registration] use this object for
@@ -40,6 +43,17 @@ module Registration
         dump_addons
 
         @cached_addons
+      end
+
+      # Find an addon using its ID
+      #
+      # @note This method needs #find_all to be call previously.
+      #
+      # @param id [Integer] Addon's ID
+      # @return [Addon,nil] The addon with the given ID or nil if it was not found
+      def find_by_id(id)
+        raise AddonsNotLoaded unless @cached_addons
+        @cached_addons.find { |a| a.id == id }
       end
 
       def reset!

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -219,6 +219,7 @@ module Registration
     # the constructor
     # @param pure_addon [SUSE::Connect::Product] a pure add-on from the registration server
     def initialize(pure_addon)
+      textdomain "registration"
       @pure_addon = pure_addon
     end
 

--- a/src/lib/registration/clients/online_search.rb
+++ b/src/lib/registration/clients/online_search.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2020] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/registration/clients/online_search.rb
+++ b/src/lib/registration/clients/online_search.rb
@@ -1,0 +1,140 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "registration/dialogs/online_search"
+require "registration/addon"
+require "registration/registration"
+require "registration/registration_ui"
+require "registration/sw_mgmt"
+require "registration/url_helpers"
+
+Yast.import "Installation"
+Yast.import "Pkg"
+Yast.import "Sequencer"
+
+module Registration
+  module Clients
+    # Online search client
+    #
+    # It offers an interface to search for packages even if they are included in
+    # modules which has not been activated yet. It is that the case, the user
+    # can select the module for registration before trying to install the package.
+    #
+    # This client will enable any needed module but package installation should
+    # be performed by the regular package manager (`sw_single` client).
+    #
+    # @see Dialogs::OnlineSearch
+    class OnlineSearch
+      include Yast::I18n
+      extend Yast::I18n
+      include Yast::Logger
+
+      def initialize
+        textdomain "registration"
+      end
+
+      # Sequence workflow aliases
+      #
+      # @see #find_addons
+      # @see #package_search
+      # @see #commit
+      def workflow_aliases
+        {
+          "find_addons"     => ->() { find_addons },
+          "search"          => ->() { search_packages },
+          "register_addons" => ->() { register_addons },
+          "select_packages" => ->() { select_packages }
+        }
+      end
+
+      # Runs the sequence
+      #
+      # This method performs these steps:
+      #
+      #   1. Find the addons
+      #   2. Search for packages (UI)
+      #   3. Register the addons
+      #   4. Select the packages for installation
+      #
+      # @return [Symbol] Sequence's result (:next or :abort)
+      def run
+        sequence = {
+          "ws_start"        => "find_addons",
+          "find_addons"     => {
+            abort: :abort,
+            next:  "search"
+          },
+          "search"          => {
+            abort: :abort,
+            next:  "register_addons"
+          },
+          "register_addons" => {
+            next:  "select_packages",
+            abort: :abort
+          },
+          "select_packages" => {
+            next:  :next,
+            abort: :abort
+          }
+        }
+
+        log.info "Starting online_search sequence"
+        Yast::Sequencer.Run(workflow_aliases, sequence)
+      end
+
+    private
+
+      def find_addons
+        ::Registration::SwMgmt.init
+        ::Registration::Addon.find_all(registration)
+        :next
+      end
+
+      # Opens the online search dialog
+      def search_packages
+        package_search_dialog.run
+      end
+
+      def register_addons
+        registration_ui = ::Registration::RegistrationUI.new(registration)
+        selected_addons = ::Registration::Addon.selected + ::Registration::Addon.auto_selected
+        return :next if selected_addons.empty?
+        registration_ui.register_addons(selected_addons, {})
+      end
+
+      def select_packages
+        package_search_dialog.selected_packages.each do |pkg|
+          Yast::Pkg.PkgInstall(pkg.name)
+        end
+        :next
+      end
+
+      def package_search_dialog
+        @package_search_dialog ||= ::Registration::Dialogs::OnlineSearch.new
+      end
+
+      def registration
+        return @registration if @registration
+        url = ::Registration::UrlHelpers.registration_url
+        @registration = ::Registration::Registration.new(url)
+      end
+    end
+  end
+end

--- a/src/lib/registration/clients/online_search.rb
+++ b/src/lib/registration/clients/online_search.rb
@@ -26,7 +26,6 @@ require "registration/sw_mgmt"
 require "registration/ui/addon_eula_dialog"
 require "registration/url_helpers"
 
-Yast.import "Installation"
 Yast.import "Pkg"
 Yast.import "Sequencer"
 

--- a/src/lib/registration/clients/online_search.rb
+++ b/src/lib/registration/clients/online_search.rb
@@ -60,7 +60,6 @@ module Registration
           "find_addons"     => ->() { find_addons },
           "search"          => ->() { search_packages },
           "display_eula"    => ->() { display_eula },
-          "register_system" => ->() { register_system },
           "register_addons" => ->() { register_addons },
           "select_packages" => ->() { select_packages }
         }
@@ -89,10 +88,6 @@ module Registration
           },
           "display_eula"    => {
             abort: :abort,
-            next:  "register_system"
-          },
-          "register_system" => {
-            abort: :abort,
             next:  "register_addons"
           },
           "register_addons" => {
@@ -120,13 +115,6 @@ module Registration
       def search_packages
         reset_selected_addons_cache!
         package_search_dialog.run
-      end
-
-      # Registers the system and the base product
-      def register_system
-        return :next if ::Registration::Registration.is_registered? || selected_addons.empty?
-        success = registration_ui.register_system_and_base_product.first
-        success ? :next : :abort
       end
 
       # display EULAs for the selected addons

--- a/src/lib/registration/clients/online_search.rb
+++ b/src/lib/registration/clients/online_search.rb
@@ -22,7 +22,6 @@ require "registration/dialogs/online_search"
 require "registration/addon"
 require "registration/registration"
 require "registration/registration_ui"
-require "registration/sw_mgmt"
 require "registration/url_helpers"
 
 Yast.import "Installation"
@@ -102,7 +101,6 @@ module Registration
     private
 
       def find_addons
-        ::Registration::SwMgmt.init
         ::Registration::Addon.find_all(registration)
         :next
       end

--- a/src/lib/registration/clients/online_search.rb
+++ b/src/lib/registration/clients/online_search.rb
@@ -22,6 +22,7 @@ require "registration/dialogs/online_search"
 require "registration/addon"
 require "registration/registration"
 require "registration/registration_ui"
+require "registration/sw_mgmt"
 require "registration/ui/addon_eula_dialog"
 require "registration/url_helpers"
 
@@ -141,6 +142,7 @@ module Registration
       end
 
       def select_packages
+        ::Registration::SwMgmt.select_addon_products
         package_search_dialog.selected_packages.each do |pkg|
           Yast::Pkg.PkgInstall(pkg.name)
         end

--- a/src/lib/registration/dialogs/online_search.rb
+++ b/src/lib/registration/dialogs/online_search.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -40,6 +40,7 @@ module Registration
 
       # @macro seeAbstractWidget
       def title
+        # TRANSLATORS: title for the dialog to search for package through all modules/extensions
         _("Online Search")
       end
 

--- a/src/lib/registration/dialogs/online_search.rb
+++ b/src/lib/registration/dialogs/online_search.rb
@@ -1,0 +1,73 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/dialog"
+require "registration/widgets/package_search"
+
+module Registration
+  module Dialogs
+    # Dialog to search for packages
+    #
+    # This dialog embeds a {Registration::Widgets::PackageSearch} returning
+    # the list of selected packages.
+    class OnlineSearch < CWM::Dialog
+      # @return [Array<RemotePackage>] Selected packages after running the dialog
+      attr_reader :selected_packages
+
+      # Constructor
+      def initialize
+        textdomain "registration"
+        @selected_packages = []
+        super
+      end
+
+      # @macro seeAbstractWidget
+      def title
+        _("Online Search")
+      end
+
+      # @macro seeAbstractWidget
+      def contents
+        VBox(package_search_widget)
+      end
+
+      # Returns the list of selected packages
+      #
+      # @return [Symbol] Dialog's result (:next or :abort)
+      #   packages. If the user aborted the dialog, it returns an empty array.
+      #
+      # @macro seeAbstractWidget
+      def run
+        ret = super
+        @selected_packages = ret == :next ? package_search_widget.selected_packages : []
+        ret
+      end
+
+    private
+
+      # Package search widget
+      #
+      # @return [Registration::Widgets::PackageSearch]
+      def package_search_widget
+        @package_search_widget ||= ::Registration::Widgets::PackageSearch.new
+      end
+    end
+  end
+end

--- a/src/lib/registration/package_search.rb
+++ b/src/lib/registration/package_search.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2020] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/src/lib/registration/package_search.rb
+++ b/src/lib/registration/package_search.rb
@@ -1,0 +1,80 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "suse/connect"
+require "registration/addon"
+require "registration/remote_package"
+
+module Registration
+  # This class implements a packages search mechanism
+  #
+  # For the time being, it uses the SCC API to search for the wanted packages.
+  #
+  # @example Search for packages containing the `yast2` text in their names
+  #   search = PackageSearch.new(text: "yast2")
+  #   search.results.first #=> #<Registration::RemotePackage @name="autoyast2", ...>
+  #
+  # @example Case sensitive search
+  class PackageSearch
+    # @return [String] Text to search for
+    attr_reader :text
+    # @return [Boolean] Whether the search is case sensitive or not
+    attr_reader :ignore_case
+
+    # Constructor
+    #
+    # @param text        [String] Text to search for
+    # @param ignore_case [Boolean] Whether the search is case sensitive or not
+    def initialize(text:, ignore_case: true)
+      @text = text
+      @ignore_case = ignore_case
+    end
+
+    # Returns search results
+    #
+    # @return [Array<RemotePackage>] Packages search result
+    def packages
+      return @results if @results
+
+      @results = find_packages(text).each_with_object([]) do |pkg, all|
+        next unless ignore_case || pkg["name"].include?(text)
+
+        remote_packages = pkg["products"].map do |product|
+          RemotePackage.new(
+            name:    pkg["name"],
+            version: pkg["version"],
+            release: pkg["release"],
+            arch:    pkg["arch"],
+            addon:   ::Registration::Addon.find_by_id(product["id"])
+          )
+        end
+        all.concat(remote_packages)
+      end
+    end
+
+  private
+
+    def find_packages(text)
+      ::FileUtils.mv("/var/run/zypp.pid", "/var/run/zypp.save") if File.exist?("/var/run/zypp.pid")
+      SUSE::Connect::PackageSearch.search(text)
+    ensure
+      ::FileUtils.mv("/var/run/zypp.save", "/var/run/zypp.pid") if File.exist?("/var/run/zypp.save")
+    end
+  end
+end

--- a/src/lib/registration/package_search.rb
+++ b/src/lib/registration/package_search.rb
@@ -50,9 +50,7 @@ module Registration
     #
     # @return [Array<RemotePackage>] Packages search result
     def packages
-      return @results if @results
-
-      @results = find_packages(text).each_with_object([]) do |pkg, all|
+      @packages ||= find_packages(text).each_with_object([]) do |pkg, all|
         next unless ignore_case || pkg["name"].include?(text)
 
         remote_packages = pkg["products"].map do |product|

--- a/src/lib/registration/package_search.rb
+++ b/src/lib/registration/package_search.rb
@@ -78,14 +78,14 @@ module Registration
     #
     # @param text    [String] Query
     # @param product [Y2Packager::Product] Base product to find the packages for.
-    # @param Array
+    # @return [Array<Hash>] Search results
     def find_packages(text, product)
       SUSE::Connect::PackageSearch.search(text, product: connect_product(product))
     end
 
     # Returns a SUSE::Connect::Zypper::Product instance to be used in the query
     #
-    # @param product [Y2Packager::Product] YaST's product representation
+    # @param yast_product [Y2Packager::Product] YaST's product representation
     # @return [SUSE::Connect::Zypper::Product]
     def connect_product(yast_product)
       SUSE::Connect::Zypper::Product.new(

--- a/src/lib/registration/remote_package.rb
+++ b/src/lib/registration/remote_package.rb
@@ -1,0 +1,72 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Registration
+  # Represents a package as seen through the SUSE::Connect API
+  #
+  # Additionally, it offers a mechanism to find out the local package (libzypp counterpart).
+  #
+  # @example Find the status
+  class RemotePackage
+    attr_reader :name, :arch, :version, :release, :addon
+
+    # @param name    [String] Package name
+    # @param arch    [String] Architecture
+    # @param version [String] Version number
+    # @param release [String] Release number
+    # @param addon   [Addon]  Addon which the package belongs to
+    def initialize(name:, arch:, version:, release:, addon:)
+      @name = name
+      @arch = arch
+      @version = version
+      @release = release
+      @addon = addon
+    end
+
+    def select!
+      @status = :selected
+    end
+
+    def selected?
+      @status == :selected
+    end
+
+    # Returns the package's status
+    #
+    # @return [Symbol] Package status (:available, :installed, etc.). :unknown
+    #   when there is no libzypp counterpart.
+    def status
+      return @status if @status
+      # TODO: Determine the correct status when the libzypp_package is not
+      # available. It might depend on whether the addon is registered/selected
+      # or not.
+      return :unknown unless libzypp_package
+      @status ||= libzypp_package.status
+    end
+
+    # @return [Y2Packager::Package,nil] Local package (libzypp) counterpart
+    def libzypp_package
+      return @libzypp_package if @libzypp_package
+      candidates = Y2Packager::Package.find(name)
+      return nil if candidates.nil?
+      # FIXME: Check the version too
+      @libzypp_package = candidates.first
+    end
+  end
+end

--- a/src/lib/registration/remote_package.rb
+++ b/src/lib/registration/remote_package.rb
@@ -39,8 +39,21 @@ module Registration
       @addon = addon
     end
 
+    def full_version
+      "#{version}-#{release}"
+    end
+
     def select!
+      @old_status = @status
       @status = :selected
+    end
+
+    def unselect!
+      @status = @old_status if selected?
+    end
+
+    def installed?
+      status == :installed
     end
 
     def selected?

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -139,7 +139,8 @@ module Registration
       # @param text [String] Text to search for
       def search_package(text)
         @search = ::Registration::PackageSearch.new(text: text)
-        Yast::Popup.Feedback(_("Searching..."), _("Searching for packages with the given name")) do
+        # TRANSLATORS: searching for packages
+        Yast::Popup.Feedback(_("Searching..."), _("Searching for packages")) do
           selected_package_names = @selected_packages.map(&:name)
           @search.packages.each do |pkg|
             pkg.select! if selected_package_names.include?(pkg.name)
@@ -205,7 +206,8 @@ module Registration
       # @param addon [Addon] Addon to ask about
       def enable_addon?(addon)
         message = format(
-          _("'%{name}' module is not enabled for this system.\nDo you want to enable it?"),
+          _("'%{name}' module/extension is not enabled for this system.\n" \
+            "Do you want to enable it?"),
           name: addon.name
         )
         Yast::Popup.YesNo(message)

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -66,7 +66,6 @@ module Registration
               60,
               VBox(
                 packages_table,
-                PushButton(Id(:toggle_package), _("Toggle package")),
                 package_details
               )
             )
@@ -76,13 +75,12 @@ module Registration
 
       # @macro seeAbstractWidget
       def handle(event)
-        if event["WidgetID"] == :search_button
+        if start_search_event?(event)
           search_package(search_form.text)
-        elsif event["WidgetID"] == :toggle_package
-          toggle_package
-        elsif event["EventReason"] == "SelectionChanged"
-          update_details
+        elsif event["WidgetID"] == "remote_packages_table"
+          handle_packages_table_event(event)
         end
+
         log.debug "Event handled #{event.inspect}"
         nil
       end
@@ -113,6 +111,27 @@ module Registration
       # @return [RemotePackageDetails] Package details widget.
       def package_details
         @package_details ||= RemotePackageDetails.new
+      end
+
+      # Handles remote packages table events
+      #
+      # @param event [Hash] Widget event to process
+      def handle_packages_table_event(event)
+        case event["EventReason"]
+        when "Activated"
+          toggle_package
+        when "SelectionChanged"
+          update_details
+        end
+      end
+
+      # Determines whether the event should start the search
+      #
+      # @param event [Hash] UI event to check
+      # @return [Boolean]
+      def start_search_event?(event)
+        event["WidgetID"] == "search_form_button" ||
+          (event["WidgetID"] == "search_form_text" && event["EventReason"] == "Activated")
       end
 
       # Performs the search and updates the packages table

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -34,7 +34,7 @@ module Registration
     # a search form ({PackageSearchForm}), a list of results ({RemotePackagesTable})
     # and the details of the selected package ({RemotePackageDetails}).
     #
-    # Additionally, it allows the user to select/unselect packages for installation.
+    # Additionally, it allows the user to select packages for installation.
     class PackageSearch < CWM::CustomWidget
       include Yast::Logger
 

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -145,8 +145,8 @@ module Registration
             pkg.select! if selected_package_names.include?(pkg.name)
           end
         end
-        update_packages_table
-        update_details unless search.packages.empty?
+        packages_table.change_items(@search.packages)
+        update_details
       end
 
       # Finds out the current package which is selected in the packages table
@@ -157,15 +157,21 @@ module Registration
         search.packages.find { |p| p.name == packages_table.value }
       end
 
+      # Selects/unselects the current package for installation
+      #
+      # It does nothing if the package is already installed.
       def toggle_package
         package = find_current_package
-        return unless package
+        return if package.nil? || package.installed?
 
         if package.selected?
           unselect_package(package)
         else
           select_package(package)
         end
+
+        packages_table.update_item(package)
+        update_details
       end
 
       # Selects the current package for installation
@@ -178,19 +184,12 @@ module Registration
         addon.selected unless addon.selected?
         package.select!
         @selected_packages << package
-        update_packages_table
       end
 
+      # Unselects the current package for installation
       def unselect_package(package)
         package.unselect!
         @selected_packages.delete(package)
-
-        update_packages_table
-      end
-
-      # Updates the packages table
-      def update_packages_table
-        packages_table.change_items(search.packages)
       end
 
       # Updates the package details widget

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -1,0 +1,197 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/custom_widget"
+require "registration/widgets/package_search_form"
+require "registration/widgets/remote_packages_table"
+require "registration/widgets/remote_package_details"
+require "registration/package_search"
+
+Yast.import "Popup"
+
+module Registration
+  module Widgets
+    # Online package search widget
+    #
+    # This widget offers a UI to search for packages using the SCC API. It features
+    # a search form ({PackageSearchForm}), a list of results ({RemotePackagesTable})
+    # and the details of the selected package ({RemotePackageDetails}).
+    #
+    # Additionally, it allows the user to select/unselect packages for installation.
+    class PackageSearch < CWM::CustomWidget
+      include Yast::Logger
+
+      # @return [Array<String>] List of selected packages
+      attr_reader :selected_packages
+
+      # @return [::Registration::PackageSearch,nil] Current search
+      attr_reader :search
+
+      # Constructor
+      def initialize
+        textdomain "registration"
+        self.handle_all_events = true
+        @selected_packages = [] # list of selected packages
+        super
+      end
+
+      # @macro seeAbstractWidget
+      def contents
+        MarginBox(
+          0.5,
+          0.5,
+          HBox(
+            VBox(
+              search_form,
+              VStretch()
+            ),
+            MinWidth(
+              60,
+              VBox(
+                packages_table,
+                PushButton(Id(:toggle_package), _("Toggle package")),
+                package_details
+              )
+            )
+          )
+        )
+      end
+
+      # @macro seeAbstractWidget
+      def handle(event)
+        if event["WidgetID"] == :search_button
+          search_package(search_form.text)
+        elsif event["WidgetID"] == :toggle_package
+          toggle_package
+        elsif event["EventReason"] == "SelectionChanged"
+          update_details
+        end
+        log.debug "Event handled #{event.inspect}"
+        nil
+      end
+
+    private
+
+      # Search form widget
+      #
+      # @return [PackageSearchForm] Search form widget instance
+      def search_form
+        @search_form ||= PackageSearchForm.new
+      end
+
+      # Packages table widget
+      #
+      # This widget is used to display the result of the search.
+      #
+      # @return [RemotePackagesTable] Packages table widget
+      def packages_table
+        @packages_table ||= RemotePackagesTable.new
+      end
+
+      # Package details widget
+      #
+      # This widget displays the details of the package which is selected in the
+      # table.
+      #
+      # @return [RemotePackageDetails] Package details widget.
+      def package_details
+        @package_details ||= RemotePackageDetails.new
+      end
+
+      # Performs the search and updates the packages table
+      #
+      # @param text [String] Text to search for
+      def search_package(text)
+        @search = ::Registration::PackageSearch.new(text: text)
+        Yast::Popup.Feedback(_("Searching..."), _("Searching for packages with the given name")) do
+          selected_package_names = @selected_packages.map(&:name)
+          @search.packages.each do |pkg|
+            pkg.select! if selected_package_names.include?(pkg.name)
+          end
+        end
+        update_packages_table
+        update_details unless search.packages.empty?
+      end
+
+      # Finds out the current package which is selected in the packages table
+      #
+      # @return [RemotePackage,nil]
+      def find_current_package
+        return unless search && packages_table.value
+        search.packages.find { |p| p.name == packages_table.value }
+      end
+
+      def toggle_package
+        package = find_current_package
+        return unless package
+
+        if package.selected?
+          unselect_package(package)
+        else
+          select_package(package)
+        end
+      end
+
+      # Selects the current package for installation
+      #
+      # If required, it selects the addon for registration.
+      def select_package(package)
+        addon = package.addon
+        return unless addon.registered? || addon.selected? || enable_addon?(addon)
+
+        addon.selected unless addon.selected?
+        package.select!
+        @selected_packages << package
+        update_packages_table
+      end
+
+      def unselect_package(package)
+        package.unselect!
+        @selected_packages.delete(package)
+
+        update_packages_table
+      end
+
+      # Updates the packages table
+      def update_packages_table
+        packages_table.change_items(search.packages)
+      end
+
+      # Updates the package details widget
+      def update_details
+        current_package = find_current_package
+        package_details.update(current_package) if current_package
+      end
+
+      # Asks the user to enable the addon
+      #
+      # It omits the question if the addon is already registered or selected for registration.
+      #
+      # @param addon [Addon] Addon to ask about
+      def enable_addon?(addon)
+        message = format(
+          _("'%{name}' module is not enabled for this system.\nDo you want to enable it?"),
+          name: addon.name
+        )
+        Yast::Popup.YesNo(message)
+      end
+    end
+  end
+end

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -181,7 +181,7 @@ module Registration
         addon = package.addon
         return unless addon.registered? || addon.selected? || enable_addon?(addon)
 
-        addon.selected unless addon.selected?
+        addon.selected unless addon.registered? || addon.selected?
         package.select!
         @selected_packages << package
       end

--- a/src/lib/registration/widgets/package_search_form.rb
+++ b/src/lib/registration/widgets/package_search_form.rb
@@ -36,9 +36,9 @@ module Registration
         Frame(
           _("Search"),
           VBox(
-            InputField(Id(:search_text), Opt(:hstretch, :notify, :immediate), _("Search Phrase")),
-            Left(CheckBox(Id(:search_ignore_case), _("Ignore Case"), true)),
-            Right(PushButton(Id(:search_button), Opt(:default), _("Search")))
+            InputField(Id("search_form_text"), Opt(:hstretch, :notify, :immediate), _("Package Name")),
+            Left(CheckBox(Id("search_form_ignore_case"), _("Ignore Case"), true)),
+            Right(PushButton(Id("search_form_button"), Opt(:default), _("Search")))
           )
         )
       end
@@ -47,14 +47,14 @@ module Registration
       #
       # @return [String]
       def text
-        Yast::UI.QueryWidget(Id(:search_text), :Value)
+        Yast::UI.QueryWidget(Id("search_form_text"), :Value)
       end
 
       # Whether the search is case sensitive or not
       #
       # @return [Boolean]
       def ignore_case
-        Yast::UI.QueryWidget(Id(:search_ignore_case), :Value)
+        Yast::UI.QueryWidget(Id("search_form_ignore_case"), :Value)
       end
     end
   end

--- a/src/lib/registration/widgets/package_search_form.rb
+++ b/src/lib/registration/widgets/package_search_form.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -34,6 +34,7 @@ module Registration
 
       def contents
         Frame(
+          # TRANSLATORS: text for labels and push buttons
           _("Search"),
           VBox(
             InputField(

--- a/src/lib/registration/widgets/package_search_form.rb
+++ b/src/lib/registration/widgets/package_search_form.rb
@@ -36,7 +36,9 @@ module Registration
         Frame(
           _("Search"),
           VBox(
-            InputField(Id("search_form_text"), Opt(:hstretch, :notify, :immediate), _("Package Name")),
+            InputField(
+              Id("search_form_text"), Opt(:hstretch, :notify, :immediate), _("Package Name")
+            ),
             Left(CheckBox(Id("search_form_ignore_case"), _("Ignore Case"), true)),
             Right(PushButton(Id("search_form_button"), Opt(:default), _("Search")))
           )

--- a/src/lib/registration/widgets/package_search_form.rb
+++ b/src/lib/registration/widgets/package_search_form.rb
@@ -1,0 +1,61 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/custom_widget"
+
+module Registration
+  module Widgets
+    # Form to perform package searches
+    #
+    # It features two fields (term and case sensitiveness) and a search button to
+    # start the query.
+    class PackageSearchForm < ::CWM::CustomWidget
+      def initialize
+        textdomain "registration"
+        super
+      end
+
+      def contents
+        Frame(
+          _("Search"),
+          VBox(
+            InputField(Id(:search_text), Opt(:hstretch, :notify, :immediate), _("Search Phrase")),
+            Left(CheckBox(Id(:search_ignore_case), _("Ignore Case"), true)),
+            Right(PushButton(Id(:search_button), Opt(:default), _("Search")))
+          )
+        )
+      end
+
+      # Returns the text in the input field
+      #
+      # @return [String]
+      def text
+        Yast::UI.QueryWidget(Id(:search_text), :Value)
+      end
+
+      # Whether the search is case sensitive or not
+      #
+      # @return [Boolean]
+      def ignore_case
+        Yast::UI.QueryWidget(Id(:search_ignore_case), :Value)
+      end
+    end
+  end
+end

--- a/src/lib/registration/widgets/remote_package_details.rb
+++ b/src/lib/registration/widgets/remote_package_details.rb
@@ -36,7 +36,10 @@ module Registration
       def update(package)
         lines = [
           format(_("<b>Name:</b> %{package_name}"), package_name: ERB::Util.h(package.name)),
-          format(_("<b>Version:</b> %{package_version}"), package_version: ERB::Util.h(package.full_version)),
+          format(
+            _("<b>Version:</b> %{package_version}"),
+            package_version: ERB::Util.h(package.full_version)
+          ),
           format(_("<b>Architecture:</b> %{package_arch}"), package_arch: ERB::Util.h(package.arch))
         ]
 

--- a/src/lib/registration/widgets/remote_package_details.rb
+++ b/src/lib/registration/widgets/remote_package_details.rb
@@ -35,7 +35,7 @@ module Registration
       # @param package [RemotePackage] Package obtained via online search
       def update(package)
         lines = [
-          format(_("<b>Name:</b> %{package_name}"), package_name: package.name),
+          format(_("<b>Name:</b> %{package_name}"), package_name: ERB::Util.h(package.name)),
           format(_("<b>Version:</b> %{package_version}"), package_version: package.full_version),
           format(_("<b>Architecture:</b> %{package_arch}"), package_arch: package.arch)
         ]
@@ -43,7 +43,7 @@ module Registration
         if package.addon
           lines << format(
             _("<b>Product:</b> %{name} (%{status})"),
-            name:   package.addon.name,
+            name:   ERB::Util.h(package.addon.name),
             status: addon_status(package.addon)
           )
         end

--- a/src/lib/registration/widgets/remote_package_details.rb
+++ b/src/lib/registration/widgets/remote_package_details.rb
@@ -1,0 +1,72 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/common_widgets"
+
+module Registration
+  module Widgets
+    # This widgets displays the details of a remote package (name, arch, etc.)
+    class RemotePackageDetails < CWM::RichText
+      # Constructor
+      def initialize
+        textdomain("registration")
+        super
+      end
+
+      # Updates the widget's content
+      #
+      # @param package [RemotePackage] Package obtained via online search
+      def update(package)
+        lines = [
+          format(_("<b>Name:</b> %{package_name}"), package_name: package.name),
+          format(_("<b>Version:</b> %{package_version}"), package_version: package.full_version),
+          format(_("<b>Architecture:</b> %{package_arch}"), package_arch: package.arch)
+        ]
+
+        if package.addon
+          lines.concat(
+            [
+              format(_("<b>Product:</b> %{name}"), name: package.addon.name),
+              format(_("<b>Product Status:</b> %{status}"), status: addon_status(package.addon))
+            ]
+          )
+        end
+
+        self.value = lines.join("<br>")
+      end
+
+    private
+
+      # Displays the status of the given addon
+      #
+      # @param addon [Addon] Addon to display the status for
+      # @return [String]
+      def addon_status(addon)
+        if addon.registered?
+          _("Registered")
+        elsif addon.selected?
+          _("To be registered")
+        else
+          _("Not registered")
+        end
+      end
+    end
+  end
+end

--- a/src/lib/registration/widgets/remote_package_details.rb
+++ b/src/lib/registration/widgets/remote_package_details.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -36,15 +36,15 @@ module Registration
       def update(package)
         lines = [
           format(_("<b>Name:</b> %{package_name}"), package_name: ERB::Util.h(package.name)),
-          format(_("<b>Version:</b> %{package_version}"), package_version: package.full_version),
-          format(_("<b>Architecture:</b> %{package_arch}"), package_arch: package.arch)
+          format(_("<b>Version:</b> %{package_version}"), package_version: ERB::Util.h(package.full_version)),
+          format(_("<b>Architecture:</b> %{package_arch}"), package_arch: ERB::Util.h(package.arch))
         ]
 
         if package.addon
           lines << format(
-            _("<b>Product:</b> %{name} (%{status})"),
+            _("<b>Module/Extension:</b> %{name} (%{status})"),
             name:   ERB::Util.h(package.addon.name),
-            status: addon_status(package.addon)
+            status: ERB::Util.h(addon_status(package.addon))
           )
         end
 
@@ -59,10 +59,13 @@ module Registration
       # @return [String]
       def addon_status(addon)
         if addon.registered?
+          # TRANSLATORS: module/extension status
           _("registered")
         elsif addon.selected?
-          _("to be registered")
+          # TRANSLATORS: module/extension status (to be registered after confirmation)
+          _("selected for registration")
         else
+          # TRANSLATORS: module/extension status
           _("not registered")
         end
       end

--- a/src/lib/registration/widgets/remote_package_details.rb
+++ b/src/lib/registration/widgets/remote_package_details.rb
@@ -41,11 +41,10 @@ module Registration
         ]
 
         if package.addon
-          lines.concat(
-            [
-              format(_("<b>Product:</b> %{name}"), name: package.addon.name),
-              format(_("<b>Product Status:</b> %{status}"), status: addon_status(package.addon))
-            ]
+          lines << format(
+            _("<b>Product:</b> %{name} (%{status})"),
+            name:   package.addon.name,
+            status: addon_status(package.addon)
           )
         end
 
@@ -60,11 +59,11 @@ module Registration
       # @return [String]
       def addon_status(addon)
         if addon.registered?
-          _("Registered")
+          _("registered")
         elsif addon.selected?
-          _("To be registered")
+          _("to be registered")
         else
-          _("Not registered")
+          _("not registered")
         end
       end
     end

--- a/src/lib/registration/widgets/remote_packages_table.rb
+++ b/src/lib/registration/widgets/remote_packages_table.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -40,7 +40,16 @@ module Registration
 
       # @macro seeTable
       def header
-        [Center(_("Status")), _("Name"), _("Product")]
+        [
+          Center(
+            # TRANSLATORS: package status (installed, selected, etc.)
+            _("Status")
+          ),
+          # TRANSLATORS: package name
+          _("Name"),
+          # TRANSLATORS: module or extension name
+          _("Module/Extension")
+        ]
       end
 
       # Returns the selected item
@@ -61,7 +70,7 @@ module Registration
 
     private
 
-      # @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FTable
+      # @see https://www.rubydoc.info/github/yast/yast-yast2/CWM%2FTable
       def format_items(items)
         items.map do |item|
           columns = [Id(item.name)] + columns_for_item(item)

--- a/src/lib/registration/widgets/remote_packages_table.rb
+++ b/src/lib/registration/widgets/remote_packages_table.rb
@@ -29,6 +29,7 @@ module Registration
       # Constructor
       def initialize
         textdomain "registration"
+        self.widget_id = "remote_packages_table"
         super
       end
 
@@ -44,7 +45,7 @@ module Registration
 
       # @macro seeTable
       def header
-        [_("Status"), _("Name"), _("Product Status"), _("Product")]
+        [_("Status"), _("Name"), _("Product")]
       end
 
       # @macro seeTable
@@ -69,8 +70,7 @@ module Registration
             Id(item.name),
             package_status(item),
             item.name,
-            addon_status(item.addon),
-            item.addon.name
+            addon_column(item.addon)
           )
         end
       end
@@ -92,14 +92,13 @@ module Registration
       #
       # @param addon [Addon] Addon to display the status for
       # @return [String]
-      def addon_status(addon)
-        if addon.registered?
-          "r"
-        elsif addon.selected?
-          "+"
-        else
-          ""
-        end
+      def addon_column(addon)
+        format(
+          # TRANSLATORS: product name and status
+          _("%{product} (%{status})"),
+          product: addon.name,
+          status:  addon.status_to_human
+        )
       end
     end
   end

--- a/src/lib/registration/widgets/remote_packages_table.rb
+++ b/src/lib/registration/widgets/remote_packages_table.rb
@@ -73,7 +73,7 @@ module Registration
       #
       # @param item [RemotePackage]
       def columns_for_item(item)
-        [package_status(item), item.name, addon_column(item.addon)]
+        [package_status(item), item.name, item.addon.name]
       end
 
       # Package status indicator
@@ -88,19 +88,6 @@ module Registration
         else
           ""
         end
-      end
-
-      # Product status indicator
-      #
-      # @param addon [Addon] Addon to display the status for
-      # @return [String]
-      def addon_column(addon)
-        format(
-          # TRANSLATORS: product name and status
-          _("%{product} (%{status})"),
-          product: addon.name,
-          status:  addon.status_to_human
-        )
       end
     end
   end

--- a/src/lib/registration/widgets/remote_packages_table.rb
+++ b/src/lib/registration/widgets/remote_packages_table.rb
@@ -78,9 +78,10 @@ module Registration
       # Package status indicator
       #
       # @param package [RemotePackage] Package to display the status for
+      # @return [String]
       def package_status(package)
         if package.installed?
-          "i"
+          Yast::UI.Glyph(:CheckMark)
         elsif package.selected?
           "+"
         else

--- a/src/lib/registration/widgets/remote_packages_table.rb
+++ b/src/lib/registration/widgets/remote_packages_table.rb
@@ -33,25 +33,14 @@ module Registration
         super
       end
 
-      # @macro seeTable
-      def items
-        @items ||= []
-      end
-
       # @macro seeAbstractWidget
       def opt
-        [:notify, :immediate]
+        [:notify, :immediate, :keepSorting]
       end
 
       # @macro seeTable
       def header
-        [_("Status"), _("Name"), _("Product")]
-      end
-
-      # @macro seeTable
-      def change_items(items_list)
-        @items = items_list
-        super
+        [Center(_("Status")), _("Name"), _("Product")]
       end
 
       # Returns the selected item
@@ -61,18 +50,30 @@ module Registration
         items.find { |i| i.name == value }
       end
 
+      # Updates the information for the given package
+      #
+      # @param item [RemotePackage] Package to update
+      def update_item(item)
+        columns_for_item(item).each_with_index do |content, idx|
+          change_cell(Id(item.name), idx, content)
+        end
+      end
+
     private
 
       # @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FTable
       def format_items(items)
         items.map do |item|
-          Item(
-            Id(item.name),
-            package_status(item),
-            item.name,
-            addon_column(item.addon)
-          )
+          columns = [Id(item.name)] + columns_for_item(item)
+          Item(*columns)
         end
+      end
+
+      # Returns the content for the given item
+      #
+      # @param item [RemotePackage]
+      def columns_for_item(item)
+        [package_status(item), item.name, addon_column(item.addon)]
       end
 
       # Package status indicator

--- a/src/lib/registration/widgets/remote_packages_table.rb
+++ b/src/lib/registration/widgets/remote_packages_table.rb
@@ -1,0 +1,106 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/table"
+
+module Registration
+  module Widgets
+    # This widgets displays a list of remote packages
+    #
+    # The listing includes the related product information too.
+    class RemotePackagesTable < CWM::Table
+      # Constructor
+      def initialize
+        textdomain "registration"
+        super
+      end
+
+      # @macro seeTable
+      def items
+        @items ||= []
+      end
+
+      # @macro seeAbstractWidget
+      def opt
+        [:notify, :immediate]
+      end
+
+      # @macro seeTable
+      def header
+        [_("Status"), _("Name"), _("Product Status"), _("Product")]
+      end
+
+      # @macro seeTable
+      def change_items(items_list)
+        @items = items_list
+        super
+      end
+
+      # Returns the selected item
+      #
+      # @return [RemotePackage]
+      def selected_item
+        items.find { |i| i.name == value }
+      end
+
+    private
+
+      # @see http://www.rubydoc.info/github/yast/yast-yast2/CWM%2FTable
+      def format_items(items)
+        items.map do |item|
+          Item(
+            Id(item.name),
+            package_status(item),
+            item.name,
+            addon_status(item.addon),
+            item.addon.name
+          )
+        end
+      end
+
+      # Package status indicator
+      #
+      # @param package [RemotePackage] Package to display the status for
+      def package_status(package)
+        if package.installed?
+          "i"
+        elsif package.selected?
+          "+"
+        else
+          ""
+        end
+      end
+
+      # Product status indicator
+      #
+      # @param addon [Addon] Addon to display the status for
+      # @return [String]
+      def addon_status(addon)
+        if addon.registered?
+          "r"
+        elsif addon.selected?
+          "+"
+        else
+          ""
+        end
+      end
+    end
+  end
+end

--- a/test/addon_spec.rb
+++ b/test/addon_spec.rb
@@ -78,6 +78,36 @@ describe Registration::Addon do
     end
   end
 
+  describe "#find_by_id" do
+    before do
+      registration = double(
+        activated_products: [],
+        get_addon_list:     load_yaml_fixture("pure_addons.yml")
+      )
+      Registration::Addon.find_all(registration)
+    end
+
+    it "returns the addon witht the given ID" do
+      addon = described_class.find_by_id(1222)
+      expect(addon.identifier).to eq("sle-we")
+    end
+
+    it "returns nil if the addon does not exist" do
+      expect(described_class.find_by_id(1)).to be_nil
+    end
+
+    context "when no addons were read" do
+      before do
+        described_class.reset!
+      end
+
+      it "raises an exception" do
+        expect { described_class.find_by_id(1) }
+          .to raise_error(Registration::Addon::AddonsNotLoaded)
+      end
+    end
+  end
+
   describe ".registration_order" do
     it "returns addons sorted in the registration order" do
       addons = load_yaml_fixture("sle15_addons.yaml")

--- a/test/registration/clients/online_search_test.rb
+++ b/test/registration/clients/online_search_test.rb
@@ -36,7 +36,6 @@ describe Registration::Clients::OnlineSearch do
     let(:package) { instance_double(Registration::RemotePackage, name: "gnome-desktop") }
     let(:search_result) { :next }
     let(:registration_result) { :next }
-    let(:registered_system?) { true }
 
     before do
       allow(Registration::Addon).to receive(:find_all)
@@ -44,7 +43,6 @@ describe Registration::Clients::OnlineSearch do
       allow(Registration::RegistrationUI).to receive(:new).and_return(registration_ui)
       allow(Registration::UrlHelpers).to receive(:registration_url)
         .and_return("https://scc.suse.com") # speed up the test
-      allow(Registration::Registration).to receive(:is_registered?).and_return(registered_system?)
     end
 
     context "when an addon is selected" do
@@ -90,27 +88,6 @@ describe Registration::Clients::OnlineSearch do
           subject.run
         end
       end
-
-      context "and the system is not registered" do
-        let(:registered_system?) { false }
-
-        it "registers the system and the base product" do
-          expect(registration_ui).to receive(:register_system_and_base_product)
-            .and_return([true, double("service")])
-          subject.run
-        end
-
-        context "and the system registration fails" do
-          before do
-            allow(registration_ui).to receive(:register_system_and_base_product)
-              .and_return([false, double("service")])
-          end
-
-          it "returns :abort" do
-            expect(subject.run).to eq(:abort)
-          end
-        end
-      end
     end
 
     context "when no addons are selected" do
@@ -122,15 +99,6 @@ describe Registration::Clients::OnlineSearch do
       it "does not register any addon" do
         expect(registration_ui).to_not receive(:register_addons)
         subject.run
-      end
-
-      context "and the system is not registered" do
-        let(:registered_system?) { false }
-
-        it "registers the system and the base product" do
-          expect(registration_ui).to_not receive(:register_system_and_base_product)
-          subject.run
-        end
       end
     end
 

--- a/test/registration/clients/online_search_test.rb
+++ b/test/registration/clients/online_search_test.rb
@@ -1,0 +1,103 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../spec_helper"
+require "registration/clients/online_search"
+require "registration/remote_package"
+
+describe Registration::Clients::OnlineSearch do
+  describe "#run" do
+    let(:search_dialog) do
+      instance_double(
+        Registration::Dialogs::OnlineSearch, run: search_result, selected_packages: [package]
+      )
+    end
+
+    let(:registration_ui) do
+      instance_double(Registration::RegistrationUI, register_addons: registration_result)
+    end
+
+    let(:package) { instance_double(Registration::RemotePackage, name: "gnome-desktop") }
+    let(:search_result) { :next }
+    let(:registration_result) { :next }
+
+    before do
+      allow(Registration::SwMgmt).to receive(:init)
+      allow(Registration::Addon).to receive(:find_all)
+      allow(Registration::Dialogs::OnlineSearch).to receive(:new).and_return(search_dialog)
+      allow(Registration::RegistrationUI).to receive(:new).and_return(registration_ui)
+      allow(Registration::UrlHelpers).to receive(:registration_url)
+        .and_return("https://scc.suse.com") # speed up the test
+    end
+
+    context "when an addon is selected" do
+      let(:addon_1) { instance_double(Registration::Addon) }
+      let(:addon_2) { instance_double(Registration::Addon) }
+
+      before do
+        allow(Registration::Addon).to receive(:selected).and_return([addon_1])
+        allow(Registration::Addon).to receive(:auto_selected).and_return([addon_2])
+      end
+      it "registers the addon" do
+        expect(registration_ui).to receive(:register_addons).with([addon_1, addon_2], {})
+        subject.run
+      end
+
+      context "when the registration fails" do
+        let(:registration_result) { :abort }
+
+        it "returns :abort" do
+          expect(subject.run).to eq(:abort)
+        end
+
+        it "does not select any package" do
+          expect(Yast::Pkg).to_not receive(:PkgInstall)
+          subject.run
+        end
+      end
+    end
+
+    context "when no addons are selected" do
+      before do
+        allow(Registration::Addon).to receive(:selected).and_return([])
+        allow(Registration::Addon).to receive(:auto_selected).and_return([])
+      end
+
+      it "does not register any addon" do
+        expect(registration_ui).to_not receive(:register_addons)
+        subject.run
+      end
+    end
+
+    context "when a package is selected" do
+      it "selects the package for installation" do
+        expect(Yast::Pkg).to receive(:PkgInstall).with(package.name)
+        subject.run
+      end
+    end
+
+    context "when the user aborts the search" do
+      let(:search_result) { :abort }
+
+      it "returns :abort" do
+        expect(subject.run).to eq(:abort)
+      end
+    end
+  end
+end

--- a/test/registration/clients/online_search_test.rb
+++ b/test/registration/clients/online_search_test.rb
@@ -38,7 +38,6 @@ describe Registration::Clients::OnlineSearch do
     let(:registration_result) { :next }
 
     before do
-      allow(Registration::SwMgmt).to receive(:init)
       allow(Registration::Addon).to receive(:find_all)
       allow(Registration::Dialogs::OnlineSearch).to receive(:new).and_return(search_dialog)
       allow(Registration::RegistrationUI).to receive(:new).and_return(registration_ui)

--- a/test/registration/dialogs/online_search_test.rb
+++ b/test/registration/dialogs/online_search_test.rb
@@ -1,0 +1,61 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../spec_helper"
+require "registration/dialogs/online_search"
+require "cwm/rspec"
+
+describe Registration::Dialogs::OnlineSearch do
+  subject(:dialog) { described_class.new }
+
+  describe "#selected_packages" do
+    let(:search_widget) do
+      Registration::Widgets::PackageSearch.new
+    end
+
+    let(:package) do
+      instance_double(Registration::RemotePackage, name: "gnome-desktop")
+    end
+
+    before do
+      allow(Registration::Widgets::PackageSearch).to receive(:new)
+        .and_return(search_widget)
+      allow(search_widget).to receive(:selected_packages).and_return([package])
+      allow(subject).to receive(:cwm_show).and_return(result)
+    end
+
+    context "when the user aborts the search" do
+      let(:result) { :abort }
+
+      it "returns an empty array" do
+        subject.run
+        expect(subject.selected_packages).to eq([])
+      end
+    end
+
+    context "when the user selects some packages for installation" do
+      let(:result) { :next }
+
+      it "returns the selected packages" do
+        subject.run
+        expect(subject.selected_packages).to eq([package])
+      end
+    end
+  end
+end

--- a/test/registration/package_search_test.rb
+++ b/test/registration/package_search_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2019] SUSE LLC
+# Copyright (c) [2020] SUSE LLC
 #
 # All Rights Reserved.
 #

--- a/test/registration/package_search_test.rb
+++ b/test/registration/package_search_test.rb
@@ -1,0 +1,123 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "registration/package_search"
+
+describe Registration::PackageSearch do
+  subject(:search) { described_class.new(text: text) }
+
+  let(:text) { "connect" }
+
+  let(:pkg1) do
+    {
+      "id"       => 19418603,
+      "name"     => "container-suseconnect",
+      "arch"     => "x86_64",
+      "version"  => "2.1.0",
+      "release"  => "4.6.1",
+      "products" => [
+        {
+          "id"           => 1963,
+          "name"         => "Containers Module",
+          "identifier"   => "sle-module-containers/15.2/x86_64",
+          "type"         => "module",
+          "free"         => true,
+          "edition"      => "15 SP2",
+          "architecture" => "x86_64"
+        }
+      ]
+    }
+  end
+
+  let(:pkg2) do
+    {
+      "id"       => 19756638,
+      "name"     => "SUSEConnect",
+      "arch"     => "x86_64",
+      "version"  => "0.3.23",
+      "release"  => "1.6",
+      "products" => [
+        {
+          "id"           => 1946,
+          "name"         => "Basesystem Module",
+          "identifier"   => "sle-module-basesystem/15.2/x86_64",
+          "type"         => "module",
+          "free"         => true,
+          "edition"      => "15 SP2",
+          "architecture" => "x86_64"
+        }
+      ]
+    }
+  end
+
+  let(:basesystem) do
+    instance_double(Registration::Addon)
+  end
+
+  describe "#results" do
+    let(:packages) { [pkg1, pkg2] }
+
+    before do
+      allow(SUSE::Connect::PackageSearch).to receive(:search)
+        .with(text).and_return(packages)
+      allow(Registration::Addon).to receive(:find_by_id)
+        .with(1946).and_return(basesystem)
+      allow(Registration::Addon).to receive(:find_by_id)
+        .with(1963).and_return(nil)
+    end
+
+    it "returns packages from SCC containing the given text in their names" do
+      expect(subject.packages).to contain_exactly(
+        an_object_having_attributes(
+          name:    "container-suseconnect",
+          version: "2.1.0",
+          release: "4.6.1",
+          arch:    "x86_64",
+          addon:   nil
+        ),
+        an_object_having_attributes(
+          name:    "SUSEConnect",
+          version: "0.3.23",
+          release: "1.6",
+          arch:    "x86_64",
+          addon:   basesystem
+        )
+      )
+    end
+
+    context "when the search is case sensitive" do
+      subject(:search) { described_class.new(text: text, ignore_case: false) }
+
+      let(:text) { "Connect" }
+
+      it "filters out package which do not match" do
+        expect(subject.packages).to contain_exactly(
+          an_object_having_attributes(
+            name:    "SUSEConnect",
+            version: "0.3.23",
+            release: "1.6",
+            arch:    "x86_64",
+            addon:   basesystem
+          )
+        )
+      end
+    end
+  end
+end

--- a/test/registration/remote_package_test.rb
+++ b/test/registration/remote_package_test.rb
@@ -1,0 +1,50 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../spec_helper"
+require "registration/remote_package"
+require "registration/addon"
+
+describe Registration::RemotePackage do
+  subject(:package) do
+    described_class.new(
+      name: "foobar", arch: :x86_64, version: "1.0", release: "1", addon: nil
+    )
+  end
+
+  describe "#status" do
+    let(:libzypp_package) { instance_double(Y2Packager::Package, status: :available) }
+
+    before do
+      allow(package).to receive(:libzypp_package).and_return(libzypp_package)
+    end
+
+    it "returns the libzypp counterpart status" do
+      expect(package.status).to eq(:available)
+    end
+
+    context "when there is no libzypp counterpart" do
+      let(:libzypp_package) { nil }
+
+      it "returns :unknown" do
+        expect(package.status).to eq(:unknown)
+      end
+    end
+  end
+end

--- a/test/registration/widgets/package_search_form_test.rb
+++ b/test/registration/widgets/package_search_form_test.rb
@@ -23,5 +23,29 @@ require "registration/widgets/package_search_form"
 require "cwm/rspec"
 
 describe Registration::Widgets::PackageSearchForm do
+  include Yast::UIShortcuts
+
   include_examples "CWM::CustomWidget"
+
+  describe "#text" do
+    before do
+      allow(Yast::UI).to receive(:QueryWidget)
+        .with(Id("search_form_text"), :Value).and_return("foo")
+    end
+
+    it "returns the content of the text widget" do
+      expect(subject.text).to eq("foo")
+    end
+  end
+
+  describe "#ignore_case" do
+    before do
+      allow(Yast::UI).to receive(:QueryWidget)
+        .with(Id("search_form_ignore_case"), :Value).and_return(true)
+    end
+
+    it "returns the content of the text widget" do
+      expect(subject.ignore_case).to eq(true)
+    end
+  end
 end

--- a/test/registration/widgets/package_search_form_test.rb
+++ b/test/registration/widgets/package_search_form_test.rb
@@ -1,0 +1,27 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../spec_helper"
+require "registration/widgets/package_search_form"
+
+require "cwm/rspec"
+
+describe Registration::Widgets::PackageSearchForm do
+  include_examples "CWM::CustomWidget"
+end

--- a/test/registration/widgets/package_search_test.rb
+++ b/test/registration/widgets/package_search_test.rb
@@ -1,0 +1,123 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../spec_helper"
+require "registration/widgets/package_search"
+
+require "cwm/rspec"
+
+describe Registration::Widgets::PackageSearch do
+  include_examples "CWM::CustomWidget"
+
+  let(:packages_table) do
+    instance_double(
+      Registration::Widgets::RemotePackagesTable, value: package.name, change_items: nil
+    )
+  end
+
+  let(:package) do
+    instance_double(
+      Registration::RemotePackage, name: "gnome-desktop", addon: addon,
+      selected?: false, select!: nil
+    )
+  end
+
+  let(:addon) do
+    instance_double(
+      Registration::Addon, name: "desktop", registered?: false, selected?: false, selected: nil
+    )
+  end
+
+  let(:search) do
+    instance_double(Registration::PackageSearch, packages: [package])
+  end
+
+  before do
+    allow(Registration::Widgets::RemotePackagesTable).to receive(:new)
+      .and_return(packages_table)
+    allow(subject).to receive(:search).and_return(search)
+  end
+
+  describe "#handle" do
+    context "when a package is selected" do
+      let(:event) { { "WidgetID" => :toggle_package } }
+
+      context "and the addon is already registered" do
+        before do
+          allow(addon).to receive(:registered?).and_return(true)
+        end
+
+        it "adds the package to the list of packages to install" do
+          subject.handle(event)
+          expect(subject.selected_packages).to eq([package])
+        end
+      end
+
+      context "when the addon is not registered" do
+        before do
+          allow(Yast::Popup).to receive(:YesNo).and_return(register?)
+        end
+
+        context "but the user accepts to register the addon" do
+          let(:register?) { true }
+
+          it "adds the package to the list of packages to install" do
+            subject.handle(event)
+            expect(subject.selected_packages).to eq([package])
+          end
+
+          it "selects the addon for registration" do
+            expect(addon).to receive(:selected)
+            subject.handle(event)
+          end
+        end
+
+        context "and the user refuses to register the addon" do
+          let(:register?) { false }
+
+          it "does not add the package to the list of packages to install" do
+            subject.handle(event)
+            expect(subject.selected_packages).to eq([])
+          end
+
+          it "does not select the addon for registration" do
+            expect(addon).to_not receive(:selected)
+            subject.handle(event)
+          end
+        end
+      end
+
+      context "when the addon is selected for registration" do
+        before do
+          allow(addon).to receive(:selected?).and_return(true)
+        end
+
+        it "does not ask about registering the addon" do
+          expect(Yast::Popup).to_not receive(:YesNo)
+          subject.handle(event)
+        end
+
+        it "adds the package to the list of packages to install" do
+          subject.handle(event)
+          expect(subject.selected_packages).to eq([package])
+        end
+      end
+    end
+  end
+end

--- a/test/registration/widgets/package_search_test.rb
+++ b/test/registration/widgets/package_search_test.rb
@@ -28,7 +28,7 @@ describe Registration::Widgets::PackageSearch do
   let(:packages_table) do
     instance_double(
       Registration::Widgets::RemotePackagesTable, value: package.name, change_items: nil,
-      selected_item: package
+      update_item: nil, selected_item: package
     )
   end
 
@@ -39,9 +39,11 @@ describe Registration::Widgets::PackageSearch do
   let(:package) do
     instance_double(
       Registration::RemotePackage, name: "gnome-desktop", addon: addon,
-      selected?: false, select!: nil
+      selected?: false, select!: nil, installed?: installed?
     )
   end
+
+  let(:installed?) { false }
 
   let(:addon) do
     instance_double(
@@ -150,6 +152,26 @@ describe Registration::Widgets::PackageSearch do
           subject.handle(event)
           expect(subject.selected_packages).to eq([package])
         end
+      end
+
+      it "updates the table and the package details" do
+        expect(packages_table).to receive(:update_item).with(package)
+        expect(package_details).to receive(:update).with(package)
+        subject.handle(event)
+      end
+    end
+
+    context "when an already installed package is selected for installation" do
+      let(:event) { { "WidgetID" => "remote_packages_table", "EventReason" => "Activated" } }
+      let(:installed?) { true }
+
+      before do
+        allow(addon).to receive(:registered?).and_return(true)
+      end
+
+      it "does not select the package" do
+        subject.handle(event)
+        expect(subject.selected_packages).to be_empty
       end
     end
 

--- a/test/registration/widgets/remote_package_details_test.rb
+++ b/test/registration/widgets/remote_package_details_test.rb
@@ -1,0 +1,51 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../spec_helper"
+require "registration/widgets/remote_package_details"
+require "registration/package_search"
+require "registration/remote_package"
+require "cwm/rspec"
+
+describe Registration::Widgets::RemotePackageDetails do
+  include_examples "CWM::RichText"
+
+  describe "#update" do
+    let(:package) do
+      instance_double(
+        Registration::RemotePackage,
+        name: "yast2", full_version: "4.2.49-1.1", arch: "x86_64", addon: addon
+      )
+    end
+
+    let(:addon) do
+      instance_double(
+        Registration::Addon, name: "Basesystem Module", registered?: true
+      )
+    end
+
+    it "displays the result details" do
+      expect(subject).to receive(:value=)
+        .with("<b>Name:</b> yast2<br><b>Version:</b> 4.2.49-1.1<br>" \
+              "<b>Architecture:</b> x86_64<br><b>Product:</b> Basesystem Module<br>" \
+              "<b>Product Status:</b> Registered")
+      subject.update(package)
+    end
+  end
+end

--- a/test/registration/widgets/remote_package_details_test.rb
+++ b/test/registration/widgets/remote_package_details_test.rb
@@ -42,9 +42,10 @@ describe Registration::Widgets::RemotePackageDetails do
 
     it "displays the result details" do
       expect(subject).to receive(:value=)
-        .with("<b>Name:</b> yast2<br><b>Version:</b> 4.2.49-1.1<br>" \
-              "<b>Architecture:</b> x86_64<br><b>Product:</b> Basesystem Module<br>" \
-              "<b>Product Status:</b> Registered")
+        .with("<b>Name:</b> yast2<br>" \
+              "<b>Version:</b> 4.2.49-1.1<br>" \
+              "<b>Architecture:</b> x86_64<br>" \
+              "<b>Product:</b> Basesystem Module (registered)")
       subject.update(package)
     end
   end

--- a/test/registration/widgets/remote_package_details_test.rb
+++ b/test/registration/widgets/remote_package_details_test.rb
@@ -45,7 +45,7 @@ describe Registration::Widgets::RemotePackageDetails do
         .with("<b>Name:</b> yast2<br>" \
               "<b>Version:</b> 4.2.49-1.1<br>" \
               "<b>Architecture:</b> x86_64<br>" \
-              "<b>Product:</b> Basesystem Module (registered)")
+              "<b>Module/Extension:</b> Basesystem Module (registered)")
       subject.update(package)
     end
   end

--- a/test/registration/widgets/remote_packages_table_test.rb
+++ b/test/registration/widgets/remote_packages_table_test.rb
@@ -23,5 +23,7 @@ require "registration/widgets/remote_packages_table"
 require "cwm/rspec"
 
 describe Registration::Widgets::RemotePackagesTable do
-  include_examples "CWM::Table"
+  # the test for the #header method included in CWM::Table
+  # does not apply
+  include_examples "CWM::AbstractWidget"
 end

--- a/test/registration/widgets/remote_packages_table_test.rb
+++ b/test/registration/widgets/remote_packages_table_test.rb
@@ -1,0 +1,27 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../spec_helper"
+require "registration/widgets/remote_packages_table"
+
+require "cwm/rspec"
+
+describe Registration::Widgets::RemotePackagesTable do
+  include_examples "CWM::Table"
+end


### PR DESCRIPTION
This PR is an initial implementation of [the online search feature SLE 9109](https://jira.suse.com/browse/SLE-9109). It is rather incomplete, but it is already able to search for packages and register modules as needed.

![online-search-enable-module](https://user-images.githubusercontent.com/15836/72726236-bf9f6080-3b7f-11ea-871f-defb53ead350.png)
*Selecting a package from an unregistered module for installation*

![online-search-module-details](https://user-images.githubusercontent.com/15836/72726240-c037f700-3b7f-11ea-8822-e7e319bab89d.png)
*Displaying package details (including version and module where it belongs to)*

![online-search-menu-option](https://user-images.githubusercontent.com/15836/72726237-bf9f6080-3b7f-11ea-9d48-68328834c9c8.png)
*The menu option to start the online search*

## Todo

- [x] Register the base system
- [x] Do not initialize the sw management when called from the packager
- [ ] Install the packages when called as a standalone client
- [ ] Display dependencies when asking about enabling a module
- [x] Refresh module details after selecting a package for installation
- [x] Keep table order after selecting a package

