### PR TITLE
Namespace fix?

### DIFF
--- a/src/lib/registration/clients/inst_migration_repos.rb
+++ b/src/lib/registration/clients/inst_migration_repos.rb
@@ -44,7 +44,7 @@ module Registration
         return if destdir == "/"
 
         # copy the old NCC/SCC credentials to inst-sys
-        SwMgmt.copy_old_credentials(destdir)
+        ::Registration::SwMgmt.copy_old_credentials(destdir)
 
         # import the SMT/RMT certificate to inst-sys
         import_ssl_certificates


### PR DESCRIPTION
- See  https://bugzilla.suse.com/show_bug.cgi?id=1172395
  - It fails with `uninitialized constant Registration::Clients::InstMigrationRepos::SwMgmt` error in [inst_migration_repos.rb](https://github.com/yast/yast-registration/blob/SLE-15-SP1/src/lib/registration/clients/inst_migration_repos.rb#L47) client
- But it's a really strange error, it worked fine for me when I tested the implementation and it was also OK for QA
- Moreover this minimized snippet works fine for me:
```ruby
module Registration
  class SwMgmt
    def self.test
      puts "OK!"
    end
  end
end

module Registration
  module Clients
    class InstMigrationRepos
      def self.test
        SwMgmt.test
      end
    end
  end
end

Registration::Clients::InstMigrationRepos.test
```

It works even without full qualification...

## Any idea why that error happened?

(Note: it's a quarterly medium respin, but that should be the same as SP1+MU, I do not expect any bigger changes there...)