### PR TITLE
[JSE-9109] Add a package search controller

### DIFF
--- a/src/lib/registration/controllers/package_search.rb
+++ b/src/lib/registration/controllers/package_search.rb
@@ -88,10 +88,13 @@ module Registration
 
       # Selects the given addon if needed
       #
+      # If the addon is registered or selected, does nothing. If the addon
+      # was auto selected, it will be marked as selected.
+      #
       # @param addon [Addon] Addon to select
       def select_addon(addon)
-        return if addon.registered? || addon.selected? || addon.auto_selected?
-        addon.selected if enable_addon?(addon)
+        return if addon.registered? || addon.selected?
+        addon.selected if addon.auto_selected? || enable_addon?(addon)
       end
 
       # Unselects the given addon if required

--- a/src/lib/registration/controllers/package_search.rb
+++ b/src/lib/registration/controllers/package_search.rb
@@ -38,22 +38,13 @@ module Registration
         @selected_packages = []
       end
 
-      # Returns the list of the current search
-      #
-      # @return [Array<RemotePackage>] List of found packages
-      def packages
-        @search ? @search.packages : []
-      end
-
       # Performs a package search
       #
       # @param text [String] Term to search for
+      # @return [Array<Registration::RemotePackage>] List of packages
       def search(text)
         @search = ::Registration::PackageSearch.new(text: text)
-        selected_package_ids = selected_packages.map(&:id)
-        @search.packages.each do |pkg|
-          pkg.select! if selected_package_ids.include?(pkg.id)
-        end
+        @search.packages
       end
 
       # Selects/unselects the current package for installation

--- a/src/lib/registration/controllers/package_search.rb
+++ b/src/lib/registration/controllers/package_search.rb
@@ -189,8 +189,8 @@ module Registration
       # @param msg [String] Message to display at the beginning of the line
       # @param addon [Registration::Addon]
       def log_addon(msg, addon)
-        log.info "#{msg}: #{addon.inspect}, registered=#{addon.registered?}, selected=#{addon.selected?}" \
-          "auto_selected=#{addon.auto_selected?}"
+        log.info "#{msg}: #{addon.inspect}, registered=#{addon.registered?}, " \
+          "selected=#{addon.selected?}, auto_selected=#{addon.auto_selected?}"
       end
     end
   end

--- a/src/lib/registration/controllers/package_search.rb
+++ b/src/lib/registration/controllers/package_search.rb
@@ -21,11 +21,23 @@ require "yast"
 require "registration/package_search"
 
 Yast.import "Popup"
+Yast.import "HTML"
 
 module Registration
   module Controllers
     # Implements the actions and keeps the state for the package search feature
     class PackageSearch
+      include Yast::I18n
+
+      # @return [Array<RemotePackage>] List of selected packages
+      attr_reader :selected_packages
+
+      # Constructor
+      def initialize
+        textdomain "registration"
+        @selected_packages = []
+      end
+
       # Returns the list of the current search
       #
       # @return [Array<RemotePackage>] List of found packages
@@ -42,6 +54,135 @@ module Registration
         @search.packages.each do |pkg|
           pkg.select! if selected_package_ids.include?(pkg.id)
         end
