### PR TITLE
Self-update: Improve and unify the behavior (bsc#1193536)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec  9 15:08:57 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Improve the self-update process, do not read the products from
+  the installation medium (bsc#1193536)
+- 4.4.6
+
+-------------------------------------------------------------------
 Fri Nov 12 14:51:45 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Adapt to the ProductSpec API (bsc#1192626).

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.4.5
+Version:        4.4.6
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -203,23 +203,25 @@ module Registration
       migration_paths
     end
 
-    # Get the list of updates for a base product or self_update_id if defined
+    # Get the list of installer updates for self_update_id and self_update_version
+    # (the fallback version is read from the /etc/os-release file).
     #
     # @return [Array<String>] List of URLs of updates repositories.
     #
-    # @see SwMgmt.base_product_to_register
-    # @see SwMgmt.remote_product
+    # @see SwMgmt.installer_update_base_product
     # @see SUSE::Connect::Yast.list_installer_updates
     def get_updates_list
       id = Yast::ProductFeatures.GetStringFeature("globals", "self_update_id")
-      product = SwMgmt.installer_update_base_product(id) || SwMgmt.base_product_to_register
-      return [] unless product
+      return [] if id.empty?
+      version = Yast::ProductFeatures.GetStringFeature("globals", "self_update_version")
+      version = Yast::OSRelease.ReleaseVersion if version.empty?
+      product = SwMgmt.installer_update_base_product(id, version)
 
-      log.info "Reading available updates for product: #{product["name"]}"
+      log.info "Reading available installer updates for product: #{product}"
       remote_product = SwMgmt.remote_product(product)
       updates = SUSE::Connect::YaST.list_installer_updates(remote_product, connect_params)
 
-      log.info "Updates for '#{product["name"]}' are available at '#{updates}'"
+      log.info "Installer updates for '#{product["name"]}' are available at '#{updates}'"
       updates
     end
 

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -132,6 +132,8 @@ module Registration
     # @return [Hash,nil] with pkg-binding format; return nil if the
     # given self_update_id is empty
     def self.installer_update_base_product(self_update_id, version = "")
+      return if self_update_id.empty?
+
       product_info = {
         "name"         => self_update_id,
         "arch"         => Yast::Arch.rpm_arch,

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -40,6 +40,7 @@ require "yast2/execute"
 require "y2packager/resolvable"
 
 module Registration
+  Yast.import "Arch"
   Yast.import "AddOnProduct"
   Yast.import "Mode"
   Yast.import "Stage"
@@ -48,6 +49,7 @@ module Registration
   Yast.import "PackageLock"
   Yast.import "Installation"
   Yast.import "PackageCallbacks"
+  Yast.import "OSRelease"
   Yast.import "Popup"
   Yast.import "Product"
 
@@ -123,27 +125,17 @@ module Registration
       true
     end
 
-    # Prepare a pkg-binding product hash using the first base product available
-    # as a template and with the given self_update_id as the product name.
-    #
-    # With a media containing multiple products it is expected that all the
-    # products use the same version and arch.
+    # Prepare a pkg-binding product hash using the requested name and version,
+    # if the version is empty the fallback from the /etc/os-release file is used.
     #
     # @param self_update_id [String] product name to be used for get the installer updates
     # @return [Hash,nil] with pkg-binding format; return nil if the
-    # given self_update_id is empty or there is no base product available
-    def self.installer_update_base_product(self_update_id)
-      return if self_update_id.empty?
-
-      # TODO: does offline makes sense for self update?
-      base_product = Y2Packager::ProductSpec.base_products.first
-      return unless base_product
-
-      # filter out not needed data
+    # given self_update_id is empty
+    def self.installer_update_base_product(self_update_id, version = "")
       product_info = {
         "name"         => self_update_id,
-        "arch"         => base_product.arch,
-        "version"      => version_without_release(base_product),
+        "arch"         => Yast::Arch.rpm_arch,
+        "version"      => version,
         "release_type" => nil
       }
 

--- a/test/registration/clients/scc_auto_test.rb
+++ b/test/registration/clients/scc_auto_test.rb
@@ -91,6 +91,8 @@ describe Registration::Clients::SCCAuto do
       allow(Y2Packager::ProductSpec).to receive(:base_products).and_return([])
       # clean cache
       ::Registration::Storage::Cache.instance.addon_services = []
+      allow(Registration::UrlHelpers).to receive(:slp_discovery_feedback).and_return([])
+      allow(::Registration::SwMgmt).to receive(:init)
     end
 
     it "just returns true if config is not set to register and mode is not update" do

--- a/test/scc_test.rb
+++ b/test/scc_test.rb
@@ -19,6 +19,7 @@ describe "scc client" do
     allow(Registration::SwMgmt).to receive(:init)
     allow(Registration::SwMgmt).to receive(:find_base_product).and_return("name" => "SLES")
     allow(Registration::Registration).to receive(:is_registered?)
+    allow(Registration::UrlHelpers).to receive(:slp_discovery_feedback).and_return([])
   end
 
   context "the system is already registered" do

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -123,42 +123,15 @@ describe Registration::SwMgmt do
   end
 
   describe ".installer_update_base_product" do
-    let(:base_product) do
-      instance_double(Y2Packager::ProductSpec, name: "dummy", version: "15.0", arch: "x86_64")
-    end
-    let(:base_products) { [base_product] }
-
-    before do
-      allow(Y2Packager::ProductSpec).to receive(:base_products).and_return(base_products)
-      allow(Y2Packager::MediumType).to receive(:online?).and_return(false)
-      allow(Y2Packager::MediumType).to receive(:offline?).and_return(false)
-    end
-
     it "returns nil if the given self_update_id is empty" do
       expect(subject.installer_update_base_product("")).to eq(nil)
     end
 
-    context "when there is no base product available" do
-      let(:base_products) { [] }
-
-      it "returns nil" do
-        allow(Y2Packager::ProductSpec).to receive(:base_products).and_return([])
-        expect(subject.installer_update_base_product("self_update_id")).to eq(nil)
-      end
-    end
-
-    context "when there is some product available" do
-      it "returns a hash with the product keys 'name', 'version', 'arch' and 'release_type' " do
-        product = subject.installer_update_base_product("self_update_id")
-        expect(product).to be_a(Hash)
-        expect(product.keys.size).to eq(4)
-        expect(product).to include("name", "version", "arch", "release_type")
-      end
-
-      it "uses the given self_update_id as the product name returned" do
-        product = subject.installer_update_base_product("self_update_id")
-        expect(product["name"]).to eq("self_update_id")
-      end
+    it "returns the product hash" do
+      expect(subject.installer_update_base_product("SLES", "15.4")).to include(
+        "name"    => "SLES",
+        "version" => "15.4"
+      )
     end
   end
 


### PR DESCRIPTION
## The Problem

Originally I wanted to speed up the product evaluation on the SLE Full medium, it takes more than 15 seconds to just get the SLES version. :grimacing: See the screencast below. I used a trick with using `libsolv` directly and skipping the slow libzypp part. See https://github.com/yast/yast-installation/pull/996.

But later I wanted to compare it with the Online medium workflow and it turned out that it behaves completely differently and it does not need to scan the products on the medium (well, because there are none...). It should behave consistently, having a different behavior and implementation for each medium (Full vs. Online) makes it difficult to debug and to do changes. Why not using the same approach on both media?

## The Old Behavior

Here is a summary how the old self-update worked:

- If a custom URL is passed via `self_update` boot option or via the AutoYaST profile then that URL is used
- If registration is available (on SLE media, not in openSUSE) then the installer asks the SCC/SMT server for the self-update repository. To get the repository the installer needs to sent the product which is being installed. The name of the product is defined in the `control.xml`. The version is read from different source:
  - Full medium: scan the installation repository and find the product defined in `control.xml` on the medium, use its version
  - Online medium: find the product version in the online product definition in `control.xml` *(there is actually a bug, it uses the first found product, not the requested SLES, accidentally it works fine :open_mouth: )*
  Then that product is sent to SCC/SMT and it returns the self-update URL
- If that fails the fallback URL template is read from `control.xml` and the product version is read from the `/etc/os-release` file... :scream: 

As you can see the product version is actually read from three (!) different sources but it is still not flexible enough as it does not easily allow detecting the quarterly updates.

## The Proposal

Let's unify and simplify that process, there is no reason why it should behave differently and slowly on the Full medium.

- Use the custom URL the same way, that's fine
- For the SCC/SMT case do not scan the products in the repository, that's not needed and just takes time (lot of time on Full medium....). Instead do:
  - Read the product name and optionally the version from the `control.xml` (we already did that on the Online medium), if the version is missing read the fallback from the `/etc/os-release` file. This makes it simple and flexible, the installer can use the default version from the inst-sys, but the product creators can easily override that in `control.xml` if needed.
- Then use the fallback as in the old way

## Advantages

- Fast also on Full medium
- Unified, works the same way with all media

### Support for Other Products

Currently the self-update is only used in the SLE installer but this improvement would allow using it also elsewhere.

- **SLE Micro** - based on SLE but has a different release cycle so it cannot reuse the same SLE installer update repositories. In theory we could add this to the `control.xml`:
  ```xml
  <globals>
    <self_update_id>SLE-Micro</self_update_id>
    <self_update_version>5.2</self_update_id>
  </globals>
  ```
  Then the SCC/SMT could distinguish it from regular SLE although it would be based on the same/similar package set.

- **SLE Quarterly Updates (QU)** - currently the quarterly updates have the self-update feature completely removed because YaST was unable to differ a QU respin from the GA release. Similarly to the previous case, we could use a specific `self_update_version` to indicate a QU release:
  ```xml
  <globals>
    <self_update_id>SLES</self_update_id>
    <self_update_version>15.4-QU3</self_update_id>
  </globals>
  ```
  (Or use version like `15.4.3`, depends what we agree on...)

- **openSUSE Leap** - it this case we could just use the hardcoded fallback in `control.xml` as openSUSE does not use the SCC/SMT registratuion.

## Other Related Pull Requests

- https://github.com/yast/yast-installation/pull/1000 - do not add the initial reposiotory, not need in the self update workflow anymore
- https://github.com/yast/yast-installation-control/pull/114 - update the schema definition, added the `self_update_version` definition

## Testing

- Tested manually in the latest SP4 builds (both Full and Online media)
- Additionally I have added missing mocks which caused to run the SLP discovery and initializing the package manager in the tests. That also decreased the test run from about 7 seconds to about 1 second. :+1: 

## Screencasts

This is the original behavior on the Full SP4 medium, as you can see it takes very long time to add all repositories present on the medium:
![self_update_orig](https://user-images.githubusercontent.com/907998/145249087-0b0ac1f6-9ad4-43f5-9145-0bcd30cbb2fd.gif)

This is the patched installer, it does not scan the products on the medium so it is much faster:
![self_update_fast](https://user-images.githubusercontent.com/907998/145249488-fcd7647c-6d8e-4097-8132-496c053a7454.gif)
