### PR TITLE
Removed rubygem-ffi dependency

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 10 09:51:02 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Removed rubygem-ffi dependency, suse-connect-ng now uses
+  Fiddle which is part of Ruby stdlib (related to jsc#CSD-21)
+- 4.4.11
+
+-------------------------------------------------------------------
 Fri Dec 31 16:11:06 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Adapt to ruby3.1 (bsc#1193192)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.4.10
+Version:        4.4.11
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only
@@ -33,10 +33,8 @@ BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-slp >= 3.1.9
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake) >= 0.2.5
-BuildRequires:  suseconnect-ruby-bindings
-# FFI is needed by suseconnect-ruby-bindings, this ensures the correct Ruby version
-# is installed, it fixes the "have choice for rubygem(ffi)" dependency problem
-BuildRequires:  rubygem(%{rb_default_ruby_abi}:ffi)
+# uses Fiddle instead of FFI
+BuildRequires:  suseconnect-ruby-bindings >= 0.0.5
 # ProductSpec API
 BuildRequires:  yast2-packager >= 4.4.13
 BuildRequires:  yast2-update >= 3.1.36
@@ -47,10 +45,8 @@ Requires:       yast2 >= 4.4.21
 Requires:       yast2-pkg-bindings >= 3.1.34
 # N_() method
 Requires:       yast2-ruby-bindings >= 3.1.12
-Requires:       suseconnect-ruby-bindings
-# FFI is needed by suseconnect-ruby-bindings, this ensures the correct Ruby version
-# is installed, it fixes the "have choice for rubygem(ffi)" dependency problem
-Requires:       rubygem(%{rb_default_ruby_abi}:ffi)
+# uses Fiddle instead of FFI
+Requires:       suseconnect-ruby-bindings >= 0.0.5
 Requires:       yast2-add-on >= 3.1.8
 Requires:       yast2-slp >= 3.1.9
 # ProductSpec API


### PR DESCRIPTION
- suse-connect-ng now uses Fiddle which is part of Ruby stdlib
- See https://github.com/SUSE/connect-ng/pull/111
- 4.4.11