### PR TITLE
Fix a typo in a warning message

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 17 06:51:38 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix a typo in the online search UI (jsc#SLE-9109).
+- 4.2.34
+
+-------------------------------------------------------------------
 Thu Feb  6 10:07:27 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Improves online search mechanism UI (jsc#SLE-9109):

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.33
+Version:        4.2.34
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/clients/online_search.rb
+++ b/src/lib/registration/clients/online_search.rb
@@ -250,7 +250,7 @@ module Registration
         Yast2::Popup.show(
           wrap_text(
             _("YaST requires your system to be registered in order to " \
-              "perform an online search. Alternatively, use the web" \
+              "perform an online search. Alternatively, use the web " \
               "version at 'https://scc.suse.com/packages/'.")
           ),
           headline: :error


### PR DESCRIPTION
Related to https://trello.com/c/LOMBsxPg/ it fixes a typo in one of the warning messages.