### PR TITLE
Several improvements to the online search feature

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,20 @@
 -------------------------------------------------------------------
+Tue Jan 28 16:19:45 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Improves the online search mechanism (jsc#SLE-9109):
+  - Do not crash when a package does not belong to an addon.
+  - Display dependencies when enabling a module/extension.
+  - Handle multiple packages with the same name properly.
+  - Show an error when a package cannot be selected for
+    installation.
+  - After selecting a package, unselect the addon if it is not
+    needed anymore.
+  - Forces a minimal number of characters before performing the
+    search.
+  - Removes the 'Back' button.
+- 4.2.29
+
+-------------------------------------------------------------------
 Thu Jan 23 11:58:16 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support to perform online package searches through all the

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.28
+Version:        4.2.29
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/addon.rb
+++ b/src/lib/registration/addon.rb
@@ -356,6 +356,17 @@ module Registration
       !eula_url.to_s.strip.empty?
     end
 
+    # Returns all the dependencies
+    #
+    # Includes all dependencies in a recursive way.
+    #
+    # @return [Array<Addon>]
+    def dependencies
+      return [] if depends_on.nil?
+
+      [depends_on] + depends_on.dependencies
+    end
+
     def self.dump_addons
       # dump the downloaded data to a file for easier debugging,
       # avoid write failures when running as an unprivileged user (rspec tests)

--- a/src/lib/registration/clients/online_search.rb
+++ b/src/lib/registration/clients/online_search.rb
@@ -18,6 +18,7 @@
 # find current contact information at www.suse.com.
 
 require "yast"
+require "yast2/popup"
 require "registration/dialogs/online_search"
 require "registration/addon"
 require "registration/registration"
@@ -131,7 +132,7 @@ module Registration
       def select_packages
         ::Registration::SwMgmt.select_addon_products
         package_search_dialog.selected_packages.each do |pkg|
-          Yast::Pkg.PkgInstall(pkg.name)
+          pkg_install_error_message(pkg.name) unless Yast::Pkg.PkgInstall(pkg.name)
         end
         :next
       end
@@ -158,6 +159,17 @@ module Registration
 
       def reset_selected_addons_cache!
         @selected_addons = nil
+      end
+
+      def pkg_install_error_message(name)
+        Yast2::Popup.show(
+          format(
+            # TRANSLATORS: 'name' is the package's name
+            _("Package %{name} could not be selected for installation."),
+            name: name
+          ),
+          headline: :error
+        )
       end
     end
   end

--- a/src/lib/registration/dialogs/online_search.rb
+++ b/src/lib/registration/dialogs/online_search.rb
@@ -61,6 +61,11 @@ module Registration
         ret
       end
 
+      # @macro seeDialog
+      def back_button
+        ""
+      end
+
     private
 
       # Package search widget

--- a/src/lib/registration/package_search.rb
+++ b/src/lib/registration/package_search.rb
@@ -59,6 +59,7 @@ module Registration
 
         remote_packages = pkg["products"].map do |product|
           RemotePackage.new(
+            id:      pkg["id"],
             name:    pkg["name"],
             version: pkg["version"],
             release: pkg["release"],

--- a/src/lib/registration/remote_package.rb
+++ b/src/lib/registration/remote_package.rb
@@ -24,20 +24,24 @@ module Registration
   #
   # @example Find the status
   class RemotePackage
-    attr_reader :name, :arch, :version, :release, :addon
+    attr_reader :id, :name, :arch, :version, :release, :addon
 
+    # @param id      [Integer] Package ID
     # @param name    [String] Package name
     # @param arch    [String] Architecture
     # @param version [String] Version number
     # @param release [String] Release number
     # @param addon   [Addon]  Addon which the package belongs to
-    def initialize(name:, arch:, version:, release:, addon:)
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(id:, name:, arch:, version:, release:, addon:)
+      @id = id
       @name = name
       @arch = arch
       @version = version
       @release = release
       @addon = addon
     end
+    # rubocop:enable Metrics/ParameterLists
 
     def full_version
       "#{version}-#{release}"

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -143,9 +143,9 @@ module Registration
         @search = ::Registration::PackageSearch.new(text: text)
         # TRANSLATORS: searching for packages
         Yast::Popup.Feedback(_("Searching..."), _("Searching for packages")) do
-          selected_package_names = selected_packages.map(&:name)
+          selected_package_ids = selected_packages.map(&:id)
           @search.packages.each do |pkg|
-            pkg.select! if selected_package_names.include?(pkg.name)
+            pkg.select! if selected_package_ids.include?(pkg.id)
           end
         end
         packages_table.change_items(@search.packages)
@@ -157,7 +157,8 @@ module Registration
       # @return [RemotePackage,nil]
       def find_current_package
         return unless search && packages_table.value
-        search.packages.find { |p| p.name == packages_table.value }
+        selected_id = packages_table.value
+        search.packages.find { |p| p.id == selected_id }
       end
 
       # Selects/unselects the current package for installation

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -267,6 +267,7 @@ module Registration
           )
           description << Yast::HTML.List(unselected_deps.map(&:name))
         end
+        # TRANSLATORS: 'it' and 'them' refers to the modules/extensions to enable
         question = n_(
           "Do you want to enable it?", "Do you want to enable them?", unselected_deps.size + 1
         )

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -194,7 +194,7 @@ module Registration
       #
       # If not needed, unselects the corresponding addon
       #
-      # @parm package [RemotePackage] Package to unselect
+      # @param package [RemotePackage] Package to unselect
       #
       # @see #unselect_addon
       # @see #unselect_package!

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -23,6 +23,7 @@ require "registration/widgets/package_search_form"
 require "registration/widgets/remote_packages_table"
 require "registration/widgets/remote_package_details"
 require "registration/package_search"
+require "yast2/popup"
 
 Yast.import "Popup"
 
@@ -138,6 +139,7 @@ module Registration
       #
       # @param text [String] Text to search for
       def search_package(text)
+        return unless valid_search_text?(text)
         @search = ::Registration::PackageSearch.new(text: text)
         # TRANSLATORS: searching for packages
         Yast::Popup.Feedback(_("Searching..."), _("Searching for packages")) do
@@ -226,6 +228,23 @@ module Registration
           name: addon.name
         )
         Yast::Popup.YesNo(message)
