### PR TITLE
fix missing product crash

### DIFF
--- a/src/lib/registration/clients/scc_auto.rb
+++ b/src/lib/registration/clients/scc_auto.rb
@@ -207,7 +207,7 @@ module Registration
         log.info "selected product #{selected_product.inspect}"
         ay_product = if selected_product.respond_to?(:name)
           selected_product.name
-        else
+        elsif selected_product.respond_to?(:details)
           selected_product.details.product
         end
 

--- a/src/lib/registration/clients/scc_auto.rb
+++ b/src/lib/registration/clients/scc_auto.rb
@@ -205,11 +205,8 @@ module Registration
 
         selected_product = Yast::AutoinstFunctions.selected_product
         log.info "selected product #{selected_product.inspect}"
-        ay_product = if selected_product.respond_to?(:name)
-          selected_product.name
-        end
 
-        if !ay_product
+        if !selected_product
           # TRANSLATORS: error message, %s is the XML path, e.g. "software/products"
           Yast::Report.Error(
             _("Missing product specification in the %s section") % "software/products"
@@ -217,6 +214,7 @@ module Registration
           return false
         end
 
+        ay_product = selected_product.name
         control_product = products.find { |p| p.name == ay_product }
 
         if !control_product

--- a/src/lib/registration/clients/scc_auto.rb
+++ b/src/lib/registration/clients/scc_auto.rb
@@ -207,8 +207,6 @@ module Registration
         log.info "selected product #{selected_product.inspect}"
         ay_product = if selected_product.respond_to?(:name)
           selected_product.name
-        elsif selected_product.respond_to?(:details)
-          selected_product.details.product
         end
 
         if !ay_product


### PR DESCRIPTION
fix for crash when product is not defined in autoyast profile - https://trello.com/c/nIoJgTXG/2615-3-sles15-sp3-p5-1188211-absence-of-product-in-autoyast-profile-causes-different-behavior-for-online-and-full-medium