### PR TITLE
  Hide the abort button when calling the network client

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr  6 16:04:44 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Hide the abort button when the network client is called
+  (bsc#1183586).
+- 4.4.0
+
+-------------------------------------------------------------------
 Fri Mar  5 13:36:44 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Allow registering system again during firstboot stage

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.3.21
+Version:        4.4.0
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/helpers.rb
+++ b/src/lib/registration/helpers.rb
@@ -92,7 +92,7 @@ module Registration
       # ensure that no registration feedback is shown
       # when running network configuration (bsc#1165705)
       Yast::Popup.SuppressFeedback do
-        Yast::WFM.call("inst_lan", [{ "skip_detection" => true }])
+        Yast::WFM.call("inst_lan", [{ "skip_detection" => true, "hide_abort_button" => true }])
       end
     end
 


### PR DESCRIPTION
### Problem

> When user presses Abort button on Network settings page, it works same way as "Back" button and returns to the previous dialog. — https://bugzilla.suse.com/show_bug.cgi?id=1183586

As stated in the [second comment](https://bugzilla.suse.com/show_bug.cgi?id=1183586#c2), this happens

>  because the network **subworkflow** should not use [Abort] (...) It should be possible to **abort only in the main workflow**.

### Solution

To use an installation argument (`hide_abort_button`) when calling the _inst\_lan_ client to force it hiding the abort button during the installation. **See https://github.com/yast/yast-network/pull/1195**


### Tests

* Only tested manually using `yupdate` to apply changes in a SLE 15-SP3 Build 168.1 

### Screenshots

| Patching the installer | The client running in an installation sub-workflow, w/o the abort button |
|-|-|
| ![Patching the SUSE SLE installer via yupdate](https://user-images.githubusercontent.com/1691872/113743921-1a2cca00-96fc-11eb-808e-3add0d2ab531.png) | ![Network inst_lan client without the abort button](https://user-images.githubusercontent.com/1691872/113594004-02d3db00-962f-11eb-8e56-5d1483120f25.png) |

---

Related Trello card (internal link): https://trello.com/c/6M4weND5

 