+      end
+
+      MINIMAL_SEARCH_TEXT_SIZE = 2
+
+      # Determines whether the search text is valid or not
+      #
+      # @param text [String] Text to search for
+      def valid_search_text?(text)
+        return true if text.to_s.size >= MINIMAL_SEARCH_TEXT_SIZE
+        Yast2::Popup.show(
+          format(
+            # TRANSLATORS: the minimal size of the text to search for package names
+            _("Please, type at least %{minimal_size} characters to search for."),
+            minimal_size: MINIMAL_SEARCH_TEXT_SIZE
+          )
+        )
+        false
       end
 
       # Determines whether the addon is still needed

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -179,25 +179,62 @@ module Registration
 
       # Selects the current package for installation
       #
-      # If required, it selects the addon for registration.
+      # If required, it selects the corresponding addon
+      #
+      # @param package [RemotePackage] Package to select
       def select_package(package)
         addon = package.addon
-        # FIXME: it will crash if addon.nil?
-        return unless addon.registered? || addon.selected? || enable_addon?(addon)
+        select_addon(addon) if addon
+        set_package_as_selected(package) if addon.nil? || addon.selected? || addon.registered?
+      end
 
-        addon.selected unless addon.registered? || addon.selected?
+      # Unselects the current package for installation
+      #
+      # If not needed, unselects the corresponding addon
+      #
+      # @parm package [RemotePackage] Package to unselect
+      #
+      # @see #unselect_addon
+      # @see #unselect_package!
+      def unselect_package(package)
+        unset_package_as_selected(package)
+        unselect_addon(package.addon) if package.addon
+      end
+
+      # Selects the given addon if needed
+      #
+      # @param addon [Addon] Addon to select
+      def select_addon(addon)
+        return if addon.registered? || addon.selected? || addon.auto_selected?
+        addon.selected if enable_addon?(addon)
+      end
+
+      # Unselects the given addon if required
+      #
+      # @param addon [Addon] Addon to unselect
+      def unselect_addon(addon)
+        return if addon.registered? || needed_addon?(addon)
+        addon.unselected if disable_addon?(addon)
+      end
+
+      # Sets the package as selected
+      #
+      # Marks the package as selected and adds it to the list of selected packages.
+      #
+      # @param package [RemotePackage] Package to add
+      def set_package_as_selected(package)
         package.select!
         selected_packages << package
       end
 
