### PR TITLE
Fixed upgrade with the `media_upgrade=1` option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ Metrics/BlockNesting:
 
 # TODO: this need some non-trivial refactoring...
 Metrics/ClassLength:
-  Max: 470
+  Max: 480
 
 # TODO: this need some non-trivial refactoring...
 Metrics/CyclomaticComplexity:

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct  1 07:00:08 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed upgrade using the Full medium with the "media_upgrade=1"
+  boot option (bsc#1176563)
+- 4.2.43
+
+-------------------------------------------------------------------
 Thu Jul  9 10:31:17 CEST 2020 - schubi@suse.de
 
 - Evaluating addon-list: Uses version without release for

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.42
+Version:        4.2.43
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -772,8 +772,9 @@ module Registration
         #   with the "media_upgrade=1" boot option. The Online medium does not
         #   contain any packages and it cannot be used in this case, Full medium
         #   is required. Use the RichText format.
-        _("<h2>Online Medium</h2><p>The system cannot be upgraded using the Online " \
-          "medium, that medium does not provide any packages to install.</p>") +
+        _("<h2>Online Medium</h2><p>The media based upgrade was requested, "\
+          "but you are using the Online medium which does not provide any packages "\
+          "to install.</p>") +
           # TRANSLATORS: Force media upgrade, Online medium detected (2/2)
           _("<p>Please use the Full medium instead of the Online.</p>")
       end


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1176563
- When using the `media_upgrade=1` boot option the base product repository was not initialized and there was no new product available to upgrade
- The fix is to call the `add_offline_base_product` method which is called when using the Offline medium also in the branch which handles the `media_upgrade=1` option.
- When using the Online medium we cannot add a product repository because there is no repository. That's the reason for a new error popup. (It's only displayed when using the Online medium with the `media_upgrade=1` option which is really rare so a missing translation should not be a problem.)

## Tests

- Tested manually, see the screenshots below

## Screenshots

The original error:

![forced_media_upgrade_broken](https://user-images.githubusercontent.com/907998/94785859-8555b680-03d0-11eb-9129-806698ddc4d7.png)

Full medium with the fix (the upgrade continues):

![forced_media_upgrade_fixed](https://user-images.githubusercontent.com/907998/94785890-93a3d280-03d0-11eb-9fe6-457b5c104c18.png)

Online medium with the fix (a new error is displayed):

![forced_media_upgrade_online](https://user-images.githubusercontent.com/907998/94786084-ccdc4280-03d0-11eb-8888-84ac4e946bf7.png)
