### PR TITLE
Make tests compatible with libsuseconnect

### DIFF
--- a/test/factories.rb
+++ b/test/factories.rb
@@ -22,12 +22,12 @@ def suse_connect_product_generator(attrs = {})
 end
 
 def addon_generator(params = {})
-  SUSE::Connect::Remote::Product.new(suse_connect_product_generator(params))
+  OpenStruct.new(suse_connect_product_generator(params))
 end
 
 def addon_with_child_generator(parent_params = {})
-  prod_child = suse_connect_product_generator
-  SUSE::Connect::Remote::Product.new(
+  prod_child = OpenStruct.new(suse_connect_product_generator)
+  OpenStruct.new(
     suse_connect_product_generator(parent_params.merge("extensions" => [prod_child]))
   )
 end

--- a/test/fixtures/activated_products.yml
+++ b/test/fixtures/activated_products.yml
@@ -1,5 +1,5 @@
 ---
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1157
     :name: SUSE Linux Enterprise High Availability GEO Extension
@@ -34,7 +34,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1245
     :name: SUSE Linux Enterprise High Availability Extension
@@ -53,7 +53,7 @@
     - 1539
     - 1500
     :extensions:
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1157
         :name: SUSE Linux Enterprise High Availability GEO Extension
@@ -105,7 +105,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1117
     :name: SUSE Linux Enterprise Server
@@ -128,7 +128,7 @@
     - 1219
     - 1478
     :extensions:
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1222
         :name: SUSE Linux Enterprise Workstation Extension
@@ -189,7 +189,7 @@
           enabled: true
           autorefresh: true
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1223
         :name: SUSE Linux Enterprise Software Development Kit
@@ -233,7 +233,7 @@
           enabled: true
           autorefresh: true
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1150
         :name: Legacy Module
@@ -276,7 +276,7 @@
           enabled: true
           autorefresh: true
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1153
         :name: Web and Scripting Module
@@ -320,7 +320,7 @@
           enabled: true
           autorefresh: true
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1220
         :name: Public Cloud Module
@@ -362,7 +362,7 @@
           enabled: true
           autorefresh: true
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1212
         :name: Advanced Systems Management Module
@@ -402,7 +402,7 @@
           enabled: true
           autorefresh: true
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1245
         :name: SUSE Linux Enterprise High Availability Extension
@@ -421,7 +421,7 @@
         - 1539
         - 1500
         :extensions:
-        - !ruby/object:SUSE::Connect::Remote::Product
+        - !ruby/object:OpenStruct
           table:
             :id: 1157
             :name: SUSE Linux Enterprise High Availability GEO Extension

--- a/test/fixtures/available_addons.yml
+++ b/test/fixtures/available_addons.yml
@@ -213,7 +213,7 @@
       :successor_ids:
       - 1324
       :extensions:
-      - &1 !ruby/object:SUSE::Connect::Remote::Product
+      - &1 !ruby/object:OpenStruct
         table:
           :id: 1157
           :name: SUSE Linux Enterprise High Availability GEO Extension

--- a/test/fixtures/available_unknown_addons.yml
+++ b/test/fixtures/available_unknown_addons.yml
@@ -1,6 +1,6 @@
 ---
 - !ruby/object:Registration::Addon
-  pure_addon: !ruby/object:SUSE::Connect::Remote::Product
+  pure_addon: !ruby/object:OpenStruct
     table:
       :id: 1153
       :name: Web and Scripting Module
@@ -43,7 +43,7 @@
     modifiable: true
   children: []
 - !ruby/object:Registration::Addon
-  pure_addon: !ruby/object:SUSE::Connect::Remote::Product
+  pure_addon: !ruby/object:OpenStruct
     table:
       :id: 1212
       :name: Advanced Systems Management Module
@@ -84,7 +84,7 @@
     modifiable: true
   children: []
 - !ruby/object:Registration::Addon
-  pure_addon: !ruby/object:SUSE::Connect::Remote::Product
+  pure_addon: !ruby/object:OpenStruct
     table:
       :id: 1223
       :name: SUSE Linux Enterprise Software Development Kit
@@ -128,7 +128,7 @@
     modifiable: true
   children: []
 - !ruby/object:Registration::Addon
-  pure_addon: !ruby/object:SUSE::Connect::Remote::Product
+  pure_addon: !ruby/object:OpenStruct
     table:
       :id: 1150
       :name: Legacy Module
@@ -171,7 +171,7 @@
     modifiable: true
   children: []
 - !ruby/object:Registration::Addon
-  pure_addon: !ruby/object:SUSE::Connect::Remote::Product
+  pure_addon: !ruby/object:OpenStruct
     table:
       :id: 1220
       :name: Public Cloud Module
@@ -213,7 +213,7 @@
     modifiable: true
   children: []
 - !ruby/object:Registration::Addon
-  pure_addon: !ruby/object:SUSE::Connect::Remote::Product
+  pure_addon: !ruby/object:OpenStruct
     table:
       :id: 1222
       :name: SUSE Linux Enterprise Workstation Extension

--- a/test/fixtures/installed_sles12_product.yml
+++ b/test/fixtures/installed_sles12_product.yml
@@ -1,5 +1,5 @@
 ---
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :arch: x86_64
     :identifier: SLES

--- a/test/fixtures/legacy_module_services.yml
+++ b/test/fixtures/legacy_module_services.yml
@@ -1,10 +1,10 @@
 ---
-- !ruby/object:SUSE::Connect::Remote::Service
+- !ruby/object:OpenStruct
   table:
     :id: 1140
     :name: Legacy_Module_12_x86_64
     :url: https://scc.suse.com/access/services/1140?credentials=Legacy_Module_12_x86_64
-    :product: !ruby/object:SUSE::Connect::Remote::Product
+    :product: !ruby/object:OpenStruct
       table:
         :id: 1150
         :name: Legacy Module

--- a/test/fixtures/migration_service.yml
+++ b/test/fixtures/migration_service.yml
@@ -1,9 +1,9 @@
---- !ruby/object:SUSE::Connect::Remote::Service
+--- !ruby/object:OpenStruct
 table:
   :id: 1311
   :name: SUSE_Linux_Enterprise_Server_12_SP1_12.1_x86_64
   :url: https://scc.suse.com/access/services/1311?credentials=SUSE_Linux_Enterprise_Server_12_SP1_12.1_x86_64
-  :product: !ruby/object:SUSE::Connect::Remote::Product
+  :product: !ruby/object:OpenStruct
     table:
       :id: 1322
       :name: SUSE Linux Enterprise Server 12 SP1
@@ -54,7 +54,7 @@ table:
         autorefresh: false
       :product_type: base
       :extensions:
-      - !ruby/object:SUSE::Connect::Remote::Product
+      - !ruby/object:OpenStruct
         table:
           :id: 1323
           :name: SUSE Linux Enterprise Software Development Kit
@@ -110,7 +110,7 @@ table:
           :product_type: extension
           :extensions: []
         modifiable: true
-      - !ruby/object:SUSE::Connect::Remote::Product
+      - !ruby/object:OpenStruct
         table:
           :id: 1324
           :name: SUSE Linux Enterprise High Availability Extension

--- a/test/fixtures/migration_sles15_activated_products.yml
+++ b/test/fixtures/migration_sles15_activated_products.yml
@@ -1,5 +1,5 @@
 ---
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1421
     :name: SUSE Linux Enterprise Server
@@ -56,7 +56,7 @@
       autorefresh: true
     :product_type: base
     :extensions:
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1574
         :name: SUSE Manager for Retail
@@ -110,7 +110,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1536
         :name: SUSE Linux Enterprise Live Patching
@@ -161,7 +161,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1153
         :name: Web and Scripting Module
@@ -224,7 +224,7 @@
         :product_type: module
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1518
         :name: SUSE Manager Server
@@ -280,7 +280,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1678
         :name: SUSE Cloud Application Platform Tools Module
@@ -340,7 +340,7 @@
         :product_type: module
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1427
         :name: SUSE Linux Enterprise Software Development Kit
@@ -403,7 +403,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1617
         :name: SUSE OpenStack Cloud
@@ -457,7 +457,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1220
         :name: Public Cloud Module
@@ -518,7 +518,7 @@
         :product_type: module
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1526
         :name: SUSE Enterprise Storage
@@ -573,7 +573,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1529
         :name: SUSE Package Hub
@@ -624,7 +624,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1725
         :name: SUSE Manager Proxy
@@ -680,7 +680,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1729
         :name: SUSE OpenStack Cloud Crowbar
@@ -734,7 +734,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1431
         :name: SUSE Linux Enterprise Workstation Extension
@@ -799,7 +799,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1212
         :name: Advanced Systems Management Module
@@ -858,7 +858,7 @@
         :product_type: module
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1520
         :name: SUSE Manager Proxy
@@ -914,7 +914,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1618
         :name: SUSE Linux Enterprise Server BCL
@@ -973,7 +973,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1150
         :name: Legacy Module
@@ -1035,7 +1035,7 @@
         :product_type: module
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1724
         :name: SUSE Manager Server
@@ -1091,7 +1091,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1730
         :name: HPE Helion OpenStack Cloud
@@ -1145,7 +1145,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1432
         :name: SUSE Linux Enterprise High Availability Extension
@@ -1198,7 +1198,7 @@
           autorefresh: true
         :product_type: extension
         :extensions:
-        - !ruby/object:SUSE::Connect::Remote::Product
+        - !ruby/object:OpenStruct
           table:
             :id: 1435
             :name: SUSE Linux Enterprise High Availability GEO Extension
@@ -1255,7 +1255,7 @@
             :extensions: []
           modifiable: true
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1349
         :name: SUSE Manager Server
@@ -1311,7 +1311,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1352
         :name: SUSE Manager Proxy
@@ -1367,7 +1367,7 @@
         :product_type: extension
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1440
         :name: HPC Module
@@ -1427,7 +1427,7 @@
         :product_type: module
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1332
         :name: Containers Module
@@ -1482,7 +1482,7 @@
         :product_type: module
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1341
         :name: Toolchain Module
@@ -1533,7 +1533,7 @@
         :product_type: module
         :extensions: []
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1619
         :name: SUSE Linux Enterprise Real Time

--- a/test/fixtures/migration_to_sles12_sp1.yml
+++ b/test/fixtures/migration_to_sles12_sp1.yml
@@ -1,5 +1,5 @@
 ---
-- - !ruby/object:SUSE::Connect::Remote::Product
+- - !ruby/object:OpenStruct
     table:
       :identifier: SLES
       :version: '12.1'

--- a/test/fixtures/migration_to_sles15.yml
+++ b/test/fixtures/migration_to_sles15.yml
@@ -1,5 +1,5 @@
 ---
-- - !ruby/object:SUSE::Connect::Remote::Product
+- - !ruby/object:OpenStruct
     table:
       :identifier: SLES
       :version: '15-0'

--- a/test/fixtures/pure_addons.yml
+++ b/test/fixtures/pure_addons.yml
@@ -1,5 +1,5 @@
 ---
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1222
     :name: SUSE Linux Enterprise Workstation Extension
@@ -60,7 +60,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1223
     :name: SUSE Linux Enterprise Software Development Kit
@@ -103,7 +103,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1150
     :name: Legacy Module
@@ -146,7 +146,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1153
     :name: Web and Scripting Module
@@ -190,7 +190,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1220
     :name: Public Cloud Module
@@ -231,7 +231,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1212
     :name: Advanced Systems Management Module
@@ -271,7 +271,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1245
     :name: SUSE Linux Enterprise High Availability Extension
@@ -290,7 +290,7 @@
     - 1539
     - 1500
     :extensions:
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1157
         :name: SUSE Linux Enterprise High Availability GEO Extension

--- a/test/fixtures/remote_product.yml
+++ b/test/fixtures/remote_product.yml
@@ -1,4 +1,4 @@
---- !ruby/object:SUSE::Connect::Remote::Product
+--- !ruby/object:OpenStruct
 table:
   :id: 1117
   :name: SUSE Linux Enterprise Server
@@ -21,7 +21,7 @@ table:
   - 1219
   - 1478
   :extensions:
-  - !ruby/object:SUSE::Connect::Remote::Product
+  - !ruby/object:OpenStruct
     table:
       :id: 1222
       :name: SUSE Linux Enterprise Workstation Extension
@@ -67,7 +67,7 @@ table:
         enabled: true
         autorefresh: true
     modifiable: true
-  - !ruby/object:SUSE::Connect::Remote::Product
+  - !ruby/object:OpenStruct
     table:
       :id: 1223
       :name: SUSE Linux Enterprise Software Development Kit
@@ -110,7 +110,7 @@ table:
         enabled: true
         autorefresh: true
     modifiable: true
-  - !ruby/object:SUSE::Connect::Remote::Product
+  - !ruby/object:OpenStruct
     table:
       :id: 1150
       :name: Legacy Module
@@ -143,7 +143,7 @@ table:
         enabled: true
         autorefresh: false
     modifiable: true
-  - !ruby/object:SUSE::Connect::Remote::Product
+  - !ruby/object:OpenStruct
     table:
       :id: 1153
       :name: Web and Scripting Module
@@ -176,7 +176,7 @@ table:
         enabled: true
         autorefresh: false
     modifiable: true
-  - !ruby/object:SUSE::Connect::Remote::Product
+  - !ruby/object:OpenStruct
     table:
       :id: 1220
       :name: Public Cloud Module
@@ -209,7 +209,7 @@ table:
         enabled: true
         autorefresh: false
     modifiable: true
-  - !ruby/object:SUSE::Connect::Remote::Product
+  - !ruby/object:OpenStruct
     table:
       :id: 1212
       :name: Advanced Systems Management Module
@@ -239,7 +239,7 @@ table:
         enabled: true
         autorefresh: false
     modifiable: true
-  - !ruby/object:SUSE::Connect::Remote::Product
+  - !ruby/object:OpenStruct
     table:
       :id: 1155
       :name: SUSE Linux Enterprise High Availability Extension
@@ -258,7 +258,7 @@ table:
       - 1242
       - 1500
       :extensions:
-      - !ruby/object:SUSE::Connect::Remote::Product
+      - !ruby/object:OpenStruct
         table:
           :id: 1157
           :name: SUSE Linux Enterprise High Availability GEO Extension

--- a/test/fixtures/sle15_addons.yaml
+++ b/test/fixtures/sle15_addons.yaml
@@ -65,7 +65,7 @@
       :shortname: Basesystem-Module
       :recommended: true
       :extensions:
-      - &1 !ruby/object:SUSE::Connect::Remote::Product
+      - &1 !ruby/object:OpenStruct
         table:
           :id: 1578
           :name: Desktop Applications Module
@@ -130,7 +130,7 @@
           :shortname: Desktop-Applications-Module
           :recommended: false
           :extensions:
-          - &6 !ruby/object:SUSE::Connect::Remote::Product
+          - &6 !ruby/object:OpenStruct
             table:
               :id: 1579
               :name: Development Tools Module
@@ -197,7 +197,7 @@
               :recommended: false
               :extensions: []
             modifiable: true
-          - &8 !ruby/object:SUSE::Connect::Remote::Product
+          - &8 !ruby/object:OpenStruct
             table:
               :id: 1580
               :name: Server Applications Module
@@ -264,7 +264,7 @@
               :recommended: false
               :extensions: []
             modifiable: true
-          - &9 !ruby/object:SUSE::Connect::Remote::Product
+          - &9 !ruby/object:OpenStruct
             table:
               :id: 1583
               :name: SUSE Linux Enterprise Workstation Extension
@@ -332,7 +332,7 @@
               :recommended: false
               :extensions: []
             modifiable: true
-          - &10 !ruby/object:SUSE::Connect::Remote::Product
+          - &10 !ruby/object:OpenStruct
             table:
               :id: 15831
               :name: SUSE Linux Enterprise Workstation Extension
@@ -401,7 +401,7 @@
               :extensions: []
             modifiable: true
         modifiable: true
-      - &3 !ruby/object:SUSE::Connect::Remote::Product
+      - &3 !ruby/object:OpenStruct
         table:
           :id: 1581
           :name: Legacy Module
@@ -471,7 +471,7 @@
           :recommended: false
           :extensions: []
         modifiable: true
-      - &4 !ruby/object:SUSE::Connect::Remote::Product
+      - &4 !ruby/object:OpenStruct
         table:
           :id: 1611
           :name: Public Cloud Module
@@ -533,7 +533,7 @@
           :recommended: false
           :extensions: []
         modifiable: true
-      - &5 !ruby/object:SUSE::Connect::Remote::Product
+      - &5 !ruby/object:OpenStruct
         table:
           :id: 1582
           :name: SUSE Linux Enterprise High Availability Extension

--- a/test/migration_repos_workflow_spec.rb
+++ b/test/migration_repos_workflow_spec.rb
@@ -281,7 +281,7 @@ describe Registration::UI::MigrationReposWorkflow do
 
     it "asks for confirmation if the system was already migrated" do
       # pretend SLES15 is already activated
-      sles15 = SUSE::Connect::Remote::Product.new(
+      sles15 = OpenStruct.new(
         arch:       "x86_64",
         identifier: "SLES",
         version:    "15"

--- a/test/registration/package_search_test.rb
+++ b/test/registration/package_search_test.rb
@@ -118,7 +118,9 @@ describe Registration::PackageSearch do
 
     it "limits the search to the given product" do
       expect(SUSE::Connect::PackageSearch).to receive(:search) do |_name, product:|
-        expect(product.to_triplet).to eq("SLES/15.2/x86_64")
+        expect(product.identifier).to eq("SLES")
+        expect(product.version).to eq("15.2")
+        expect(product.arch).to eq("x86_64")
         packages
       end
       subject.packages

--- a/test/registration/storage/config_test.rb
+++ b/test/registration/storage/config_test.rb
@@ -158,34 +158,34 @@ describe Registration::Storage::Config do
     end
 
     let(:sles_activation) do
-      SUSE::Connect::Remote::Activation.new(
+      OpenStruct.new(
         "regcode" => "0123456789",
-        "service" => {
-          "product" => {
+        "service" => OpenStruct.new(
+          "product" => OpenStruct.new(
             "name" => "SUSE Linux Enteprise Server", "identifier" => "SLES", "isbase" => true
-          }
-        }
+          )
+        )
       )
     end
 
     let(:basesystem_activation) do
-      SUSE::Connect::Remote::Activation.new(
-        "service" => {
-          "product" => {
+      OpenStruct.new(
+        "service" => OpenStruct.new(
+          "product" => OpenStruct.new(
             "name" => "Basesystem Module", "identifier" => "sle-basesystem"
-          }
-        }
+          )
+        )
       )
     end
 
     let(:workstation_activation) do
-      SUSE::Connect::Remote::Activation.new(
+      OpenStruct.new(
         "regcode" => "ABCDEFGHIJ",
-        "service" => {
-          "product" => {
+        "service" => OpenStruct.new(
+          "product" => OpenStruct.new(
             "name" => "Workstation Extension", "identifier" => "sle-we"
-          }
-        }
+          )
+        )
       )
     end
 

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -16,7 +16,6 @@ describe Registration::Registration do
       reg_code = "reg_code"
       target_distro = "sles-12-x86_64"
 
-      expect_any_instance_of(SUSE::Connect::Credentials).to receive(:write)
       expect(SUSE::Connect::YaST).to(receive(:announce_system)
         .with(hash_including(token: reg_code), target_distro)
         .and_return([username, password]))
@@ -45,11 +44,11 @@ describe Registration::Registration do
       {
         "name"    => "service",
         "url"     => "https://example.com",
-        "product" => product
+        "product" => OpenStruct.new(product)
       }
     end
 
-    let(:service) { SUSE::Connect::Remote::Service.new(service_data) }
+    let(:service) { OpenStruct.new(service_data) }
     let(:destdir) { "/foo" }
 
     before do
@@ -82,11 +81,9 @@ describe Registration::Registration do
       allow(Yast::Stage).to receive(:initial).and_return(false)
       expect(Yast::Installation).to_not receive(:destdir)
 
-      expect(File).to receive(:exist?).with(SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE)
-        .and_return(true)
-
-      expect(File).to receive(:read).with(SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE)
-        .and_return("username=SCC_foo\npassword=bar")
+      expect(SUSE::Connect::YaST).to receive(:credentials)
+        .with(SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE)
+        .and_return(OpenStruct.new(username: "SCC_foo", password: "bar"))
 
       subject.send(yast_method, product)
     end

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -181,9 +181,9 @@ describe Registration::SwMgmt do
 
   describe ".add_services" do
     let(:service_url) { "https://example.com/foo/bar?credentials=TEST_credentials" }
-    let(:credentials) { SUSE::Connect::Credentials.new("user", "password", "file") }
+    let(:credentials) { OpenStruct.new(username: "user", password: "password", file: "file") }
     let(:product_service) do
-      SUSE::Connect::Remote::Service.new(
+      OpenStruct.new(
         "name"    => service_name,
         "url"     => service_url,
         "product" => {}
@@ -194,7 +194,7 @@ describe Registration::SwMgmt do
       expect(Yast::Pkg).to receive(:SourceSaveAll).and_return(true).twice
       expect(Yast::Pkg).to receive(:ServiceForceRefresh).with(service_name).and_return(true)
       expect(Yast::Pkg).to receive(:ServiceSave).with(service_name).and_return(true)
-      expect_any_instance_of(SUSE::Connect::Credentials).to receive(:write)
+      expect(SUSE::Connect::YaST).to receive(:create_credentials_file)
 
       allow(Yast::Pkg).to receive(:SourceGetCurrent).with(false).and_return(repos.keys)
       repos.each do |id, repo|

--- a/test/url_helpers_spec.rb
+++ b/test/url_helpers_spec.rb
@@ -110,15 +110,6 @@ describe "Registration::UrlHelpers" do
           .and_return(false)
         expect(Registration::UrlHelpers.registration_url).to be_nil
       end
-
-      it "reads the URL from config file if present" do
-        # stub config file reading
-        url = "https://example.com"
-        expect(File).to receive(:exist?).with(SUSE::Connect::YaST::DEFAULT_CONFIG_FILE)
-          .and_return(true).twice
-        expect(YAML).to receive(:load_file).and_return("url" => url, "insecure" => false)
-        expect(Registration::UrlHelpers.registration_url).to eq(url)
-      end
     end
 
     context "at upgrade" do
@@ -166,7 +157,7 @@ describe "Registration::UrlHelpers" do
         end
 
         it "returns URL of RMT server" do
-          expect(File).to receive(:exist?).with(fixtures_file("SUSEConnect")).and_return(true)
+          allow(File).to receive(:exist?).with(fixtures_file("SUSEConnect")).and_return(true)
           expect(SUSE::Connect::Config).to receive(:new).with(suse_connect)
             .and_return(SUSE::Connect::Config.new(fixtures_file("SUSEConnect")))
           expect(Registration::UrlHelpers.registration_url).to eq("https://myserver.com")


### PR DESCRIPTION
Most functions return generic OpenStruct instead of specialized classes.
Some features (only used in tests) are missing (e.g. Product.to_triplet).
Asserts related to internal implementation details were removed or
converted to higher level (e.g. File mocks).