### PR TITLE
Fix popup

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 15 17:39:06 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.20
+
+-------------------------------------------------------------------
 Mon Feb  8 17:06:54 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Log details about the imported SSL certificate during migration

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.3.19
+Version:        4.3.20
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/test/inst_scc_test.rb
+++ b/test/inst_scc_test.rb
@@ -56,6 +56,7 @@ describe Yast::InstSccClient do
     end
 
     it "switchs to manual registration when aborting selection of url" do
+      allow(Yast::Report).to receive(:Error)
       # User cancels the selection of registration url
       expect_any_instance_of(Registration::UI::RegistrationUpdateDialog).to receive(
         :init_registration

--- a/test/migration_repos_workflow_spec.rb
+++ b/test/migration_repos_workflow_spec.rb
@@ -211,6 +211,7 @@ describe Registration::UI::MigrationReposWorkflow do
       end
 
       it "reports error and indicates needed rollback when upgrading a product fails" do
+        expect(Yast::Report).to receive(:Error)
         # installed SLES12
         allow(Registration::SwMgmt).to receive(:installed_products)
           .and_return([load_yaml_fixture("products_legacy_installation.yml")[1]])

--- a/test/registration/clients/scc_auto_test.rb
+++ b/test/registration/clients/scc_auto_test.rb
@@ -99,6 +99,10 @@ describe Registration::Clients::SCCAuto do
       allow(Yast::Mode).to receive(:normal).and_return(true)
       expect(::Registration::SwMgmt).to receive(:init)
 
+      allow(subject).to receive(:registration_ui).and_return(
+        double(register_system_and_base_product: true, disable_update_repos: true)
+      )
+
       subject.write
     end
 

--- a/test/registration/clients/scc_auto_test.rb
+++ b/test/registration/clients/scc_auto_test.rb
@@ -85,6 +85,8 @@ describe Registration::Clients::SCCAuto do
     before do
       Y2Packager::MediumType.type = :online
       allow(Y2Packager::ProductControlProduct).to receive(:products).and_return("SLES")
+      # clean cache
+      ::Registration::Storage::Cache.instance.addon_services = []
     end
 
     it "just returns true if config is not set to register and mode is not update" do

--- a/test/registration/ui/addon_eula_dialog_test.rb
+++ b/test/registration/ui/addon_eula_dialog_test.rb
@@ -63,6 +63,7 @@ describe Registration::UI::AddonEulaDialog do
       before do
         allow(Yast::ProductLicense).to receive(:HandleLicenseDialogRet)
           .and_return(first_dialog_response, second_dialog_response)
+        allow(Yast::ProductLicense).to receive(:DisplayLicenseDialogWithTitle)
       end
 
       context "and the user wants to go back" do
@@ -104,6 +105,7 @@ describe Registration::UI::AddonEulaDialog do
       before do
         allow(Yast::ProductLicense).to receive(:HandleLicenseDialogRet)
           .and_return(:accepted)
+        allow(Yast::ProductLicense).to receive(:DisplayLicenseDialogWithTitle)
       end
 
       it "sets it as accepted" do
@@ -125,6 +127,7 @@ describe Registration::UI::AddonEulaDialog do
       before do
         allow(Yast::ProductLicense).to receive(:HandleLicenseDialogRet)
           .and_return(:abort)
+        allow(Yast::ProductLicense).to receive(:DisplayLicenseDialogWithTitle)
       end
 
       it "does not set it as accepted" do
@@ -164,10 +167,17 @@ describe Registration::UI::AddonEulaDialog do
     context "when the eula could not be downloaded" do
       before do
         allow(eula_downloader).to receive(:download).and_raise(StandardError)
+        allow(Yast::Report).to receive(:Error)
       end
 
       it "returns :back" do
         expect(dialog.send(:accept_eula, addon)).to eq(:back)
+      end
+
+      it "shows error" do
+        expect(Yast::Report).to receive(:Error)
+
+        dialog.send(:accept_eula, addon)
       end
     end
 

--- a/test/wizard_client_spec.rb
+++ b/test/wizard_client_spec.rb
@@ -33,8 +33,9 @@ describe Registration::UI::WizardClient do
       subject.main
     end
 
-    it "returns :abort when an exception is raised" do
+    it "returns :abort and show error when an exception is raised" do
       expect(subject).to receive(:run_sequence).and_raise("Error")
+      expect(Yast::Report).to receive(:Error)
       expect(subject.run).to eq(:abort)
     end
   end


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager and yast-sysconfig.

This should fix the problem for this repository.