### PR TITLE
Fixed migration rollback in Leap => SLES migration

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 22 15:08:21 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed migration rollback in Leap => SLES migration
+  (related to jsc#SLE-17309)
+- 4.4.18
+
+-------------------------------------------------------------------
 Mon Feb 28 08:33:10 UTC 2022 - David Diaz <dgonzalez@suse.com>
 
 - Adapt test code for work with Ruby >= 3 (related to bsc#1193192)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.4.17
+Version:        4.4.18
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/ui/registration_sync_workflow.rb
+++ b/src/lib/registration/ui/registration_sync_workflow.rb
@@ -43,11 +43,13 @@ module Registration
       # workaround for rollback from the Leap => SLES migration,
       # maps installed => activated product
       SYNC_FALLBACKS = {
-        "openSUSE" => "SLES"
+        "openSUSE" => "SLES",
+        # openSUSE Leap 15.3 and newer
+        "Leap"     => "SLES"
       }.freeze
 
       # restore the registration status
-      # @return [Symbol] :next on sucess, :abort on error
+      # @return [Symbol] :next on success, :abort on error
       def run_sequence
         log.info "Restoring the original repository and registration status..."
 


### PR DESCRIPTION
## The Problem

When the openSUSE Leap => SLES migration fails or is aborted by user then the rollback to the original openSUSE Leap failed.

## The Fix

Since openSUSE Leap 15.3 the product name is `Leap`, we need to add this to the hardcoded product mapping which handles the Leap rollback specifically.