### PR TITLE
Using tag  in the control.xml file

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 22 14:57:55 CET 2020 - schubi@suse.de
+- Using tag $os_release_version in the control.xml file
+  (entry <full_system_media_name>) which will be replaced by the
+  value of VERSION in /etc/os-release. (improvement for fate#325834)
+- 4.2.27
+
+-------------------------------------------------------------------
 Wed Jan 15 12:44:24 CET 2020 - schubi@suse.de
 
 - AY: Providing a "retry" button if a request timed out.

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -40,7 +40,7 @@ BuildRequires:  yast2-update >= 3.1.36
 
 
 # Yast::OSReleaseClass.ReleaseVersionHumanReadable
-dRequires:      yast2 >= 4.2.56
+Requires:       yast2 >= 4.2.56
 # "dupAllowVendorChange" option in Pkg.SetSolverFlags()
 Requires:       yast2-pkg-bindings >= 3.1.34
 # N_() method

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.26
+Version:        4.2.27
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only
@@ -27,8 +27,8 @@ Url:            https://github.com/yast/yast-registration
 Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  update-desktop-files
-# Y2Packager::ProductControlProduct
-BuildRequires:  yast2 >= 4.2.22
+# Yast::OSReleaseClass.ReleaseVersionHumanReadable
+BuildRequires:  yast2 >= 4.2.56
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-slp >= 3.1.9
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
@@ -38,8 +38,9 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake) >= 0.2.5
 BuildRequires:  yast2-packager >= 4.2.37
 BuildRequires:  yast2-update >= 3.1.36
 
-# Y2Packager::ProductControlProduct
-Requires:       yast2 >= 4.2.22
+
+# Yast::OSReleaseClass.ReleaseVersionHumanReadable
+dRequires:      yast2 >= 4.2.56
 # "dupAllowVendorChange" option in Pkg.SetSolverFlags()
 Requires:       yast2-pkg-bindings >= 3.1.34
 # N_() method

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -27,7 +27,7 @@ Url:            https://github.com/yast/yast-registration
 Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  update-desktop-files
-# Yast::OSReleaseClass.ReleaseVersionHumanReadable
+# Yast::OSRelease.ReleaseVersionHumanReadable
 BuildRequires:  yast2 >= 4.2.56
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-slp >= 3.1.9
@@ -39,7 +39,7 @@ BuildRequires:  yast2-packager >= 4.2.37
 BuildRequires:  yast2-update >= 3.1.36
 
 
-# Yast::OSReleaseClass.ReleaseVersionHumanReadable
+# Yast::OSRelease.ReleaseVersionHumanReadable
 Requires:       yast2 >= 4.2.56
 # "dupAllowVendorChange" option in Pkg.SetSolverFlags()
 Requires:       yast2-pkg-bindings >= 3.1.34

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -35,7 +35,7 @@ module Registration
       Yast.import "Report"
       Yast.import "ProductFeatures"
       Yast.import "Stage"
-      Yast.import "OSReleaseClass"
+      Yast.import "OSRelease"
 
       WIDGETS = {
         register_scc:      [:email, :reg_code],

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -35,6 +35,7 @@ module Registration
       Yast.import "Report"
       Yast.import "ProductFeatures"
       Yast.import "Stage"
+      Yast.import "OSReleaseClass"
 
       WIDGETS = {
         register_scc:      [:email, :reg_code],
@@ -359,14 +360,18 @@ module Registration
 
       #
       # Read the full media name from the product control file
+      # Substituting $os_release_version pattern with the release
+      # of the current system.
       #
       # @return [String] the name or empty string if not set
       #
       def media_name
-        ProductFeatures.GetStringFeature(
+        name = ProductFeatures.GetStringFeature(
           "globals",
           "full_system_media_name"
         )
+        name.gsub(/\$os_release_version\b/,
+          Yast::OSRelease.ReleaseVersionHumanReadable)
       end
 
       #

--- a/test/base_system_registration_dialog_test.rb
+++ b/test/base_system_registration_dialog_test.rb
@@ -200,9 +200,10 @@ describe Registration::UI::BaseSystemRegistrationDialog do
           " is defined in control.xml" do
             before do
               allow(Yast::ProductFeatures).to receive(:GetStringFeature)
-                .with("globals", "full_system_media_name").and_return("SLE-15-SP2-Full")
+                .with("globals", "full_system_media_name").and_return("SLE-$os_release_version-Full")
               allow(Yast::ProductFeatures).to receive(:GetStringFeature)
                 .with("globals", "full_system_download_url").and_return("https://download.suse.com")
+              allow(Yast::OSRelease).to receive(:ReleaseVersionHumanReadable).and_return("15-SP2")
             end
 
             it "reports the media name and the download url to the user" do

--- a/test/base_system_registration_dialog_test.rb
+++ b/test/base_system_registration_dialog_test.rb
@@ -200,7 +200,8 @@ describe Registration::UI::BaseSystemRegistrationDialog do
           " is defined in control.xml" do
             before do
               allow(Yast::ProductFeatures).to receive(:GetStringFeature)
-                .with("globals", "full_system_media_name").and_return("SLE-$os_release_version-Full")
+                .with("globals", "full_system_media_name")
+                .and_return("SLE-$os_release_version-Full")
               allow(Yast::ProductFeatures).to receive(:GetStringFeature)
                 .with("globals", "full_system_download_url").and_return("https://download.suse.com")
               allow(Yast::OSRelease).to receive(:ReleaseVersionHumanReadable).and_return("15-SP2")


### PR DESCRIPTION
Using tag $os_release_version in the control.xml file which will be replaced by the entry VERSION in /etc/os-release.
(improvement for fate#325834)