+      end
+
+      # Selects/unselects the current package for installation
+      #
+      # It does nothing if the package is already installed.
+      def toggle_package(package)
+        return if package.installed?
+
+        if package.selected?
+          unselect_package(package)
+        else
+          select_package(package)
+        end
+      end
+
+    private
+
+      # Selects the current package for installation
+      #
+      # If required, it selects the corresponding addon
+      #
+      # @param package [RemotePackage] Package to select
+      def select_package(package)
+        addon = package.addon
+        select_addon(addon) if addon
+        set_package_as_selected(package) if addon.nil? || addon.selected? || addon.registered?
+      end
+
+      # Unselects the current package for installation
+      #
+      # If not needed, unselects the corresponding addon
+      #
+      # @param package [RemotePackage] Package to unselect
+      #
+      # @see #unselect_addon
+      # @see #unselect_package!
+      def unselect_package(package)
+        unset_package_as_selected(package)
+        unselect_addon(package.addon) if package.addon
+      end
+
+      # Selects the given addon if needed
+      #
+      # @param addon [Addon] Addon to select
+      def select_addon(addon)
+        return if addon.registered? || addon.selected? || addon.auto_selected?
+        addon.selected if enable_addon?(addon)
+      end
+
+      # Unselects the given addon if required
+      #
+      # @param addon [Addon] Addon to unselect
+      def unselect_addon(addon)
+        return if addon.registered? || needed_addon?(addon)
+        addon.unselected if disable_addon?(addon)
+      end
+
+      # Sets the package as selected
+      #
+      # Marks the package as selected and adds it to the list of selected packages.
+      #
+      # @param package [RemotePackage] Package to add
+      def set_package_as_selected(package)
+        package.select!
+        selected_packages << package
+      end
+
+      # Unsets the package as selected
+      #
+      # Marks the package as not selected and removes it from the list of selected packages.
+      #
+      # @param package [RemotePackage] Package to remove
+      def unset_package_as_selected(package)
+        package.unselect!
+        selected_packages.delete(package)
+      end
+
+      # Asks the user to enable the addon
+      #
+      # @param addon [Addon] Addon to ask about
+      def enable_addon?(addon)
+        description = Yast::HTML.Para(
+          format(
+            _("The selected package is provided by the '%{name}', " \
+              "which is not enabled on this system yet."),
+            name: addon.name
+          )
+        )
+
+        unselected_deps = addon.dependencies.reject { |d| d.selected? || d.registered? }
+        if !unselected_deps.empty?
+          description << Yast::HTML.Para(
+            format(
+              _("Additionally, '%{name}' depends on the following modules/extensions:"),
+              name: addon.name
+            )
+          )
+          description << Yast::HTML.List(unselected_deps.map(&:name))
+        end
+        # TRANSLATORS: 'it' and 'them' refers to the modules/extensions to enable
+        question = n_(
+          "Do you want to enable it?", "Do you want to enable them?", unselected_deps.size + 1
+        )
+        yes_no_popup(description + question)
+      end
+
+      # Asks the user to disable the addon
+      #
+      # @param addon [Addon] Addon to ask about
+      def disable_addon?(addon)
+        message = format(
+          _("The '%{name}' is not needed anymore.\n" \
+            "Do you want to unselect it?"),
+          name: addon.name
+        )
+        yes_no_popup(message)
+      end
+
+      # Determines whether the addon is still needed
+      def needed_addon?(addon)
+        selected_packages.any? { |pkg| pkg.addon == addon }
+      end
+
+      # Asks a yes/no question
+      #
+      # @return [Boolean] true if the answer is affirmative; false otherwise
+      def yes_no_popup(message)
+        ret = Yast2::Popup.show(message, richtext: true, buttons: :yes_no)
+        ret == :yes
       end
     end
   end

--- a/src/lib/registration/controllers/package_search.rb
+++ b/src/lib/registration/controllers/package_search.rb
@@ -1,0 +1,48 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "registration/package_search"
+
+Yast.import "Popup"
+
+module Registration
+  module Controllers
+    # Implements the actions and keeps the state for the package search feature
+    class PackageSearch
+      # Returns the list of the current search
+      #
+      # @return [Array<RemotePackage>] List of found packages
+      def packages
+        @search ? @search.packages : []
+      end
+
+      # Performs a package search
+      #
+      # @param text [String] Term to search for
+      def search(text)
+        @search = ::Registration::PackageSearch.new(text: text)
+        selected_package_ids = selected_packages.map(&:id)
+        @search.packages.each do |pkg|
+          pkg.select! if selected_package_ids.include?(pkg.id)
+        end
+      end
+    end
+  end
+end

--- a/src/lib/registration/controllers/package_search.rb
+++ b/src/lib/registration/controllers/package_search.rb
@@ -68,6 +68,7 @@ module Registration
       #
       # @param package [RemotePackage] Package to select
       def select_package(package)
+        log.info "Selecting package: #{package.inspect}"
         addon = package.addon
         select_addon(addon) if addon
         set_package_as_selected(package) if addon.nil? || addon.selected? || addon.registered?
