### PR TITLE
Show loading addons error

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 16 07:20:58 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Show errors when loading addons fails (bsc#1187844).
+- 4.3.23
+
+-------------------------------------------------------------------
 Wed Apr 21 11:22:55 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: do not crash when cloning a registered system with

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.3.22
+Version:        4.3.23
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -24,6 +24,7 @@ require "y2packager/resolvable"
 require "registration/registration"
 require "registration/registration_ui"
 require "registration/migration_repositories"
+require "registration/connect_helpers"
 require "registration/releasever"
 require "registration/sw_mgmt"
 require "registration/url_helpers"
@@ -264,8 +265,7 @@ module Registration
       #
       # @return [Array<Hash>] installed products and addons selected to be installed
       def merge_registered_addons
-        # load the extensions to merge the registered but not installed extensions
-        Addon.find_all(registration)
+        return unless load_addons
 
         # TRANSLATORS: Popup question, merge this addon that are registered but not
         # installed to the current migration products list.
@@ -285,6 +285,18 @@ module Registration
           end
 
         products.concat(addons)
+      end
+
+      # Tries to load the registered addons
+      #
+      # Registration errors are shown to the user, allowing to retry in some cases.
+      #
+      # @return [Boolean] true on success
+      def load_addons
+        ConnectHelpers.catch_registration_errors do
+          # load the extensions to merge the registered but not installed extensions
+          Addon.find_all(registration)
+        end
       end
 
       # load migration products for the installed products from the registration server,


### PR DESCRIPTION
## Problem

During the product migration, the registered but not installed addons are loaded in order to allow adding them. But sometimes the registration call fails for different reasons: timeout, internal error, etc. These exceptions are not controlled and they are raised to the user. 

* https://bugzilla.suse.com/show_bug.cgi?id=1187844
* (Internal) https://trello.com/c/epEQ3nt6/2579-3-publicsles-15-sp3-p3-1187844-build-maint-openqa-test-fails-in-upgradeselect

## Solution

As suggested by @lslezak, the *ConnectHelpers.catch_registration_errors* helper method is used. That helper displays an error popup and allows retrying in some cases, it can import the used SSL certificate, etc.
