### PR TITLE
Catch exceptions during cloning (bsc#1181075)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 19 14:27:15 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Catch exceptions during cloning, display an error popup
+  instead of crash (bsc#1181075)
+- 4.3.18
+
+-------------------------------------------------------------------
 Fri Dec 18 13:44:58 UTC 2020 - Stefan Schubert <schubi@suse.de>
 
 - Updating warning popup if the user has skipped the registration.

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.3.17
+Version:        4.3.18
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/clients/scc_auto.rb
+++ b/src/lib/registration/clients/scc_auto.rb
@@ -147,8 +147,9 @@ module Registration
       end
 
       def read
-        @config.read
-        true
+        ::Registration::ConnectHelpers.catch_registration_errors do
+          @config.read
+        end
       end
 
       # return extra packages needed by this module (none so far)


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1181075
- Display an error popup instead of crash
- The [catch_registration_errors](https://github.com/yast/yast-registration/blob/b021cdc4dd1891c25afc42bf87f99a4b28bb614a/src/lib/registration/connect_helpers.rb#L63) method catches exceptions and displays an error popup. It returns `true`/`false` depending on the success status of the block.
- 4.3.18