### PR TITLE
Declining/refusal of an addon license means canceling all addons. (bsc#1169577)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 28 10:50:51 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- Declining/refusal of an addon license means canceling all addons.
+  (bsc#1169577)
+- 4.1.26
+
+-------------------------------------------------------------------
 Thu Apr  9 12:35:25 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Crash fix backport: Added missing require (bsc#1167945)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.1.25
+Version:        4.1.26
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/registration/ui/addon_eula_dialog_test.rb
+++ b/test/registration/ui/addon_eula_dialog_test.rb
@@ -53,7 +53,7 @@ describe Registration::UI::AddonEulaDialog do
 
     context "when there are EULA acceptances pending" do
       let(:addons) { [addon_with_eula, second_addon_with_eula] }
-      let(:first_dialog_response) { :refused }
+      let(:first_dialog_response) { :accepted }
       let(:second_dialog_response) { :accepted }
 
       before do
@@ -72,8 +72,8 @@ describe Registration::UI::AddonEulaDialog do
       context "and the user wants to abort" do
         let(:first_dialog_response) { :abort }
 
-        it "returns :abort" do
-          expect(subject.run).to eq(:abort)
+        it "returns :back anyway" do
+          expect(subject.run).to eq(:back)
         end
       end
 
@@ -120,15 +120,15 @@ describe Registration::UI::AddonEulaDialog do
 
       before do
         allow(Yast::ProductLicense).to receive(:HandleLicenseDialogRet)
-          .and_return(:refused)
+          .and_return(:abort)
       end
 
       it "does not set it as accepted" do
         expect(product_license).to_not receive(:accept!)
       end
 
-      it "returns :next" do
-        expect(dialog.run).to eq(:next)
+      it "returns :back" do
+        expect(dialog.run).to eq(:back)
       end
     end
   end
@@ -194,8 +194,8 @@ describe Registration::UI::AddonEulaDialog do
     context "when the license was previously accepted" do
       let(:accepted?) { true }
 
-      it "returns :next" do
-        expect(dialog.send(:accept_eula, addon)).to eq(:next)
+      it "returns :accepted" do
+        expect(dialog.send(:accept_eula, addon)).to eq(:accepted)
       end
 
       it "does not show the eula" do


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1169577
- https://trello.com/c/zRXvFHx3

Without this, an addon is still installed even if its license is declined.

In commit 1c7d041f6b3e71dce6a6f6062f10b1d6f0121754, PR https://github.com/yast/yast-registration/pull/440 ,
the idea was that we can unselect an addon whose license was declined, and
proceed with installing the remaining addons. But that does not work out with
autoselected addons ( https://github.com/yast/yast-registration/pull/335 https://github.com/yast/yast-registration/pull/338 ) where we take into account the product dependencies.

~~The new solution is to interpret a refusal of a license as the Abort button,
which ends installation of ALL selected addons.~~
Well that did not work out (because the dialog sequence has a dynamic ws_start) but now we have a better, simpler solution: declining a license is interpreted as the **Back** button, leading to the addon selection screen where you can unselect the offending one and still get the benefit of dependency resolution.

## Testing

Tested this manually:
- started with an unpatched SLE_15_SP1-x86_64-default.qcow2 image from Slenkins
- (in this state, declining a license immeidately aborts yast)
- `zypper up yast\*`
- `zypper in /tmp/yast2-registration-4.1.26-1.noarch.rpm`
- `yast scc` (first register)
- `yast scc select_extensions` (like `yast`, "Software > Add System Extensions or Modules")
- On x86_86 I could not reproduce the ppc64 case of an addon that has a licence without a regcode, it's one or the other. I used the Workstation Extensions (license AND regcode) and Package Hub (no license, no regcode)
- Without the fix, declining the WE license still asks for its regcode. With the fix, it goes back ald lets you unselect.