### PR TITLE
Ruby 3 code adaptation

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 28 08:33:10 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Adapt test code for work with Ruby >= 3 (related to bsc#1193192)
+- 4.4.17
+
+-------------------------------------------------------------------
 Wed Feb 23 11:34:03 UTC 2022 - David Diaz <dgonzalez@suse.com>
 
 - Makes the addon selector more "themeable" (bsc#1196362).

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.4.16
+Version:        4.4.17
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/test/autoyast_addons_spec.rb
+++ b/test/autoyast_addons_spec.rb
@@ -85,14 +85,17 @@ describe Registration::AutoyastAddons do
 
   describe "#register" do
     it "registers the selected addons" do
-      expect(registration).to receive(:register_product).with({
+      basesystem_module = {
         "name" => "sle-module-basesystem", "reg_code" => nil, "arch" => "x86_64",
         "version" => "15"
-      }).ordered
-      expect(registration).to receive(:register_product).with({
+      }
+      desktop_apps_module = {
         "name" => "sle-module-desktop-applications", "reg_code" => nil,
         "arch" => "x86_64", "version" => "15"
-      }).ordered
+      }
+
+      expect(registration).to receive(:register_product).with(basesystem_module).ordered
+      expect(registration).to receive(:register_product).with(desktop_apps_module).ordered
 
       ayaddons = Registration::AutoyastAddons.new(unsorted_addons, registration)
       ayaddons.select
@@ -100,10 +103,12 @@ describe Registration::AutoyastAddons do
     end
 
     it "registers the selected addon using the provided reg. key" do
-      expect(registration).to receive(:register_product).with({
+      basesystem_module = {
         "name" => "sle-module-basesystem", "reg_code" => "abcd42", "arch" => "x86_64",
         "version" => "15"
-      })
+      }
+
+      expect(registration).to receive(:register_product).with(basesystem_module)
 
       ayaddons = Registration::AutoyastAddons.new(addons_with_reg_key, registration)
       ayaddons.select

--- a/test/autoyast_addons_spec.rb
+++ b/test/autoyast_addons_spec.rb
@@ -85,14 +85,14 @@ describe Registration::AutoyastAddons do
 
   describe "#register" do
     it "registers the selected addons" do
-      expect(registration).to receive(:register_product).with(
+      expect(registration).to receive(:register_product).with({
         "name" => "sle-module-basesystem", "reg_code" => nil, "arch" => "x86_64",
         "version" => "15"
-      ).ordered
-      expect(registration).to receive(:register_product).with(
+      }).ordered
+      expect(registration).to receive(:register_product).with({
         "name" => "sle-module-desktop-applications", "reg_code" => nil,
         "arch" => "x86_64", "version" => "15"
-      ).ordered
+      }).ordered
 
       ayaddons = Registration::AutoyastAddons.new(unsorted_addons, registration)
       ayaddons.select
@@ -100,10 +100,10 @@ describe Registration::AutoyastAddons do
     end
 
     it "registers the selected addon using the provided reg. key" do
-      expect(registration).to receive(:register_product).with(
+      expect(registration).to receive(:register_product).with({
         "name" => "sle-module-basesystem", "reg_code" => "abcd42", "arch" => "x86_64",
         "version" => "15"
-      )
+      })
 
       ayaddons = Registration::AutoyastAddons.new(addons_with_reg_key, registration)
       ayaddons.select


### PR DESCRIPTION
Adapt the unit test code for working with Ruby >= 3.

Related to https://bugzilla.suse.com/show_bug.cgi?id=1193192 and https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:I/yast2-registration/standard/x86_64

## Tests

Tested locally using RSpec 3.11

> RSpec 3.11
>  - rspec-core 3.11.0
>  - rspec-expectations 3.11.0
>  - rspec-mocks 3.11.0
>  - rspec-support 3.11.0


Finished in 3.52 seconds (files took 2.3 seconds to load)
665 examples, 0 failures