### PR TITLE
Evaluating addon-list: Uses version without release for connecting SCC.

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul  9 10:31:17 CEST 2020 - schubi@suse.de
+
+- Evaluating addon-list: Uses version without release for
+  connecting SCC (bsc#1162755).
+- 4.3.2
+
+-------------------------------------------------------------------
 Thu May 28 10:50:51 UTC 2020 - Martin Vidner <mvidner@suse.com>
 
 - Declining/refusal of an addon license means canceling all addons.

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.3.1
+Version:        4.3.2
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -153,7 +153,10 @@ module Registration
 
       log.info "Reading available addons for product: #{base_product["name"]}"
 
-      remote_product = SwMgmt.remote_product(base_product)
+      # base_product_to_register returns "version_version" for the version
+      # whereas installed_base_product returns "version_release".
+      # SCC needs in this case the version without the release.
+      remote_product = SwMgmt.remote_product(base_product, version_release: false)
       addons = SUSE::Connect::YaST.show_product(remote_product, connect_params).extensions || []
       addons.each { |a| log.info "Found available addon: #{a.inspect}" }
 

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -153,6 +153,13 @@ describe Registration::Registration do
           "sle-module-legacy", "sle-module-web-scripting", "sle-module-public-cloud",
           "sle-module-adv-systems-management", "sle-hae")
       end
+
+      it "uses version without release for connecting SCC" do
+        expect(Registration::SwMgmt).to receive(:remote_product).with(
+          base_product, version_release: false
+        )
+        Registration::Registration.new.get_addon_list
+      end
     end
   end
 


### PR DESCRIPTION
Due this change
https://github.com/yast/yast-registration/pull/454/files#diff-8abb084e7b29d0f192dcc6ab937bc948R140

The call "old" base_product_to_register returns "version_version" for the version whereas the "new" call installed_base_product returns "version_release".

While an upgrade SCC will be given a version_release number now which seems to be wrong. 