-      # Unselects the current package for installation
-      def unselect_package(package)
+      # Unsets the package as selected
+      #
+      # Marks the package as not selected and removes it from the list of selected packages.
+      #
+      # @param package [RemotePackage] Package to remove
+      def unset_package_as_selected(package)
         package.unselect!
         selected_packages.delete(package)
-        addon = package.addon
-        return unless addon
-
-        addon.unselected unless needed_addon?(package.addon) || !disable_addon?(addon)
       end
 
       # Updates the package details widget

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -251,7 +251,7 @@ module Registration
       def enable_addon?(addon)
         description = Yast::HTML.Para(
           format(
-            _("The selected package is provided by the '%{name}' module/extension, " \
+            _("The selected package is provided by the '%{name}', " \
               "which is not enabled on this system yet."),
             name: addon.name
           )

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -278,7 +278,7 @@ module Registration
       # @param addon [Addon] Addon to ask about
       def disable_addon?(addon)
         message = format(
-          _("The '%{name}' module/extension is not needed anymore.\n" \
+          _("The '%{name}' is not needed anymore.\n" \
             "Do you want to unselect it?"),
           name: addon.name
         )

--- a/src/lib/registration/widgets/remote_packages_table.rb
+++ b/src/lib/registration/widgets/remote_packages_table.rb
@@ -52,19 +52,12 @@ module Registration
         ]
       end
 
-      # Returns the selected item
-      #
-      # @return [RemotePackage]
-      def selected_item
-        items.find { |i| i.name == value }
-      end
-
       # Updates the information for the given package
       #
       # @param item [RemotePackage] Package to update
       def update_item(item)
         columns_for_item(item).each_with_index do |content, idx|
-          change_cell(Id(item.name), idx, content)
+          change_cell(Id(item.id), idx, content)
         end
       end
 
@@ -73,7 +66,7 @@ module Registration
       # @see https://www.rubydoc.info/github/yast/yast-yast2/CWM%2FTable
       def format_items(items)
         items.map do |item|
-          columns = [Id(item.name)] + columns_for_item(item)
+          columns = [Id(item.id)] + columns_for_item(item)
           Item(*columns)
         end
       end

--- a/src/lib/registration/widgets/remote_packages_table.rb
+++ b/src/lib/registration/widgets/remote_packages_table.rb
@@ -82,7 +82,11 @@ module Registration
       #
       # @param item [RemotePackage]
       def columns_for_item(item)
-        [package_status(item), item.name, item.addon.name]
+        [
+          package_status(item),
+          item.name,
+          item.addon ? item.addon.name : ""
+        ]
       end
 
       # Package status indicator

--- a/src/lib/registration/widgets/remote_packages_table.rb
+++ b/src/lib/registration/widgets/remote_packages_table.rb
@@ -78,7 +78,7 @@ module Registration
         [
           package_status(item),
           item.name,
-          item.addon ? item.addon.name : ""
+          item.addon&.name.to_s
         ]
       end
 

--- a/src/lib/registration/widgets/remote_packages_table.rb
+++ b/src/lib/registration/widgets/remote_packages_table.rb
@@ -78,7 +78,7 @@ module Registration
         [
           package_status(item),
           item.name,
-          item.addon&.name.to_s
+          item.addon ? item.addon.name : ""
         ]
       end
 

--- a/test/addon_spec.rb
+++ b/test/addon_spec.rb
@@ -374,4 +374,26 @@ describe Registration::Addon do
       expect(addon.to_h).to be_a(Hash)
     end
   end
+
+  describe "#dependencies" do
+    let(:registration) do
+      instance_double(
+        Registration::Registration,
+        activated_products: load_yaml_fixture("activated_products.yml"),
+        get_addon_list:     load_yaml_fixture("pure_addons.yml")
+      )
+    end
+
+    let(:addons) do
+      Registration::Addon.find_all(registration)
+    end
+
+    subject(:addon) do
+      addons.find { |a| a.identifier == "sle-ha-geo" }
+    end
+
+    it "returns all addon dependencies" do
+      expect(addon.dependencies.map(&:identifier)).to eq(["sle-ha"])
+    end
+  end
 end

--- a/test/registration/remote_package_test.rb
+++ b/test/registration/remote_package_test.rb
@@ -24,7 +24,7 @@ require "registration/addon"
 describe Registration::RemotePackage do
   subject(:package) do
     described_class.new(
-      name: "foobar", arch: :x86_64, version: "1.0", release: "1", addon: nil
+      id: 1, name: "foobar", arch: :x86_64, version: "1.0", release: "1", addon: nil
     )
   end
 

--- a/test/registration/widgets/package_search_test.rb
+++ b/test/registration/widgets/package_search_test.rb
@@ -27,8 +27,8 @@ describe Registration::Widgets::PackageSearch do
 
   let(:packages_table) do
     instance_double(
-      Registration::Widgets::RemotePackagesTable, value: package.name, change_items: nil,
-      update_item: nil, selected_item: package
+      Registration::Widgets::RemotePackagesTable, value: package.id,
+      change_items: nil, update_item: nil
     )
   end
 
@@ -38,7 +38,7 @@ describe Registration::Widgets::PackageSearch do
 
   let(:package) do
     instance_double(
-      Registration::RemotePackage, name: "gnome-desktop", addon: addon,
+      Registration::RemotePackage, id: 1, name: "gnome-desktop", addon: addon,
       selected?: false, select!: nil, installed?: installed?
     )
   end
@@ -108,7 +108,7 @@ describe Registration::Widgets::PackageSearch do
       context "and the package is already selected" do
         let(:package) do
           instance_double(
-            Registration::RemotePackage, name: "gnome-desktop", addon: addon,
+            Registration::RemotePackage, id: 1, name: "gnome-desktop", addon: addon,
             selected?: true, unselect!: nil, installed?: false
           )
         end

--- a/test/registration/widgets/package_search_test.rb
+++ b/test/registration/widgets/package_search_test.rb
@@ -114,6 +114,7 @@ describe Registration::Widgets::PackageSearch do
         end
 
         it "unselects the package" do
+          allow(Yast2::Popup).to receive(:show).and_return(:yes)
           expect(package).to receive(:unselect!)
           subject.handle(event)
         end
@@ -129,7 +130,6 @@ describe Registration::Widgets::PackageSearch do
           end
 
           it "does not unselect the addon" do
-            expect(Yast::Popup).to_not receive(:YesNo)
             expect(addon).to_not receive(:unselected)
             subject.handle(event)
           end
@@ -137,11 +137,11 @@ describe Registration::Widgets::PackageSearch do
 
         context "and the addon is not needed anymore" do
           before do
-            allow(Yast::Popup).to receive(:YesNo).and_return(unselect?)
+            allow(Yast2::Popup).to receive(:show).and_return(unselect?)
           end
 
           context "and the user agrees to unselect it" do
-            let(:unselect?) { true }
+            let(:unselect?) { :yes }
 
             it "unselects the addon" do
               expect(addon).to receive(:unselected)
@@ -150,7 +150,7 @@ describe Registration::Widgets::PackageSearch do
           end
 
           context "and the user wants to keep the addon" do
-            let(:unselect?) { false }
+            let(:unselect?) { :no }
 
             it "does not unselect the addon" do
               expect(addon).to_not receive(:unselected)
@@ -173,7 +173,7 @@ describe Registration::Widgets::PackageSearch do
 
       context "when the addon is not registered" do
         before do
-          allow(Yast::Popup).to receive(:YesNo).and_return(register?)
+          allow(Yast2::Popup).to receive(:show).and_return(register?)
         end
 
         let(:addon) do
@@ -182,7 +182,7 @@ describe Registration::Widgets::PackageSearch do
         end
 
         context "but the user accepts to register the addon" do
-          let(:register?) { true }
+          let(:register?) { :yes }
 
           it "adds the package to the list of packages to install" do
             subject.handle(event)
@@ -196,7 +196,7 @@ describe Registration::Widgets::PackageSearch do
         end
 
         context "and the user refuses to register the addon" do
-          let(:register?) { false }
+          let(:register?) { :no }
 
           it "does not add the package to the list of packages to install" do
             subject.handle(event)
@@ -216,7 +216,7 @@ describe Registration::Widgets::PackageSearch do
         end
 
         it "does not ask about registering the addon" do
-          expect(Yast::Popup).to_not receive(:YesNo)
+          expect(Yast2::Popup).to_not receive(:show)
           subject.handle(event)
         end
 
@@ -227,6 +227,7 @@ describe Registration::Widgets::PackageSearch do
       end
 
       it "updates the table and the package details" do
+        allow(Yast2::Popup).to receive(:show)
         expect(packages_table).to receive(:update_item).with(package)
         expect(package_details).to receive(:update).with(package)
         subject.handle(event)

--- a/test/registration/widgets/package_search_test.rb
+++ b/test/registration/widgets/package_search_test.rb
@@ -66,9 +66,10 @@ describe Registration::Widgets::PackageSearch do
   describe "#handle" do
     context "when the user asks for a package" do
       let(:event) { { "WidgetID" => "search_form_button" } }
+      let(:text) { "gnome" }
 
       let(:search_form) do
-        instance_double(Registration::Widgets::PackageSearchForm, text: "gnome")
+        instance_double(Registration::Widgets::PackageSearchForm, text: text)
       end
 
       before do
@@ -79,7 +80,7 @@ describe Registration::Widgets::PackageSearch do
 
       it "searches for the package in SCC" do
         expect(Registration::PackageSearch).to receive(:new)
-          .with(text: "gnome").and_return(search)
+          .with(text: text).and_return(search)
         subject.handle(event)
       end
 
@@ -87,6 +88,16 @@ describe Registration::Widgets::PackageSearch do
         expect(packages_table).to receive(:change_items).with([package])
         expect(package_details).to receive(:update).with(package)
         subject.handle(event)
+      end
+
+      context "when the search text is not enough" do
+        let(:text) { "g" }
+
+        it "asks the user to introduce some text" do
+          expect(Yast2::Popup).to receive(:show)
+            .with(/at least/)
+          subject.handle(event)
+        end
       end
     end
 

--- a/test/registration/widgets/package_search_test.rb
+++ b/test/registration/widgets/package_search_test.rb
@@ -47,7 +47,8 @@ describe Registration::Widgets::PackageSearch do
 
   let(:addon) do
     instance_double(
-      Registration::Addon, name: "desktop", registered?: false, selected?: false, selected: nil
+      Registration::Addon, name: "desktop", registered?: false, selected?: false,
+      auto_selected?: nil, selected: nil, unselected: nil, dependencies: []
     )
   end
 
@@ -173,6 +174,11 @@ describe Registration::Widgets::PackageSearch do
       context "when the addon is not registered" do
         before do
           allow(Yast::Popup).to receive(:YesNo).and_return(register?)
+        end
+
+        let(:addon) do
+          pure_addon = load_yaml_fixture("pure_addons.yml").first
+          Registration::Addon.new(pure_addon)
         end
 
         context "but the user accepts to register the addon" do


### PR DESCRIPTION
- https://jira.suse.com/browse/SLE-9109
- https://trello.com/c/69gVjscd

## Changes

This PR introduces a few improvements to the online search feature:

- Do not crash when a package does not belong to an addon.
- Display dependencies when enabling a module/extension.
- Handle multiple packages with the same name properly.
- Show an error when a package cannot be selected for installation.
- After selecting a package, unselect the addon if it is not needed anymore.
- Forces a minimal number of characters before performing the search.
- Removes the 'Back' button.

## Screenshots

<details>
  <summary>Enabling a module/extension with no dependencies</summary>

![online-search-enable-extension](https://user-images.githubusercontent.com/15836/73285590-2bbc3d00-41ee-11ea-9896-54c4e9ddbbe3.png)
</details>

<details>
  <summary>Enabling a module/extension with dependencies</summary>

![online-search-enable-multi-extensions](https://user-images.githubusercontent.com/15836/73285859-95d4e200-41ee-11ea-9b4f-6836e9e6c2ca.png)
</details>

<details>
  <summary>Disabling a module/extension when not needed</summary>

![online-search-disable-addon](https://user-images.githubusercontent.com/15836/73287079-8f476a00-41f0-11ea-900e-9005edeafac4.png)
</details>


<details>
  <summary>Enabling a module/extension with no dependencies (Qt)</summary>

![online-search-enable-extension-qt](https://user-images.githubusercontent.com/15836/73345197-8c458b80-427b-11ea-8a93-3fd3dcdc77da.png)
</details>

<details>
  <summary>Enabling a module/extension with dependencies (Qt)</summary>

![online-search-enable-multi-extensions-qt](https://user-images.githubusercontent.com/15836/73345213-92d40300-427b-11ea-9c85-34064dfeeea5.png)
</details>