@@ -82,6 +83,7 @@ module Registration
       # @see #unselect_addon
       # @see #unselect_package!
       def unselect_package(package)
+        log.info "Unselecting package: #{package.inspect}"
         unset_package_as_selected(package)
         unselect_addon(package.addon) if package.addon
       end
@@ -93,6 +95,7 @@ module Registration
       #
       # @param addon [Addon] Addon to select
       def select_addon(addon)
+        log_addon("selecting the addon", addon)
         return if addon.registered? || addon.selected?
         addon.selected if addon.auto_selected? || enable_addon?(addon)
       end
@@ -101,6 +104,7 @@ module Registration
       #
       # @param addon [Addon] Addon to unselect
       def unselect_addon(addon)
+        log_addon("unselecting the addon", addon)
         return if addon.registered? || needed_addon?(addon)
         addon.unselected if disable_addon?(addon)
       end
@@ -176,7 +180,17 @@ module Registration
       # @return [Boolean] true if the answer is affirmative; false otherwise
       def yes_no_popup(message)
         ret = Yast2::Popup.show(message, richtext: true, buttons: :yes_no)
+        log.info "yes/no pop-up. The answer is '#{ret}"
         ret == :yes
+      end
+
+      # Logs information about a given addon
+      #
+      # @param msg [String] Message to display at the beginning of the line
+      # @param addon [Registration::Addon]
+      def log_addon(msg, addon)
+        log.info "#{msg}: #{addon.inspect}, registered=#{addon.registered?}, selected=#{addon.selected?}" \
+          "auto_selected=#{addon.auto_selected?}"
       end
     end
   end

--- a/src/lib/registration/dialogs/online_search.rb
+++ b/src/lib/registration/dialogs/online_search.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "cwm/dialog"
+require "registration/controllers/package_search"
 require "registration/widgets/package_search"
 
 module Registration
@@ -57,7 +58,7 @@ module Registration
       # @macro seeAbstractWidget
       def run
         ret = super
-        @selected_packages = ret == :next ? package_search_widget.selected_packages : []
+        @selected_packages = ret == :next ? controller.selected_packages : []
         ret
       end
 
@@ -72,7 +73,14 @@ module Registration
       #
       # @return [Registration::Widgets::PackageSearch]
       def package_search_widget
-        @package_search_widget ||= ::Registration::Widgets::PackageSearch.new
+        @package_search_widget ||= ::Registration::Widgets::PackageSearch.new(controller)
+      end
+
+      # Package search controller
+      #
+      # @return [Registration::Controllers::PackageSearch]
+      def controller
+        @controller ||= ::Registration::Controllers::PackageSearch.new
       end
     end
   end

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -19,7 +19,6 @@
 
 require "yast"
 require "cwm/custom_widget"
-require "registration/controllers/package_search"
 require "registration/widgets/package_search_form"
 require "registration/widgets/remote_packages_table"
 require "registration/widgets/remote_package_details"
@@ -40,7 +39,9 @@ module Registration
       include Yast::Logger
 
       # Constructor
-      def initialize(controller = ::Registration::Controllers::PackageSearch.new)
+      #
+      # @param controller [Registration::Controllers::PackageSearch] Package search controller
+      def initialize(controller)
         textdomain "registration"
         self.handle_all_events = true
         @controller = controller

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -158,15 +158,12 @@ module Registration
       #
       # @return [RemotePackage,nil]
       def find_current_package
-        return unless packages_table.value
         packages.find { |p| p.id == packages_table.value }
       end
 
       # Selects/unselects the current package for installation
       def toggle_package
         package = find_current_package
-        return if package.nil?
-
         controller.toggle_package(package)
         packages_table.update_item(package)
         update_details

--- a/test/registration/controllers/package_search_test.rb
+++ b/test/registration/controllers/package_search_test.rb
@@ -123,6 +123,32 @@ describe Registration::Controllers::PackageSearch do
           expect(subject.selected_packages).to eq([package])
         end
       end
