### PR TITLE
Makes the addon selector more "themeable"

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 23 11:34:03 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Makes the addon selector more "themeable" (bsc#1196362).
+- 4.4.16
+
+-------------------------------------------------------------------
 Mon Jan 31 11:36:53 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not read registration codes from a USB stick when using

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.4.15
+Version:        4.4.16
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/ui/addon_selection_base_dialog.rb
+++ b/src/lib/registration/ui/addon_selection_base_dialog.rb
@@ -177,14 +177,13 @@ module Registration
 
           image = (installation ? "inst:" : "normal:") +
             selected + ":" + (enabled ? "enabled" : "disabled")
-          color = installation ? "white" : "black"
 
           check = "<img src='#{IMAGE_DIR}/#{IMAGES[image]}'></img>"
           widget = "#{check} #{label}"
           enabled_widget = if enabled
-            "<a href='#{id}' style='text-decoration:none; color:#{color}'>#{widget}</a>"
+            "<a href='#{id}' class='enabled-item'>#{widget}</a>"
           else
-            "<span style='color:grey'>#{widget}</span>"
+            "<span class='disabled-item'>#{widget}</span>"
           end
           "<p>#{INDENT}#{enabled_widget}</p>"
         end


### PR DESCRIPTION
# TL;DR

Read https://github.com/yast/yast-registration/pull/566#issuecomment-1031412078

# The Long Story

While working on a light theme, @jhmarina couldn't style the "Extension and Module Selection" dialog for a registered system, ending up with an almost empty (and not usable at all) screen.

## Why?

Because the styles for the checkboxes are neither, in the .qss nor the _richtext.css_ file. Instead, they are [hard-coded in the HTML](https://github.com/yast/yast-registration/blob/8a6d8b3c906e6f029595ab58ca9e4cf68dc82613/src/lib/registration/ui/addon_selection_base_dialog.rb#L185-L187) built for simulating them. 

### Wait, HTML?

Yes, HTML. Contrary to the [dialog used for displaying the extensions/modules for a no registered system](https://github.com/yast/yast-packager/blob/18946c1c72f009a36919d8b286d23bc7da652755/src/lib/y2packager/dialogs/addon_selector.rb#L130-L135), which uses a [**MultiSelectionBox**](https://github.com/yast/yast-ycp-ui-bindings/blob/master/examples/MultiSelectionBox-test.rb), when the system is registered the [dialog](https://github.com/yast/yast-registration/blob/55262e22d917b017879cdc4f51f82e59900ab56b/src/lib/registration/ui/addon_selection_base_dialog.rb#L196) uses a [**RichText**](https://github.com/yast/yast-ycp-ui-bindings/blob/master/examples/RichText4.rb) to simulate the multi selection with more than two (on/off) statuses. Interesting and clever idea, isn't it? For reading more details about the reasoning behind it, read following links:

* https://bugzilla.suse.com/show_bug.cgi?id=967387
* https://gist.github.com/lslezak/5ed82fe19337bef4807b
* https://github.com/yast/yast-registration/pull/261
* https://yast.opensuse.org/blog/2016/07/27/highlights-of-yast-development-sprint-22#make-many-extensions-fit-on-the-screen-properly

## Solution

At first sight, the fix looks simple: just move those hard-coded styles to the corresponding _(installation\_)richtext.css_ file, which is [read by the **Y2Styler**](https://github.com/libyui/libyui/blob/ef33bacdb799a103abad8a4ea3cfed0434648792/libyui-qt/src/QY2Styler.cc#L257-L296) and set as a default CSS document for the RichText [before adding its content](https://github.com/libyui/libyui/blob/ef33bacdb799a103abad8a4ea3cfed0434648792/libyui-qt/src/YQRichText.cc#L76-L87). 

Unfortunately, the Qt's rich text engine only supports a [limited HTML and CSS subset](https://doc.qt.io/qt-5/richtext-html-subset.html), which basically means that this solution will work only partially. 

### Text color and _decoration_

Since `color` and `text-decoration` CSS properties are supported, the styles for the checkbox caption can be safely moved to the mentioned CSS file, no matter if it is surrounded by an `a` or `span` element. In fact, this is exactly the change that this PR proposes: replacing the `style='text-decoration:none; color:#{color}'` and `style='color:grey'` by `class='enabled-item'` and `class='disabled-item'` respectively. Better class names are welcome, of course. 

It should work as long as https://github.com/yast/yast-theme/ and https://github.com/openSUSE got the needed CSS (PRs not created yet).


```css
/* For the installation_richtext.css */
.enabled-item {
  color: white;
  text-decoration: none;
}

.disabled-item {
  color: gray;
}

/* For the richtext.css */
.enabled-item {
  color: black;
  text-decoration: none;
}

.disabled-item {
  color: gray;
}
```

### Checkbox image

Due to mentioned limitations, the checkbox image cannot be moved to the CSS file (read, @dgdavid was not able to do it). Let's recap tests done:

* Using a `span` or `div` element

  It will not work because `display`, `width`, and `height` CSS properties [are not supported](https://doc.qt.io/qt-5/richtext-html-subset.html#css-properties)

* Still using the `img` without the `src` attribute but with a `class` instead

   > \<img class="fake-checkbox"\>

  Does not work, because Qt renders a _file_ icon somehow meaning "missing file" or so when the `src` is not present, wrong, or empty.

* Ok, use a [transparent pixel](https://png-pixel.com/) as `src`

  > \<img class="fake-checkbox" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=">

  Good try, but remember: `width` and `height` CSS properties are not supported.

* Then, use the **supported** `width` and `height` img **attributes**.

  > \<img class="fake-checkbox" width="18" height="18" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=">`

  Great! It even opens the door to use them for setting a reasonable big value (18x18, maybe?) and leave the checkbox size up to the designers (14x14? 15x15? 12x12?). Unluckily, `background-position` and `background-repeat` CSS properties aren't supported either.

* Never mind, tell them a fixed size

  > \<img class="fake-checkbox" width="14" height="14" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=">`

  It does not work. Looks like Qt places the center of the image as the origin (??), repeating it until filling the _placeholder_ reserved for it.


See the screenshot for a _visual summary_

![Visual summary about why checkbox image cannot be moved to the richtext CSS file](https://user-images.githubusercontent.com/1691872/152707164-5be79649-3e99-4835-9182-b31a43aa8178.png)


Anyway, there are other extra disadvantages with the `background-image` approach

* Designers must know the image location in the file system (not a big deal, though)
* When the user selects the RichText content, checkboxes disappears (because of the transparent pixel) 


### Checkbox image, the workaround

_Fortunately_, there is a quick workaround for making those checkboxes visible in a light theme too: changing the border of [_inst\_checkbox-off.svg_](https://github.com/yast/yast-theme/blob/master/theme/SLE/wizard/inst_checkbox-off.svg) from white to gray. It will work unless the theme uses a gray background, obviously.

See the screenshots below

| Dark theme | Light theme |
|-|-|
| ![Unselected checkboxes in dark theme](https://user-images.githubusercontent.com/1691872/152781167-1acade6b-981e-46ce-a16a-eaa36de14b62.png) | ![Unselected checkboxes in light theme](https://user-images.githubusercontent.com/1691872/152781247-aaa34459-be63-4dd3-a9fd-53c26c38781f.png) |

However, still being not perfect (that's why is called workaround): designers cannot change/adapt the checkbox color to the theme. Imagine a dark theme with green checkboxes and a light theme using orange ones instead.


| Dark theme | Light theme |
|-|-|
| ![Dark theme using green checkbox](https://user-images.githubusercontent.com/1691872/152707249-eb463b76-58de-42d0-9bb2-e0db37c5e174.png) | ![Light theme using orange checkbox](https://user-images.githubusercontent.com/1691872/152707254-a0bf71db-958c-440f-a6ad-85f498dccdae.png) |

**Unless** we can provide a solution for loading the icons per theme. E.g., `/usr/share/YaST2/theme/sle/dark-installation/icons` or `/usr/share/YaST2/theme/sle/light-installation/icons` or so. Even falling back to a default one in case of file missing (?) `/usr/share/YaST2/theme/sle/installation/icons` 

For this, themes need a name or identifier, of course. Perhaps something to have in consideration in the context of https://trello.com/c/joXRejJi (internal link).

## Additional information

This is not the first time we have issues with those dialogs/selectors. Read https://github.com/yast/yast-registration/pull/483 (specially "The Long Story" chapter), https://github.com/yast/yast-registration/pull/484, and https://github.com/yast/yast-registration/pull/487 to know more.

## More additional information (2022-02-23)

 * Summary of limitations in current libyui widgets: https://gist.github.com/shundhammer/069004d1c8e8e002917b295ce123c697
 * Summary of issues in the current approach of the dialog: https://gist.github.com/joseivanlopez/46f11f146ec898f1b15aebd279e024e0
 * https://trello.com/c/Wy2PJDj8/5099-fix-the-addon-selection-mess (internal link)

---

**DISCLAIMER**: I (@dgdavid) do not like the [trick of using the transparent pixel](https://css-tricks.com/snippets/html/base64-encode-of-1x1px-transparent-gif/). I was just exploring the ways for moving the hard-coded styles to a CSS file. Moreover, although I strongly admire the work and effort done back in the time for providing solutions with the tools at hand, I don't like the emulated multi selector either. IMHO, a native [libyui](https://github.com/libyui/libyui) solution is the right way to definitely improve these dialogs.