### PR TITLE
Do not catch exceptions

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 18 16:34:38 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not catch exceptions when getting the updates list from the
+  registration server (bsc#1162903)
+- 4.2.35
+
+-------------------------------------------------------------------
 Mon Feb 17 06:51:38 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix a typo in the online search UI (jsc#SLE-9109).

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.34
+Version:        4.2.35
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -215,9 +215,7 @@ module Registration
       log.info "Reading available updates for product: #{product["name"]}"
       remote_product = SwMgmt.remote_product(product)
       updates = []
-      ConnectHelpers.catch_registration_errors do
-        updates = SUSE::Connect::YaST.list_installer_updates(remote_product, connect_params)
-      end
+      updates = SUSE::Connect::YaST.list_installer_updates(remote_product, connect_params)
 
       log.info "Updates for '#{product["name"]}' are available at '#{updates}'"
       updates

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -214,7 +214,6 @@ module Registration
 
       log.info "Reading available updates for product: #{product["name"]}"
       remote_product = SwMgmt.remote_product(product)
-      updates = []
       updates = SUSE::Connect::YaST.list_installer_updates(remote_product, connect_params)
 
       log.info "Updates for '#{product["name"]}' are available at '#{updates}'"

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -259,6 +259,16 @@ describe Registration::Registration do
         expect(subject.get_updates_list).to eq(updates)
       end
     end
+
+    context "when an exception connecting to the server occurs" do
+      before do
+        allow(suse_connect).to receive(:list_installer_updates).and_raise(Timeout::Error)
+      end
+
+      it "does not catch the error" do
+        expect { subject.get_updates_list }.to raise_error(Timeout::Error)
+      end
+    end
   end
 
   describe "#synchronize_products" do

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -260,7 +260,7 @@ describe Registration::Registration do
       end
     end
 
-    context "when an exception connecting to the server occurs" do
+    context "when an exception connecting to the server takes place" do
       before do
         allow(suse_connect).to receive(:list_installer_updates).and_raise(Timeout::Error)
       end


### PR DESCRIPTION
## Problem

During an installation, YaST is able to update itself through [self-update](https://github.com/yast/yast-installation/blob/master/doc/SELF_UPDATE.md). By default, self-update uses a public server for getting the list of repositories to be used by it.

If the server is not reachable or there is some network problem, then an error is reported (this is an unexpected behavior introduced by #470).

![SelfUpdateError](https://user-images.githubusercontent.com/7056681/74780542-b517da00-5297-11ea-8c8c-a929158ddfd0.png)

Originally, we only reported errors in case of a `custom` reg_server, but it was requested to also show errors in case that `self_update` was explicitly enabled (implemented by yast/yast-installation#673). Otherwise, errors were logged.

- https://trello.com/c/5Qoy10HE/1642-5-sles15-sp2-p1-1162903-installer-is-probing-a-public-network-sccsusecom-and-is-showing-it-as-error-during-private-network-insta

## Solution

Bring back previous behavior logging the error when getting the updates list and using the default registration server without enabling self_update explicitly.

## Tests

- Tested manually in Installation and Autoinstallation (online & full medium)