+
+      context "when the addon is auto selected for registration" do
+        let(:addon) do
+          pure_addon = load_yaml_fixture("pure_addons.yml").first
+          Registration::Addon.new(pure_addon)
+        end
+
+        before do
+          allow(addon).to receive(:auto_selected?).and_return(true)
+        end
+
+        it "does not ask about registering the addon" do
+          expect(Yast2::Popup).to_not receive(:show)
+          subject.toggle_package(package)
+        end
+
+        it "selects the addon" do
+          expect(addon).to receive(:selected)
+          subject.toggle_package(package)
+        end
+
+        it "adds the package to the list of packages to install" do
+          subject.toggle_package(package)
+          expect(subject.selected_packages).to eq([package])
+        end
+      end
     end
 
     context "when the package is already selected for installation" do

--- a/test/registration/controllers/package_search_test.rb
+++ b/test/registration/controllers/package_search_test.rb
@@ -51,29 +51,8 @@ describe Registration::Controllers::PackageSearch do
   end
 
   describe "#search" do
-    it "updates the list of packages with results from SCC" do
-      expect { controller.search(text) }.to change { controller.packages }
-        .from([]).to([package])
-    end
-  end
-
-  describe "#packages" do
-    context "when no search has been peformed" do
-      it "returns an empty array" do
-        expect(controller.packages).to eq([])
-      end
-    end
-
-    context "when there are search results" do
-      before do
-        allow(Registration::PackageSearch).to receive(:new)
-          .and_return(search)
-        controller.search(text)
-      end
-
-      it "returns the search results" do
-        expect(controller.packages).to eq([package])
-      end
+    it "returns the list of packages from SCC" do
+      expect(controller.search(text)).to eq([package])
     end
   end
 

--- a/test/registration/controllers/package_search_test.rb
+++ b/test/registration/controllers/package_search_test.rb
@@ -76,4 +76,144 @@ describe Registration::Controllers::PackageSearch do
       end
     end
   end
+
+  describe "#toggle_package" do
+    context "when the package is not selected for installation" do
+      context "and the addon is already registered" do
+        before do
+          allow(addon).to receive(:registered?).and_return(true)
+        end
+
+        it "adds the package to the list of packages to install" do
+          subject.toggle_package(package)
+          expect(subject.selected_packages).to eq([package])
+        end
+      end
+
+      context "when the addon is not registered" do
+        before do
+          allow(Yast2::Popup).to receive(:show).and_return(register?)
+        end
+
+        let(:addon) do
+          pure_addon = load_yaml_fixture("pure_addons.yml").first
+          Registration::Addon.new(pure_addon)
+        end
+
+        context "but the user accepts to register the addon" do
+          let(:register?) { :yes }
+
+          it "adds the package to the list of packages to install" do
+            subject.toggle_package(package)
+            expect(subject.selected_packages).to eq([package])
+          end
+
+          it "selects the addon for registration" do
+            expect(addon).to receive(:selected)
+            subject.toggle_package(package)
+          end
+        end
+
+        context "and the user refuses to register the addon" do
+          let(:register?) { :no }
+
+          it "does not add the package to the list of packages to install" do
+            subject.toggle_package(package)
+            expect(subject.selected_packages).to eq([])
+          end
+
+          it "does not select the addon for registration" do
+            expect(addon).to_not receive(:selected)
+            subject.toggle_package(package)
+          end
+        end
+      end
+
+      context "when the addon is selected for registration" do
+        before do
+          allow(addon).to receive(:selected?).and_return(true)
+        end
+
+        it "does not ask about registering the addon" do
+          expect(Yast2::Popup).to_not receive(:show)
+          subject.toggle_package(package)
+        end
+
+        it "adds the package to the list of packages to install" do
+          subject.toggle_package(package)
+          expect(subject.selected_packages).to eq([package])
+        end
+      end
+    end
+
+    context "when the package is already selected for installation" do
+      context "and the package is already selected" do
+        let(:package) do
+          instance_double(
+            Registration::RemotePackage, id: 1, name: "gnome-desktop", addon: addon,
+            selected?: true, unselect!: nil, installed?: false
+          )
+        end
+
+        it "unselects the package" do
+          allow(Yast2::Popup).to receive(:show).and_return(:yes)
+          expect(package).to receive(:unselect!)
+          subject.toggle_package(package)
+        end
+
+        context "and the addon is still needed" do
+          let(:another_package) do
+            instance_double(Registration::RemotePackage, name: "eog", addon: addon)
+          end
+
+          before do
+            allow(subject).to receive(:selected_packages).and_return([package, another_package])
+          end
+
+          it "does not unselect the addon" do
+            expect(addon).to_not receive(:unselected)
+            subject.toggle_package(package)
+          end
+        end
+
+        context "and the addon is not needed anymore" do
+          before do
+            allow(Yast2::Popup).to receive(:show).and_return(unselect?)
+          end
+
+          context "and the user agrees to unselect it" do
+            let(:unselect?) { :yes }
+
+            it "unselects the addon" do
+              expect(addon).to receive(:unselected)
+              subject.toggle_package(package)
+            end
+          end
+
+          context "and the user wants to keep the addon" do
+            let(:unselect?) { :no }
+
+            it "does not unselect the addon" do
+              expect(addon).to_not receive(:unselected)
+              subject.toggle_package(package)
+            end
+          end
+        end
+      end
+    end
+
+    context "when an already installed package is selected for installation" do
+      let(:installed?) { true }
+
+      before do
+        allow(addon).to receive(:registered?).and_return(true)
+      end
+
+      it "does not select the package" do
+        subject.toggle_package(package)
+        expect(subject.selected_packages).to be_empty
+      end
+    end
+
+  end
 end

