### PR TITLE
[bsc#1175682] Element 'release_type' is not mandatory

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 24 11:31:58 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST: the release_type element is not mandatory
+  (bsc#1175682).
+- 4.3.8
+
+-------------------------------------------------------------------
 Thu Aug 13 11:24:33 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Improved skipping message in the first boot mode, the first boot

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.3.7
+Version:        4.3.8
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/registration.rnc
+++ b/src/autoyast-rnc/registration.rnc
@@ -27,7 +27,7 @@ addon = element addon {
     addon_name &
     addon_version &
     addon_arch &
-    addon_release_type &
+    addon_release_type? &
     addon_reg_code?
   )
 }


### PR DESCRIPTION
Fixes the [bsc#1175682](https://bugzilla.suse.com/show_bug.cgi?id=1175682). This snippet should validate:

```xml
   <suse_register>
      <reg_code>REG_CODE_GOES_HERE</reg_code>
      <install_updates config:type="boolean">true</install_updates>
      <addons config:type="list">
        <addon>
          <name>sle-module-basesystem</name>
          <version>15.3</version>
          <arch>x86_64</arch>
        </addon>
      </addons>
    </suse_register>
```