### PR TITLE
WIP: Added missing require (bsc#1167945)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr  9 12:18:33 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Crash fix: Added missing require (bsc#1167945)
+- 4.2.40
+
+-------------------------------------------------------------------
 Thu Mar 26 12:07:36 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Reverts changes made in 4.2.36 to improve the addons selection,

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.39
+Version:        4.2.40
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/clients/inst_migration_repos.rb
+++ b/src/lib/registration/clients/inst_migration_repos.rb
@@ -14,6 +14,7 @@
 
 require "yast"
 require "yast/suse_connect"
+require "registration/sw_mgmt"
 
 module Registration
   module Clients


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1167945

## Trello

https://trello.com/c/qgtrjtcA/

## Problem

Crash during offline migration from SLES-12-SP5 to SLE-15-SP1:

![2020-03-28_12-42-34](https://user-images.githubusercontent.com/11538225/78890201-7a474c80-7a65-11ea-8696-e5c8e4856770.png)


## Cause

Missing `require`.
(found by @mvidner)

## Fix

Added the `require`.


## Test

I have no reasonable way to test this.


## Affected Distributions

- [SLE-15 GA](https://github.com/yast/yast-registration/blob/SLE-15-GA/src/lib/registration/clients/inst_migration_repos.rb#L46)
- [SLE-15-SP1](https://github.com/yast/yast-registration/blob/SLE-15-SP1/src/lib/registration/clients/inst_migration_repos.rb#L46)  (this is what the bug was reported against)
- [SLE-15-SP2](https://github.com/yast/yast-registration/blob/master/src/lib/registration/clients/inst_migration_repos.rb#L46)

No SLE-12 release is affected: This source file did not exist prior to SLE-15.