--- a/test/registration/controllers/package_search_test.rb
+++ b/test/registration/controllers/package_search_test.rb
@@ -1,0 +1,79 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../spec_helper"
+require "registration/controllers/package_search"
+
+describe Registration::Controllers::PackageSearch do
+  subject(:controller) { described_class.new }
+
+  let(:package) do
+    instance_double(
+      Registration::RemotePackage, id: 1, name: "gnome-desktop", addon: addon,
+      selected?: false, select!: nil, installed?: installed?
+    )
+  end
+
+  let(:addon) do
+    instance_double(
+      Registration::Addon, name: "desktop", registered?: false, selected?: false,
+      auto_selected?: nil, selected: nil, unselected: nil, dependencies: []
+    )
+  end
+
+  let(:search) do
+    instance_double(Registration::PackageSearch, packages: [package])
+  end
+
+  let(:installed?) { false }
+
+  let(:text) { "gnome" }
+
+  before do
+    allow(Registration::PackageSearch).to receive(:new)
+      .with(text: text).and_return(search)
+  end
+
+  describe "#search" do
+    it "updates the list of packages with results from SCC" do
+      expect { controller.search(text) }.to change { controller.packages }
+        .from([]).to([package])
+    end
+  end
+
+  describe "#packages" do
+    context "when no search has been peformed" do
+      it "returns an empty array" do
+        expect(controller.packages).to eq([])
+      end
+    end
+
+    context "when there are search results" do
+      before do
+        allow(Registration::PackageSearch).to receive(:new)
+          .and_return(search)
+        controller.search(text)
+      end
+
+      it "returns the search results" do
+        expect(controller.packages).to eq([package])
+      end
+    end
+  end
+end

--- a/test/registration/dialogs/online_search_test.rb
+++ b/test/registration/dialogs/online_search_test.rb
@@ -26,7 +26,11 @@ describe Registration::Dialogs::OnlineSearch do
 
   describe "#selected_packages" do
     let(:search_widget) do
-      Registration::Widgets::PackageSearch.new
+      Registration::Widgets::PackageSearch.new(controller)
+    end
+
+    let(:controller) do
+      Registration::Controllers::PackageSearch.new
     end
 
     let(:package) do
@@ -36,7 +40,9 @@ describe Registration::Dialogs::OnlineSearch do
     before do
       allow(Registration::Widgets::PackageSearch).to receive(:new)
         .and_return(search_widget)
