### PR TITLE
Typo fix in Help Text

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 16 13:51:06 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed typo (bsc#1193800)
+- 4.4.7
+
+-------------------------------------------------------------------
 Thu Dec  9 15:08:57 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Improve the self-update process, do not read the products from

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.4.6
+Version:        4.4.7
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/ui/addon_selection_registration_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_registration_dialog.rb
@@ -31,7 +31,7 @@ module Registration
           _("Extension and Module Selection"),
           content,
           # help text (1/3)
-          _("<p>Here you can select available extensions and modules for your"\
+          _("<p>Here you can select available extensions and modules for your "\
               "system.</p>") + generic_help_text + checkboxes_help,
           # always enable Back/Next, the dialog cannot be the first in workflow
           true,


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1193800

## Problem

"yoursystem" in help text instead of "your system"

![typo_help_ext_and_mod_sel](https://user-images.githubusercontent.com/11538225/146384546-8c12d13e-08d5-4bc2-9d75-a5437acdc040.png)


## Cause

Missing blank at the end of text lines that are joined with a backslash `\`, so the words are not separated by a delimiter.