### PR TITLE
Fixed Rubygem FFI dependencies

### DIFF
--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -34,6 +34,9 @@ BuildRequires:  yast2-slp >= 3.1.9
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake) >= 0.2.5
 BuildRequires:  suseconnect-ruby-bindings
+# FFI is needed by suseconnect-ruby-bindings, this ensures the correct Ruby version
+# is installed, it fixes the "have choice for rubygem(ffi)" dependency problem
+BuildRequires:  rubygem(%{rb_default_ruby_abi}:ffi)
 # ProductSpec API
 BuildRequires:  yast2-packager >= 4.4.13
 BuildRequires:  yast2-update >= 3.1.36
@@ -45,6 +48,9 @@ Requires:       yast2-pkg-bindings >= 3.1.34
 # N_() method
 Requires:       yast2-ruby-bindings >= 3.1.12
 Requires:       suseconnect-ruby-bindings
+# FFI is needed by suseconnect-ruby-bindings, this ensures the correct Ruby version
+# is installed, it fixes the "have choice for rubygem(ffi)" dependency problem
+Requires:       rubygem(%{rb_default_ruby_abi}:ffi)
 Requires:       yast2-add-on >= 3.1.8
 Requires:       yast2-slp >= 3.1.9
 # ProductSpec API


### PR DESCRIPTION
- Fixes "unresolvable: have choice for rubygem(ffi) needed by suseconnect-ruby-bindings: ruby2.7-rubygem-ffi ruby3.0-rubygem-ffi" build issue
- See https://ci.opensuse.org/job/yast-yast-registration-master/127/console