### PR TITLE
Fix crash in AutoYaST when connecting to SCC (bsc#1160909)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 14 16:01:27 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed crash in AutoYaST when connecting to SCC (bsc#1160909)
+- 4.2.25
+
+-------------------------------------------------------------------
 Fri Jan 10 14:16:55 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Load the old repositories before running the migration

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.24
+Version:        4.2.25
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/clients/scc_auto.rb
+++ b/src/lib/registration/clients/scc_auto.rb
@@ -324,9 +324,8 @@ module Registration
 
       def register_base_product
         handle_product_service do
-          options = ::Registration::Storage::InstallationOptions.instance
-          options.email = @config.email
-          options.reg_code = @config.reg_code
+          options_instance.email = @config.email
+          options_instance.reg_code = @config.reg_code
 
           registration_ui.register_system_and_base_product
         end
@@ -335,8 +334,7 @@ module Registration
       # register the addons specified in the profile
       def register_addons
         # set the option for installing the updates for addons
-        options = Registration::Storage::InstallationOptions.instance
-        options.install_updates = @config.install_updates
+        options_instance.install_updates = @config.install_updates
 
         ay_addons_handler = Registration::AutoyastAddons.new(@config.addons, registration)
         ay_addons_handler.select
@@ -344,6 +342,11 @@ module Registration
 
         # select the new products to install
         ::Registration::SwMgmt.select_addon_products
+      end
+
+      # Singleton instance of Registration::Storage::InstallationOptions
+      def options_instance
+        ::Registration::Storage::InstallationOptions.instance
       end
 
       # was the system already registered?


### PR DESCRIPTION
Reported as https://bugzilla.suse.com/show_bug.cgi?id=1160909

Looking at the code, it's obvious that `Registration` was used instead of `::Registration`.