### PR TITLE
Fix scc auto

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 14 15:04:15 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- fix crash in autoyast registration (bsc#1160909)
+- 4.2.25
+
+-------------------------------------------------------------------
 Fri Jan 10 14:16:55 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Load the old repositories before running the migration

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.24
+Version:        4.2.25
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/clients/scc_auto.rb
+++ b/src/lib/registration/clients/scc_auto.rb
@@ -130,7 +130,7 @@ module Registration
 
         # special handling for the online installation medium,
         # we need to evaluate the base products defined in the control.xml
-        if Y2Packager::MediumType.online?
+        if Yast::Stage.initial && Y2Packager::MediumType.online?
           return false unless online_medium_config
         end
 
@@ -335,10 +335,10 @@ module Registration
       # register the addons specified in the profile
       def register_addons
         # set the option for installing the updates for addons
-        options = Registration::Storage::InstallationOptions.instance
+        options = ::Registration::Storage::InstallationOptions.instance
         options.install_updates = @config.install_updates
 
-        ay_addons_handler = Registration::AutoyastAddons.new(@config.addons, registration)
+        ay_addons_handler = ::Registration::AutoyastAddons.new(@config.addons, registration)
         ay_addons_handler.select
         ay_addons_handler.register
 

--- a/test/registration/clients/scc_auto_test.rb
+++ b/test/registration/clients/scc_auto_test.rb
@@ -101,6 +101,28 @@ describe Registration::Clients::SCCAuto do
       subject.write
     end
 
+    it "registers previously registered base system and addons" do
+      allow(Yast::Mode).to receive(:update).and_return(false)
+      subject.import(
+        "do_registration" => true,
+        "addons" => [{
+          "name" => "sle-module-basesystem",
+          "version" => "15.2",
+          "arch"    => "x86_64"
+        }]
+      )
+
+      allow(subject).to receive(:registration_ui).and_return(
+        double(register_system_and_base_product: true, disable_update_repos: true)
+      )
+
+      addon = double.as_null_object
+      expect(Registration::AutoyastAddons).to receive(:new).and_return(addon)
+      expect(addon).to receive(:register)
+
+      subject.write
+    end
+
     context "in autoupgrade mode" do
       before do
         allow(Yast::Mode).to receive(:update).and_return(true)

--- a/test/registration/clients/scc_auto_test.rb
+++ b/test/registration/clients/scc_auto_test.rb
@@ -105,8 +105,8 @@ describe Registration::Clients::SCCAuto do
       allow(Yast::Mode).to receive(:update).and_return(false)
       subject.import(
         "do_registration" => true,
-        "addons" => [{
-          "name" => "sle-module-basesystem",
+        "addons"          => [{
+          "name"    => "sle-module-basesystem",
           "version" => "15.2",
           "arch"    => "x86_64"
         }]


### PR DESCRIPTION
*(Description copied from https://github.com/yast/yast-registration/pull/469 :wink:)*

Reported as https://bugzilla.suse.com/show_bug.cgi?id=1160909

Looking at the code, it's obvious that `Registration` was used instead of `::Registration`.