### PR TITLE
Suppress feedback

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 23 14:34:05 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Hide registration feedback window when configuring network
+  (bsc#1165705)
+- 4.2.38
+
+-------------------------------------------------------------------
 Wed Mar 18 15:25:57 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Improves online search UX (bsc#1165913 and bsc#1166038):

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -27,8 +27,8 @@ Url:            https://github.com/yast/yast-registration
 Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  update-desktop-files
-# CWM::MultiStatusSelector
-BuildRequires:  yast2 >= 4.2.72
+# Popup::SuppressFeedback
+BuildRequires:  yast2 >= 4.2.76
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-slp >= 3.1.9
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
@@ -38,9 +38,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake) >= 0.2.5
 BuildRequires:  yast2-packager >= 4.2.37
 BuildRequires:  yast2-update >= 3.1.36
 
-
-# CWM::MultiStatusSelector
-Requires:       yast2 >= 4.2.72
+# Popup::SuppressFeedback
+Requires:       yast2 >= 4.2.76
 # "dupAllowVendorChange" option in Pkg.SetSolverFlags()
 Requires:       yast2-pkg-bindings >= 3.1.34
 # N_() method

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.37
+Version:        4.2.38
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/helpers.rb
+++ b/src/lib/registration/helpers.rb
@@ -41,6 +41,7 @@ module Registration
     Yast.import "Installation"
     Yast.import "Linuxrc"
     Yast.import "Mode"
+    Yast.import "Popup"
     Yast.import "Stage"
     Yast.import "Report"
     Yast.import "SlpService"
@@ -91,7 +92,11 @@ module Registration
     # run the network configuration module
     def self.run_network_configuration
       log.info "Running network configuration..."
-      Yast::WFM.call("inst_lan", [{ "skip_detection" => true }])
+      # ensure that no registration feedback is shown
+      # when running network configuration (bsc#1165705)
+      Yast::Popup.SuppressFeedback do
+        Yast::WFM.call("inst_lan", [{ "skip_detection" => true }])
+      end
     end
 
     # check if the network configuration module is present


### PR DESCRIPTION
trello: https://trello.com/c/AyGNkbK3/1708-3-sle15-sp2-p1-1165705-not-able-to-setup-network-when-connection-with-registration-server-failed-a-blocking-popupfeedback

bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1165705

Issue: Feedback is shown when registering system. When network is not configured it raise popup that allow to configure it. When clicked yes to configure it, popup that mentions "registering system" is still shown on top.

Fix: in yast2 was implemented in call to suppress feedback - https://github.com/yast/yast-yast2/pull/1034 . And this call is used here before calling network client.