### PR TITLE
AutoYaST: Added supplements: autoyast(suse_register) into the spec file

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Aug 10 16:01:31 CEST 2020 - schubi@suse.de
+
+- AutoYaST: Added supplements: autoyast(suse_register) into the spec file
+  in order to install this packages if the section has been defined
+  in the AY configuration file (bsc#1146494).
+- 4.3.6
+
+-------------------------------------------------------------------
 Tue Jul 28 07:20:28 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Handle exceptions when parsing xml file (related to bsc#1170886)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.3.5
+Version:        4.3.6
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only
@@ -60,6 +60,8 @@ Requires:       yast2-update >= 3.1.36
 
 # new calls in AutoinstGeneral
 Conflicts:      autoyast2 < 4.3.23
+
+Supplements:    autoyast(suse_register)
 
 BuildArch:      noarch
 # SUSEConnect does not build for i586 and s390 and is not supported on those architectures


### PR DESCRIPTION
…e in order to install this packages if the section has been defined in the AY configuration file (bsc#1146494).