### PR TITLE
AY: Providing a "retry" button if a request timed out.

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 15 12:44:24 CET 2020 - schubi@suse.de
+
+- AY: Providing a "retry" button if a request timed out.
+  (bsc#1159277)
+- 4.2.26
+
+-------------------------------------------------------------------
 Tue Jan 14 15:04:15 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - fix crash in autoyast registration (bsc#1160909)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.25
+Version:        4.2.26
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -80,9 +80,7 @@ module Registration
       rescue Timeout::Error => e
         # Error popup
         log.error "Timeout error: #{e.message}"
-        # FIXME: to not break existing translation, this typo should be fixed
-        # later after SP2: time -> timed
-        retry if report_error_and_retry?(message_prefix + _("Connection time out."),
+        retry if report_error_and_retry?(message_prefix + _("Connection timed out."),
           _("Make sure that the registration server is reachable and\n" \
             "the connection is reliable."))
 
@@ -158,7 +156,8 @@ module Registration
     end
 
     def self.details_error(msg, error_message, retry_button: false)
-      if Yast::Mode.auto
+      if Yast::Mode.auto && !retry_button
+        # AY mode and no retry button available
         report_error(msg, error_message)
       else
         buttons =

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -159,15 +159,16 @@ module Registration
       if Yast::Mode.auto && !retry_button
         # AY mode and no retry button available
         report_error(msg, error_message)
-      else
-        buttons =
-          if retry_button
-            { retry: Yast::Label.RetryButton, cancel: Yast::Label.CancelButton }
-          else
-            :ok
-          end
-        Yast2::Popup.show(msg, details: error_message, headline: :error, buttons: buttons)
+        return
       end
+
+      buttons =
+        if retry_button
+          { retry: Yast::Label.RetryButton, cancel: Yast::Label.CancelButton }
+        else
+          :ok
+        end
+      Yast2::Popup.show(msg, details: error_message, headline: :error, buttons: buttons)
     end
 
     def self.report_error_and_retry?(msg, details_message)

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -52,7 +52,11 @@ module Registration
       )
 
       log.info "Announcing system with distro_target: #{distro_target}"
-      login, password = SUSE::Connect::YaST.announce_system(settings, distro_target)
+      login = ""
+      password = ""
+      ConnectHelpers.catch_registration_errors do
+        login, password = SUSE::Connect::YaST.announce_system(settings, distro_target)
+      end
       log.info "Global SCC credentials (username): #{login}"
 
       # write the global credentials
@@ -210,7 +214,10 @@ module Registration
 
       log.info "Reading available updates for product: #{product["name"]}"
       remote_product = SwMgmt.remote_product(product)
-      updates = SUSE::Connect::YaST.list_installer_updates(remote_product, connect_params)
+      updates = []
+      ConnectHelpers.catch_registration_errors do
+        updates = SUSE::Connect::YaST.list_installer_updates(remote_product, connect_params)
+      end
 
       log.info "Updates for '#{product["name"]}' are available at '#{updates}'"
       updates

--- a/test/connect_helpers_spec.rb
+++ b/test/connect_helpers_spec.rb
@@ -59,13 +59,10 @@ describe Registration::ConnectHelpers do
 
       context "and in AutoYaST mode" do
         let(:autoinst?) { true }
-
-        it "reports an error with details on timeout" do
-          expect(subject).to receive(:wrap_text).with("Details: #{details}", screen_width - 4)
-            .and_return("Details wrapped text")
-          expect(Yast::Report).to receive(:Error).with(
-            "Registration: " + _("Connection time out.") + "\n\nDetails wrapped text"
-          )
+        it "shows an error dialog with a retry and details button" do
+          expect(Yast2::Popup).to receive(:show)
+          # A retry should be provided. So no "common" AY error report.
+          expect(Yast::Report).not_to receive(:Error)
 
           helpers.catch_registration_errors(message_prefix: "Registration: ") do
             raise Timeout::Error
@@ -76,7 +73,7 @@ describe Registration::ConnectHelpers do
       context "and in a common installation" do
         it "shows an error dialog with a retry and details button" do
           expect(helpers).to receive(:report_error_and_retry?)
-            .with("Registration: " + _("Connection time out."), details)
+            .with("Registration: " + _("Connection timed out."), details)
 
           helpers.catch_registration_errors(message_prefix: "Registration: ") do
             raise Timeout::Error
@@ -85,7 +82,7 @@ describe Registration::ConnectHelpers do
 
         it "retries the given block if selected by the user" do
           expect(helpers).to receive(:report_error_and_retry?).twice
-            .with("Registration: " + _("Connection time out."), details).and_return(true, false)
+            .with("Registration: " + _("Connection timed out."), details).and_return(true, false)
 
           helpers.catch_registration_errors(message_prefix: "Registration: ") do
             raise Timeout::Error

--- a/test/migration_repos_workflow_spec.rb
+++ b/test/migration_repos_workflow_spec.rb
@@ -205,7 +205,7 @@ describe Registration::UI::MigrationReposWorkflow do
           .and_return([load_yaml_fixture("products_legacy_installation.yml")[1]])
         expect_any_instance_of(Registration::RegistrationUI).to receive(:migration_products)
           .and_return([])
-        expect(Yast::Report).to receive(:Error)
+        expect(Yast::Report).to receive(:Error).at_least(:once)
 
         expect(subject.run).to eq(:abort)
       end


### PR DESCRIPTION
**Problem**
If registration is needed while an AutoYaST installation the installation will be broken if there is
network is not available or it is not stable.

**Solution**
Telling the user that there is a problem with the network and giving him a chance to retry the
connection in order to go on with the installation.