### PR TITLE
Use isbase

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 24 15:29:29 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix detection of base products coming from SCC (bsc#1194989).
+- 4.4.13
+
+-------------------------------------------------------------------
 Fri Jan 21 06:29:22 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Unify YaST module mocking in unit tests (related to bsc#1194784)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.4.12
+Version:        4.4.13
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -562,7 +562,7 @@ module Registration
 
       # update the $releasever
       def update_releasever
-        new_base = selected_migration.find(&:base)
+        new_base = selected_migration.find(&:isbase)
 
         if new_base
           log.info "Activating new $releasever for base product: #{new_base}"

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -181,7 +181,7 @@ module Registration
 
       # @return [String] textual representation of base product living in arr
       def base_product_text_for(arr)
-        base_product = arr.find(&:base)
+        base_product = arr.find(&:isbase)
         base_product.friendly_name || base_product.short_name ||
           (base_product.identifier + "-" + base_product.version)
       end

--- a/test/fixtures/migration_sles15_offline_migrations.yml
+++ b/test/fixtures/migration_sles15_offline_migrations.yml
@@ -7,7 +7,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: true
+      :isbase: true
       :product_type: base
       :free: false
       :release_stage: beta
@@ -19,7 +19,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -31,7 +31,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -43,7 +43,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -55,7 +55,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -67,7 +67,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -79,7 +79,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -91,7 +91,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -103,7 +103,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -115,7 +115,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released

--- a/test/fixtures/migration_to_sles12_sp1.yml
+++ b/test/fixtures/migration_to_sles12_sp1.yml
@@ -7,5 +7,5 @@
       :release_type: 
       :friendly_name: SUSE Linux Enterprise Server SP1 x86_64
       :shortname: SLES12-SP1
-      :base: true
+      :isbase: true
       :product_type: base


### PR DESCRIPTION
Bug: [bsc#1194989](https://bugzilla.suse.com/show_bug.cgi?id=1194989)
Trello: https://trello.com/c/LX0JUO1E/

Starting in `SP4`, the `#base` method on objects coming from SCC does not seem to work anymore (it always returns `nil`, like any other non-existent method). Instead, using `isbase` works just fine.

See [comment 3](https://bugzilla.suse.com/show_bug.cgi?id=1194989#c3) in the bug report for further information.