### PR TITLE
Improved skipping message in the first boot mode (bsc#1174467)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Aug 13 11:24:33 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Improved skipping message in the first boot mode, the first boot
+  workflow might not contain the add-on module in the next step
+  (bsc#1174467)
+- 4.3.7
+
+-------------------------------------------------------------------
 Mon Aug 10 16:01:31 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(suse_register) into the spec file

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.3.6
+Version:        4.3.7
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/ui/base_system_registration_dialog.rb
+++ b/src/lib/registration/ui/base_system_registration_dialog.rb
@@ -424,10 +424,20 @@ module Registration
       def default_skipping_text
         # TRANSLATORS:
         # Popup question: confirm skipping the registration on the Full medium
-        _("<p>You are skipping registration.\n"\
-          "Please configure access to packages medium in the next step.</p>"\
-          "<p>Without registration update-channels will not be configured.\n"\
-          "This will disable the updates and security fixes.</p>")
+        "<p>" + _("You are skipping registration.") + medium_access_text + "</p>" +
+          # TRANSLATORS:
+          # Popup question: confirm skipping the registration on the Full medium
+          _("<p>Without registration update-channels will not be configured.\n"\
+            "This will disable the updates and security fixes.</p>")
+      end
+
+      def medium_access_text
+        # in the firstboot mode the add-on module might be skipped,
+        # do not display this part there
+        return "" if Stage.firstboot
+        # TRANSLATORS:
+        # Popup question: confirm skipping the registration on the Full medium
+        " " + _("Please configure access to packages medium in the next step.")
       end
 
       # the warning for the Online media


### PR DESCRIPTION
- The first boot workflow might not contain the add-on module in the next step (it is defined by the vendor). So let's omit a part of the message in the first boot mode.
- https://bugzilla.suse.com/show_bug.cgi?id=1174467
- 4.3.7