### PR TITLE
Fix the MigrationReposWorkflow test

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jan 29 14:26:12 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix random building problems (bsc#1162122).
+- 4.2.30
+
+-------------------------------------------------------------------
 Tue Jan 28 16:19:45 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Improves the online search mechanism (jsc#SLE-9109):

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.29
+Version:        4.2.30
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/test/migration_repos_workflow_spec.rb
+++ b/test/migration_repos_workflow_spec.rb
@@ -192,7 +192,7 @@ describe Registration::UI::MigrationReposWorkflow do
       end
 
       it "reports error and aborts when no installed product is found" do
-        expect(Registration::SwMgmt).to receive(:installed_products)
+        allow(Registration::SwMgmt).to receive(:installed_products)
           .and_return([])
         expect(Yast::Report).to receive(:Error)
 
@@ -201,7 +201,7 @@ describe Registration::UI::MigrationReposWorkflow do
 
       it "reports error and aborts when no migration is available" do
         # installed SLES12
-        expect(Registration::SwMgmt).to receive(:installed_products)
+        allow(Registration::SwMgmt).to receive(:installed_products)
           .and_return([load_yaml_fixture("products_legacy_installation.yml")[1]])
         expect_any_instance_of(Registration::RegistrationUI).to receive(:migration_products)
           .and_return([])


### PR DESCRIPTION
Fixes a random failure that depends on the order of tests. The changed lines are not expectations at all, but they are used to set the test scenario.