### PR TITLE
Log details about the imported SSL certificate (bsc#1179464)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     # just for easier debugging...
     - name: Inspect Installed Packages
@@ -38,7 +38,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Rubocop
       run: rake check:rubocop
@@ -50,7 +50,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Package Build
       run: yast-ci-ruby -o package
@@ -62,7 +62,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Yardoc
       run: rake check:doc
@@ -76,7 +76,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Perl Syntax
       run: yast-ci-ruby -o perl_syntax

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb  8 17:06:54 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Log details about the imported SSL certificate during migration
+  (related to bsc#1179464)
+- 4.3.19
+
+-------------------------------------------------------------------
 Tue Jan 19 14:27:15 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Catch exceptions during cloning, display an error popup

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.3.18
+Version:        4.3.19
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/clients/inst_migration_repos.rb
+++ b/src/lib/registration/clients/inst_migration_repos.rb
@@ -15,6 +15,8 @@
 require "yast"
 require "yast/suse_connect"
 require "registration/sw_mgmt"
+require "registration/ssl_certificate"
+require "registration/ssl_certificate_details"
 
 module Registration
   module Clients
@@ -59,6 +61,8 @@ module Registration
           if File.exist?(cert_file)
             log.info("Importing the SSL certificate from the old system: (#{prefix})#{file} ...")
             cert = SslCertificate.load_file(cert_file)
+            # log the certificate details
+            log.info(SslCertificateDetails.new(cert).summary)
             target_path = File.join(SslCertificate::INSTSYS_CERT_DIR, File.basename(cert_file))
             cert.import_to_instsys(target_path)
           else

--- a/src/lib/registration/clients/inst_migration_repos.rb
+++ b/src/lib/registration/clients/inst_migration_repos.rb
@@ -61,14 +61,25 @@ module Registration
           if File.exist?(cert_file)
             log.info("Importing the SSL certificate from the old system: (#{prefix})#{file} ...")
             cert = SslCertificate.load_file(cert_file)
-            # log the certificate details
-            log.info(SslCertificateDetails.new(cert).summary)
+            log_certificate(cert)
             target_path = File.join(SslCertificate::INSTSYS_CERT_DIR, File.basename(cert_file))
             cert.import_to_instsys(target_path)
           else
             log.debug("SSL certificate (#{prefix})#{file} not found in the system")
           end
         end
+      end
+
+      # Log the certificate details
+      # @param cert [Registration::SslCertificate] the SSL certificate
+      def log_certificate(cert)
+        # log also the dates
+        log.info("#{SslCertificateDetails.new(cert).summary}\n" \
+        "Issued on: #{cert.issued_on}\nExpires on: #{cert.expires_on}")
+
+        # log a warning for expired certificate
+        expires = cert.x509_cert.not_after.localtime
+        log.warn("The certificate has EXPIRED! (#{expires})") if expires < Time.now
       end
     end
   end


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1179464
- In the bug we import a certificate which is not valid for the RMT server anymore
- But as we actually do not log any details about the certificate we do not know what exactly we are importing
- Solution: Log the certificate details in a human readable form
- Testing: Covered by the existing unit tests
- 4.3.19

Example log (as printed by the unit tests using the [test.pem](https://github.com/yast/yast-registration/blob/master/test/fixtures/test.pem) certificate):

```
2021-02-09 13:46:54 <1> PC(13980) [Ruby] clients/inst_migration_repos.rb(log_certificate):77 Certificate:
Issued To
Common Name (CN): linux-1hyn
Organization (O): WebYaST
Organization Unit (OU): WebYaST

Issued By
Common Name (CN): linux-1hyn
Organization (O): WebYaST
Organization Unit (OU): WebYaST

SHA1 Fingerprint: 
   A8:DE:08:B1:57:52:FE:70:DF:D5:31:EA:E3:53:BB:39:EE:01:FF:B9
SHA256 Fingerprint: 
   2A:02:DA:EC:A9:FF:4C:B4:A6:C0:57:08:F6:1C:8B:B0:94:FA:F4:60:96:5E:18:48:CA:84:81:48:60:F3:CB:BF
Issued on: 2014-04-24
Expires on: 2017-04-23
2021-02-09 13:46:54 <2> PC(13980) [Ruby] clients/inst_migration_repos.rb(log_certificate):82 The certificate has EXPIRED! (2017-04-23 10:16:31 +0200)
```