### PR TITLE
Online Search: add a summary screen

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,16 @@
 -------------------------------------------------------------------
+Wed Feb  5 14:35:00 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Improves online search mechanism UI (jsc#SLE-9109):
+  - Add a summary screen that enumerates which changes will
+    take place (addons and packages).
+  - Fix the 'Cancel' button label.
+  - Improve feedback when waiting for network I/O.
+  - Inform users about unsupported scenarios: unregistered and
+    SMT/RMT registered systems.
+- 4.2.31
+
+-------------------------------------------------------------------
 Wed Jan 29 14:26:12 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix random building problems (bsc#1162122).

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.30
+Version:        4.2.31
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/clients/online_search.rb
+++ b/src/lib/registration/clients/online_search.rb
@@ -30,6 +30,7 @@ require "registration/url_helpers"
 
 Yast.import "Pkg"
 Yast.import "Sequencer"
+Yast.import "Popup"
 
 module Registration
   module Clients
@@ -121,7 +122,10 @@ module Registration
       #
       # @return [:next]
       def find_addons
-        ::Registration::Addon.find_all(registration)
+        Yast::Popup.Feedback(_("Initializing..."), _("Fetching the list of known modules/extensions")) do
+          ::Registration::Addon.reset!
+          ::Registration::Addon.find_all(registration)
+        end
         :next
       end
 

--- a/src/lib/registration/clients/online_search.rb
+++ b/src/lib/registration/clients/online_search.rb
@@ -141,7 +141,7 @@ module Registration
       #
       # @return [:next]
       def display_summary
-        return :next if selected_addons.empty?
+        return :next if selected_packages.empty?
         ::Registration::Dialogs::OnlineSearchSummary.run(
           selected_packages, selected_addons
         )

--- a/src/lib/registration/controllers/package_search.rb
+++ b/src/lib/registration/controllers/package_search.rb
@@ -171,8 +171,10 @@ module Registration
       end
 
       # Determines whether the addon is still needed
+      #
+      # @param addon [Addon] Addon to compare with
       def needed_addon?(addon)
-        selected_packages.any? { |pkg| pkg.addon == addon }
+        selected_packages.any? { |pkg| pkg.addon && pkg.addon.id == addon.id }
       end
 
       # Asks a yes/no question

--- a/src/lib/registration/controllers/package_search.rb
+++ b/src/lib/registration/controllers/package_search.rb
@@ -126,7 +126,7 @@ module Registration
       # @param package [RemotePackage] Package to remove
       def unset_package_as_selected(package)
         package.unselect!
-        selected_packages.delete(package)
+        selected_packages.reject! { |p| p.id == package.id }
       end
 
       # Asks the user to enable the addon

--- a/src/lib/registration/dialogs/online_search.rb
+++ b/src/lib/registration/dialogs/online_search.rb
@@ -63,6 +63,11 @@ module Registration
       end
 
       # @macro seeDialog
+      def abort_button
+        Yast::Label.CancelButton
+      end
+
+      # @macro seeDialog
       def back_button
         ""
       end

--- a/src/lib/registration/dialogs/online_search_summary.rb
+++ b/src/lib/registration/dialogs/online_search_summary.rb
@@ -1,0 +1,83 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cwm/dialog"
+
+module Registration
+  module Dialogs
+    class OnlineSearchSummary < CWM::Dialog
+      include Yast::I18n
+
+      # Constructor
+      #
+      # @param packages [Array<RemotePackage>] Packages to install
+      # @param addons [Array<Addon>] Addons to register
+      def initialize(packages, addons)
+        textdomain "registration"
+        @packages = packages
+        @addons = addons
+      end
+
+      # @macro seeDialog
+      def contents
+        VBox(
+          RichText(Id(:summary), addons_text + packages_text)
+        )
+      end
+
+      # @macro seeDialog
+      def abort_button
+        Yast::Label.CancelButton
+      end
+
+      def title
+        # TRANSLATORS: title for the dialog which displays modules/extensions to
+        # install and packages to register
+        _("Changes Summary")
+      end
+
+    private
+
+      # @return [Array<RemotePackage>] Packages to install
+      attr_reader :packages
+
+      # @return [Array<Addon>] Addons to register
+      attr_reader :addons
+
+      # Returns a string that contains a list of addons to register
+      #
+      # @return [String] text containing the list of addons; an empty string
+      #   is returned if there are no addons
+      def addons_text
+        return "" if addons.empty?
+        heading = format(_("Modules/extensions to register (%{count})"), count: addons.size)
+        Yast::HTML.Heading(heading) + Yast::HTML.List(addons.map(&:name).sort)
+      end
+
+      # Returns a string that contains the list of packages to select
+      #
+      # @return [String] text containing the list of packages
+      def packages_text
+        heading = format(_("Selected packages (%{count})"), count: packages.size)
+        Yast::HTML.Heading(heading) + Yast::HTML.List(packages.map(&:name).sort)
+      end
+    end
+  end
+end

--- a/src/lib/registration/url_helpers.rb
+++ b/src/lib/registration/url_helpers.rb
@@ -84,6 +84,10 @@ module Registration
       url
     end
 
+    def self.default_registration_url?
+      [nil, SUSE::Connect::YaST::DEFAULT_URL].include?(registration_url)
+    end
+
     # @return [void]
     def self.reset_registration_url
       ::Registration::Storage::Cache.instance.reg_url = nil

--- a/src/lib/registration/widgets/package_search.rb
+++ b/src/lib/registration/widgets/package_search.rb
@@ -65,7 +65,7 @@ module Registration
             MinWidth(
               60,
               VBox(
-                packages_table,
+                MinHeight(14, packages_table),
                 package_details
               )
             )

--- a/test/registration/clients/online_search_test.rb
+++ b/test/registration/clients/online_search_test.rb
@@ -40,6 +40,7 @@ describe Registration::Clients::OnlineSearch do
     before do
       allow(Registration::Addon).to receive(:find_all)
       allow(Registration::Dialogs::OnlineSearch).to receive(:new).and_return(search_dialog)
+      allow(Registration::Dialogs::OnlineSearchSummary).to receive(:run).and_return(:next)
       allow(Registration::RegistrationUI).to receive(:new).and_return(registration_ui)
       allow(Registration::UI::AddonEulaDialog).to receive(:run).and_return(:next)
       allow(Registration::SwMgmt).to receive(:select_addon_products)

--- a/test/registration/dialogs/online_search_summary_test.rb
+++ b/test/registration/dialogs/online_search_summary_test.rb
@@ -1,0 +1,51 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../spec_helper"
+require "registration/dialogs/online_search_summary"
+require "registration/addon"
+require "registration/remote_package"
+require "cwm/rspec"
+
+describe Registration::Dialogs::OnlineSearchSummary do
+  subject { described_class.new([package], [addon]) }
+
+  include_examples "CWM::Dialog"
+
+  let(:addon) { instance_double(Registration::Addon, name: "addon1") }
+  let(:package) { instance_double(Registration::RemotePackage, name: "pkg1") }
+
+  describe "#contents" do
+    it "includes a list of addons" do
+      expect(subject.contents.to_s).to include("Modules/extensions to register (1)")
+    end
+
+    it "includes a list of packages" do
+      expect(subject.contents.to_s).to include("Selected packages (1)")
+    end
+
+    context "when the list of addons is empty" do
+      subject { described_class.new([package], []) }
+
+      it "does not include a list of addons" do
+        expect(subject.contents.to_s).to_not include("Modules")
+      end
+    end
+  end
+end

--- a/test/url_helpers_spec.rb
+++ b/test/url_helpers_spec.rb
@@ -3,6 +3,7 @@
 require_relative "spec_helper"
 
 describe "Registration::UrlHelpers" do
+
   describe ".registration_url" do
     before do
       # reset the cache before each test
@@ -209,6 +210,36 @@ describe "Registration::UrlHelpers" do
 
       it "returns nil (default URL)" do
         expect(Registration::UrlHelpers.registration_url).to be_nil
+      end
+    end
+  end
+
+  describe ".default_registration_url?" do
+    before do
+      allow(Registration::UrlHelpers).to receive(:registration_url).and_return(url)
+    end
+
+    context "when the registration_url is nil" do
+      let(:url) { nil }
+
+      it "returns true" do
+        expect(Registration::UrlHelpers.default_registration_url?).to eq(true)
+      end
+    end
+
+    context "when the registration_url is the default one" do
+      let(:url) { SUSE::Connect::YaST::DEFAULT_URL }
+
+      it "returns true" do
+        expect(Registration::UrlHelpers.default_registration_url?).to eq(true)
+      end
+    end
+
+    context "when the registration_url is not nil nor the default one" do
+      let(:url) { "https://smt.example.net" }
+
+      it "returns false" do
+        expect(Registration::UrlHelpers.default_registration_url?).to eq(false)
       end
     end
   end


### PR DESCRIPTION
This PR improves UX of the online search feature.

## Summary screen

![online-search-summary-final](https://user-images.githubusercontent.com/15836/73751732-9bcf4380-4757-11ea-8af3-3d4cb6d71e82.png)

## Unregistered messages warning

![online-search-registration-required](https://user-images.githubusercontent.com/15836/73852166-a4427f80-4826-11ea-8f9f-7baa83f71f49.png)

## SMT/RMT not supported

![online-search-smt-rmt](https://user-images.githubusercontent.com/15836/73843720-11e6af80-4817-11ea-8d27-f951e9333cb7.png)

## Another fixes

* Packages unselection
* Resets addons selection