### PR TITLE
[bsc#1194440] Do not try to read regcode when the short_name is unknown

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jan 31 11:36:53 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not read registration codes from a USB stick when using
+  AutoYaST to upgrade a system with the online installation medium
+  (related to bsc#1194440).
+- 4.4.15
+
+-------------------------------------------------------------------
 Fri Jan 28 14:04:30 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Handle service name collision during upgrade (bsc#1194453),

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.4.14
+Version:        4.4.15
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/clients/scc_auto.rb
+++ b/src/lib/registration/clients/scc_auto.rb
@@ -95,7 +95,7 @@ module Registration
         # merge reg code if not defined in the profile but
         # available from other sources
         product = Yast::AutoinstFunctions.selected_product
-        if product && !settings["reg_code"]
+        if product&.respond_to?(:short_name) && !settings["reg_code"]
           reg_codes_loader = ::Registration::Storage::RegCodes.instance
           settings["reg_code"] = reg_codes_loader.reg_codes[product.short_name] || ""
         end


### PR DESCRIPTION
Bug report: [bsc#1194440](https://bugzilla.suse.com/1194440)

When running the auto-upgrade using the online medium, the product's short name is unknown when the registration configuration is being imported (there are no repositories yet), so it is not possible to read the reg codes from a USB stick. Ideally, we could include the short name in the control file. But, for now, we just avoid reading the reg codes in such a scenario.