-      allow(search_widget).to receive(:selected_packages).and_return([package])
+      allow(Registration::Controllers::PackageSearch).to receive(:new)
+        .and_return(controller)
+      allow(controller).to receive(:selected_packages).and_return([package])
       allow(subject).to receive(:cwm_show).and_return(result)
     end
 

--- a/test/registration/widgets/package_search_test.rb
+++ b/test/registration/widgets/package_search_test.rb
@@ -25,6 +25,12 @@ require "cwm/rspec"
 describe Registration::Widgets::PackageSearch do
   include_examples "CWM::CustomWidget"
 
+  subject { described_class.new(controller) }
+
+  let(:controller) do
+    instance_double(Registration::Controllers::PackageSearch, packages: [package], search: nil)
+  end
+
   let(:packages_table) do
     instance_double(
       Registration::Widgets::RemotePackagesTable, value: package.id,
@@ -52,16 +58,11 @@ describe Registration::Widgets::PackageSearch do
     )
   end
 
-  let(:search) do
-    instance_double(Registration::PackageSearch, packages: [package])
-  end
-
   before do
     allow(Registration::Widgets::RemotePackagesTable).to receive(:new)
       .and_return(packages_table)
     allow(Registration::Widgets::RemotePackageDetails).to receive(:new)
       .and_return(package_details)
-    allow(subject).to receive(:search).and_return(search)
   end
 
   describe "#handle" do
@@ -76,12 +77,10 @@ describe Registration::Widgets::PackageSearch do
       before do
         allow(Registration::Widgets::PackageSearchForm).to receive(:new)
           .and_return(search_form)
-        allow(Registration::PackageSearch).to receive(:new).and_return(search)
       end
 
       it "searches for the package in SCC" do
-        expect(Registration::PackageSearch).to receive(:new)
-          .with(text: text).and_return(search)
+        expect(controller).to receive(:search).with(text)
         subject.handle(event)
       end
 

--- a/test/registration/widgets/package_search_test.rb
+++ b/test/registration/widgets/package_search_test.rb
@@ -28,10 +28,7 @@ describe Registration::Widgets::PackageSearch do
   subject { described_class.new(controller) }
 
   let(:controller) do
-    instance_double(
-      Registration::Controllers::PackageSearch, packages: [package], search: nil,
-      toggle_package: nil
-    )
+    Registration::Controllers::PackageSearch.new
   end
 
   let(:packages_table) do
@@ -66,12 +63,14 @@ describe Registration::Widgets::PackageSearch do
       .and_return(packages_table)
     allow(Registration::Widgets::RemotePackageDetails).to receive(:new)
       .and_return(package_details)
+    allow(controller).to receive(:search).and_return([package])
   end
 
   describe "#handle" do
+    let(:text) { "gnome" }
+
     context "when the user asks for a package" do
       let(:event) { { "WidgetID" => "search_form_button" } }
-      let(:text) { "gnome" }
 
       let(:search_form) do
         instance_double(Registration::Widgets::PackageSearchForm, text: text)
@@ -107,6 +106,10 @@ describe Registration::Widgets::PackageSearch do
     context "when a package is selected for installation" do
       let(:event) { { "WidgetID" => "remote_packages_table", "EventReason" => "Activated" } }
 
+      before do
+        allow(subject).to receive(:packages).and_return([package])
+      end
+
       it "toggles the selected package" do
         expect(controller).to receive(:toggle_package).with(package)
         subject.handle(event)
@@ -122,6 +125,10 @@ describe Registration::Widgets::PackageSearch do
 
     context "when the user selects a different package in the table" do
       let(:event) { { "WidgetID" => "remote_packages_table", "EventReason" => "SelectionChanged" } }
+
+      before do
+        allow(subject).to receive(:packages).and_return([package])
+      end
 
       it "updates the package details" do
         expect(package_details).to receive(:update).with(package)


### PR DESCRIPTION
This PRs extracts business logic from `Widgets::PackageSearch` to a separate `Controllers::PackageSearch` class. This class will be responsible for keeping the state and implementing the actions of the package search feature.

I am keeping the same version number because (hopefully) the user will not notice any difference.