### PR TITLE
bsc#1177135: do not export the registration e-mail when it is not defined

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct  7 21:26:11 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not export the registration e-mail if it is not defined
+  (bsc#1177135).
+- 4.3.10
+
+-------------------------------------------------------------------
 Thu Oct  1 14:15:55 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed upgrade using the Full medium with the "media_upgrade=1"

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.3.9
+Version:        4.3.10
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/storage/config.rb
+++ b/src/lib/registration/storage/config.rb
@@ -73,11 +73,10 @@ module Registration
         ret.merge!(
           "reg_server"      => reg_server,
           "slp_discovery"   => slp_discovery,
-          "email"           => email,
           "reg_code"        => reg_code,
           "install_updates" => install_updates
         )
-
+        ret["email"] = email if email
         ret["addons"] = export_addons
         ret.merge!(export_ssl_config)
 

--- a/test/registration/storage/config_test.rb
+++ b/test/registration/storage/config_test.rb
@@ -81,6 +81,17 @@ describe Registration::Storage::Config do
         "reg_code"        => "FOOBAR42"
       )
     end
+
+    context "when the email is nil" do
+      before do
+        subject.do_registration = true
+        subject.email = nil
+      end
+
+      it "does not include the email" do
+        expect(subject.export.keys).to_not include("email")
+      end
+    end
   end
 
   describe "#import" do


### PR DESCRIPTION
Fixes [bsc#1177135](https://bugzilla.suse.com/show_bug.cgi?id=1177135).
