### PR TITLE
Fixed evaluating the update repositories (bsc#1188717)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Sep 22 06:50:30 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed evaluating the update repositories (bsc#1188717),
+  the SUSE Manager update repositories were not disabled
+  when installing the system without updates
+- 4.2.47
+
+-------------------------------------------------------------------
 Wed Dec  2 14:20:56 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed finding the installed base product when doing upgrade

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.2.46
+Version:        4.2.47
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/test/inst_scc_test.rb
+++ b/test/inst_scc_test.rb
@@ -19,6 +19,7 @@ describe Yast::InstSccClient do
     allow(Y2Packager::MediumType).to receive(:online?).and_return(false)
     allow(subject).to receive(:init_registration)
     allow(Registration::Addon).to receive(:find_all).and_return([])
+    allow(Yast::Report).to receive(:Error)
   end
 
   context "the system is already registered" do

--- a/test/migration_repos_workflow_spec.rb
+++ b/test/migration_repos_workflow_spec.rb
@@ -20,6 +20,7 @@ describe Registration::UI::MigrationReposWorkflow do
       allow(Yast::Linuxrc).to receive(:InstallInf)
       allow(Y2Packager::MediumType).to receive(:offline?).and_return(false)
       allow(Y2Packager::MediumType).to receive(:online?).and_return(false)
+      allow(Yast::Report).to receive(:Error)
     end
 
     shared_examples "media based upgrade" do |popup_method|

--- a/test/registration/clients/scc_auto_test.rb
+++ b/test/registration/clients/scc_auto_test.rb
@@ -16,6 +16,10 @@ end
 describe Registration::Clients::SCCAuto do
   let(:config) { ::Registration::Storage::Config.instance }
 
+  before do
+    allow(Yast::Report).to receive(:Error)
+  end
+
   describe "#summary" do
     it "returns string with config description" do
       expect(subject.summary).to be_a(::String)

--- a/test/registration/ui/addon_eula_dialog_test.rb
+++ b/test/registration/ui/addon_eula_dialog_test.rb
@@ -34,6 +34,7 @@ describe Registration::UI::AddonEulaDialog do
       allow(Yast::Wizard).to receive(:SetContents)
       allow(dialog).to receive(:find_license).and_return(product_license)
       allow(dialog).to receive(:download_eula).and_return(true)
+      allow(Yast::Report).to receive(:Error)
       registered_addon.registered
     end
 
@@ -159,6 +160,7 @@ describe Registration::UI::AddonEulaDialog do
         .and_return(license_content)
       allow(dialog).to receive(:setup_eula_dialog)
       allow(dialog).to receive(:run_eula_dialog)
+      allow(Yast::Report).to receive(:Error)
     end
 
     context "when the eula could not be downloaded" do

--- a/test/registration_ui_test.rb
+++ b/test/registration_ui_test.rb
@@ -120,6 +120,33 @@ describe "Registration::RegistrationUI" do
 
       # stub the registration
       allow(registration).to receive(:register_product)
+      allow(Registration::SwMgmt).to receive(:service_repos).and_return([])
+      allow(registration_ui).to receive(:handle_updates)
+    end
+
+    it "disables update repositories if requested" do
+      # unmock the call
+      allow(registration_ui).to receive(:handle_updates).and_call_original
+
+      allow(registration_ui).to receive(:try_register_addons).and_return([])
+
+      prod_service = double("Product service")
+      allow(Registration::Storage::Cache.instance).to receive(:addon_services)
+        .and_return([prod_service])
+
+      update_repo = double("Update repo")
+      allow(Registration::SwMgmt).to receive(:service_repos)
+        .with(prod_service, only_updates: true).and_return([update_repo])
+
+      # user does not want to install the updates
+      allow(registration_ui).to receive(:install_updates?).and_return(false)
+
+      # make sure the update repo is disabled
+      expect(Registration::SwMgmt).to receive(:set_repos_state)
+        .with([update_repo], false)
+
+      # Register Legacy module
+      registration_ui.register_addons([addon_legacy], {})
     end
 
     context "when the addons are free" do

--- a/test/wizard_client_spec.rb
+++ b/test/wizard_client_spec.rb
@@ -35,6 +35,7 @@ describe Registration::UI::WizardClient do
 
     it "returns :abort when an exception is raised" do
       expect(subject).to receive(:run_sequence).and_raise("Error")
+      allow(Yast::Report).to receive(:Error)
       expect(subject.run).to eq(:abort)
     end
   end


### PR DESCRIPTION
# The Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1188717
- The SUSE Manager update repositories were not disabled when installing the system without updates.
- There are actually two separate problems:
  - YaST evaluated the update repositories in a wrong way
  - SUMA repositories do not have the matching tags ([details](https://bugzilla.suse.com/show_bug.cgi?id=1188717#c28))

# The Fix

- According to libzypp experts YaST needs to evaluate the update repositories differently ([link](https://bugzilla.suse.com/show_bug.cgi?id=1188717#c9))
- The `isUpdateRepo()` call needs to be done after loading *all* used repositories to the libzypp pool, YaST originally did that earlier, after adding each repository.