### PR TITLE
Fixed tests

### DIFF
--- a/src/lib/registration/clients/inst_scc.rb
+++ b/src/lib/registration/clients/inst_scc.rb
@@ -228,8 +228,15 @@ module Yast
       log.info "The system is already registered, displaying registered dialog"
       # ensure that @registration is initialized
       return :cancel if init_registration == :cancel
+
+      extensions_enabled = true
+      success = Registration::ConnectHelpers.catch_registration_errors do
+        extensions_enabled = !Registration::Addon.find_all(@registration).empty?
+      end
+      return :abort unless success
+
       ::Registration::UI::RegisteredSystemDialog.run(
-        extensions_enabled: !Registration::Addon.find_all(@registration).empty?
+        extensions_enabled: extensions_enabled
       )
     end
 

--- a/test/inst_scc_test.rb
+++ b/test/inst_scc_test.rb
@@ -17,6 +17,8 @@ describe Yast::InstSccClient do
     allow(Yast::Mode).to receive(:update).and_return(false)
     allow(Yast::SlpService).to receive(:all).and_return([])
     allow(Y2Packager::MediumType).to receive(:online?).and_return(false)
+    allow(subject).to receive(:init_registration)
+    allow(Registration::Addon).to receive(:find_all).and_return([])
   end
 
   context "the system is already registered" do
@@ -35,16 +37,13 @@ describe Yast::InstSccClient do
 
     it "displays an error when loading the available extensions fails" do
       error = "Invalid system credentials"
-      # click installing extensions, abort the workflow
-      expect(Yast::UI).to receive(:UserInput).and_return(:extensions, :abort)
 
       expect(Yast::Report).to receive(:Error) do |msg|
         # make sure the propoer error is displayed
         expect(msg).to include(error)
       end
 
-      expect_any_instance_of(Registration::RegistrationUI).to receive(:get_available_addons)
-        .and_raise(error)
+      expect(Registration::Addon).to receive(:find_all).and_raise(error)
 
       expect(subject.main).to eq(:abort)
     end


### PR DESCRIPTION
- Fixed an unit test error reported during `rake osc:build`:
```
[    4s] Failures:
[    4s] 
[    4s]   1) Yast::InstSccClient the system is already registered returns :abort when closing the status dialog
[    4s]      Failure/Error: expect(subject.main).to eq(:abort)
[    4s] 
[    4s]      SUSE::Connect::CannotBuildBasicAuth:
[    4s] 
[    4s]        Cannot read username and password from /etc/zypp/credentials.d/SCCcredentials. Please activate your system first.
[    4s]      # ./src/lib/registration/registration.rb:160:in `get_addon_list'
[    4s]      # ./src/lib/registration/addon.rb:162:in `load_addons'
[    4s]      # ./src/lib/registration/addon.rb:46:in `find_all'
[    4s]      # ./src/lib/registration/clients/inst_scc.rb:232:in `registration_check'
[    4s]      # ./src/lib/registration/clients/inst_scc.rb:275:in `block in workflow_aliases'
[    4s]      # /usr/share/YaST2/modules/Sequencer.rb:249:in `WS_run'
[    4s]      # /usr/share/YaST2/modules/Sequencer.rb:320:in `block in Run'
[    4s]      # /usr/share/YaST2/modules/Sequencer.rb:312:in `loop'
[    4s]      # /usr/share/YaST2/modules/Sequencer.rb:312:in `Run'
[    4s]      # ./src/lib/registration/clients/inst_scc.rb:337:in `start_workflow'
[    4s]      # ./src/lib/registration/clients/inst_scc.rb:75:in `main'
[    4s]      # ./test/inst_scc_test.rb:33:in `block (3 levels) in <top (required)>'
[    4s]      # ------------------
[    4s]      # --- Caused by: ---
[    4s]      # SUSE::Connect::MissingSccCredentialsFile:
[    4s]      #   SUSE::Connect::MissingSccCredentialsFile
[    4s]      #   ./src/lib/registration/registration.rb:160:in `get_addon_list'
[    4s] 
[    4s]   2) Yast::InstSccClient the system is already registered displays an error when loading the available extensions fails
[    4s]      Failure/Error: expect(subject.main).to eq(:abort)
[    4s] 
[    4s]      SUSE::Connect::CannotBuildBasicAuth:
[    4s] 
[    4s]        Cannot read username and password from /etc/zypp/credentials.d/SCCcredentials. Please activate your system first.
[    4s]      # ./src/lib/registration/registration.rb:160:in `get_addon_list'
[    4s]      # ./src/lib/registration/addon.rb:162:in `load_addons'
[    4s]      # ./src/lib/registration/addon.rb:46:in `find_all'
[    4s]      # ./src/lib/registration/clients/inst_scc.rb:232:in `registration_check'
[    4s]      # ./src/lib/registration/clients/inst_scc.rb:275:in `block in workflow_aliases'
[    4s]      # /usr/share/YaST2/modules/Sequencer.rb:249:in `WS_run'
[    4s]      # /usr/share/YaST2/modules/Sequencer.rb:320:in `block in Run'
[    4s]      # /usr/share/YaST2/modules/Sequencer.rb:312:in `loop'
[    4s]      # /usr/share/YaST2/modules/Sequencer.rb:312:in `Run'
[    4s]      # ./src/lib/registration/clients/inst_scc.rb:337:in `start_workflow'
[    4s]      # ./src/lib/registration/clients/inst_scc.rb:75:in `main'
[    4s]      # ./test/inst_scc_test.rb:49:in `block (3 levels) in <top (required)>'
[    4s]      # ------------------
[    4s]      # --- Caused by: ---
[    4s]      # SUSE::Connect::MissingSccCredentialsFile:
[    4s]      #   SUSE::Connect::MissingSccCredentialsFile
[    4s]      #   ./src/lib/registration/registration.rb:160:in `get_addon_list'
```
- The mocks in the tests did match the code
- The exceptions were not caught at all
