### PR TITLE
Unify YaST module mocking in unit tests

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 21 06:29:22 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Unify YaST module mocking in unit tests (related to bsc#1194784)
+- 4.4.12
+
+-------------------------------------------------------------------
 Mon Jan 10 09:51:02 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Removed rubygem-ffi dependency, suse-connect-ng now uses

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.4.11
+Version:        4.4.12
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only
@@ -38,6 +38,8 @@ BuildRequires:  suseconnect-ruby-bindings > 0.0.4
 # ProductSpec API
 BuildRequires:  yast2-packager >= 4.4.13
 BuildRequires:  yast2-update >= 3.1.36
+# yast/rspec/helpers.rb
+BuildRequires:  yast2-ruby-bindings >= 4.4.7
 
 # ProductSpec API
 Requires:       yast2 >= 4.4.21

--- a/test/registration/clients/scc_auto_test.rb
+++ b/test/registration/clients/scc_auto_test.rb
@@ -2,17 +2,6 @@
 
 require_relative "../../spec_helper"
 
-# we have enabled strict method checking in rspec, so we need to define profile method
-# by opening class. Profile is stubbed, so it is just fake class
-
-module Yast
-  class Profile
-    def self.current
-      {}
-    end
-  end
-end
-
 describe Registration::Clients::SCCAuto do
   let(:config) { ::Registration::Storage::Config.instance }
 

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -81,6 +81,7 @@ def load_yaml_fixture(file)
 end
 
 require "yast"
+require "yast/rspec"
 require "y2packager/product"
 def stub_product_selection
   name = "AutoinstFunctions"
@@ -98,14 +99,8 @@ end
 
 stub_product_selection
 
-# stub module to prevent its Import
-# Useful for modules from different yast packages, to avoid build dependencies
-def stub_module(name)
-  Yast.const_set name.to_sym, Class.new { def self.fake_method; end }
-end
-
 # stub classes from other modules to avoid build dependencies
-stub_module("Profile")
+Yast::RSpec::Helpers.define_yast_module("Profile", methods: [:current])
 
 # load data generators
 require_relative "factories"


### PR DESCRIPTION
- Use the new YaST RSpec helper everywhere