### PR TITLE
[L3] Fixed base product evaluation (bsc#1178652)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec  2 14:20:56 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed finding the installed base product when doing upgrade
+  using the Full installation medium (bsc#1178652)
+- 4.2.46
+
+-------------------------------------------------------------------
 Tue Oct 27 15:50:31 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix the latest change to work in firstboot when system is

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.45
+Version:        4.2.46
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -643,9 +643,9 @@ module Registration
       # for upgrade, select the new base product to install.
       def add_offline_base_product
         # find the installed base product
-        installed_base = Y2Packager::Resolvable.find(
-          kind: :product, status: :installed, type: "base"
-        ).first
+        installed = Y2Packager::Resolvable.find(kind: :product, status: :installed)
+        # Resolvable.find cannot filter by product type, run the filter here
+        installed_base = installed.find { |p| p.type == "base" }
 
         if !installed_base
           log.error("Installed base product not found")


### PR DESCRIPTION
- Fixes L3: https://bugzilla.suse.com/show_bug.cgi?id=1178652
  
![SLES4SAP_broken_migration](https://user-images.githubusercontent.com/907998/100979662-5f6d9f00-3544-11eb-9c86-14e5f0f18442.png)

- The `pkg-bindings` call used in the underlying `Resolvables.find` method cannot filter the resolvables using the `type` key, the filtering must be done in a dedicated call.
- Just by chance the first product is usually a base product, but that's not guaranteed. It seems that the products are returned in the order as saved on the disk. And a different filesystem (Ext4 in this case) might result in a different product ordering.
- 4.2.46

## Testing

- Tested manually, with the fix the error popup is not displayed, the SLES4SAP base product is correctly found. And the license confirmation dialog is displayed: 
![SLES4SAP_fixed_migration](https://user-images.githubusercontent.com/907998/100979884-af4c6600-3544-11eb-95a6-400706d7c02b.png)


