### PR TITLE
Fix missing product crash sp3

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov  1 11:28:32 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Report properly that no product is selected in autoinstallation
+  instead of nil crash (bsc#1188211)
+- 4.3.25
+
+-------------------------------------------------------------------
 Tue Oct 12 08:30:59 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed evaluating the update repositories (bsc#1188717),

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.3.24
+Version:        4.3.25
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/clients/scc_auto.rb
+++ b/src/lib/registration/clients/scc_auto.rb
@@ -207,7 +207,7 @@ module Registration
         log.info "selected product #{selected_product.inspect}"
         ay_product = if selected_product.respond_to?(:name)
           selected_product.name
-        else
+        elsif selected_product.respond_to?(:details)
           selected_product.details.product
         end
 


### PR DESCRIPTION
related pr https://github.com/yast/yast-autoinstallation/pull/803
in general do not crash if no product is selected ( so selected is nil ).