### PR TITLE
Reload SUSEConnect certs in instsys (bsc#1195220)

### DIFF
--- a/src/lib/registration/ssl_certificate.rb
+++ b/src/lib/registration/ssl_certificate.rb
@@ -103,6 +103,9 @@ module Registration
       # Cleanup
       FileUtils.rm_rf(TMP_CA_CERTS_DIR)
 
+      # Reload SUSEConnect internal cert pool (suseconnect-ng only)
+      SUSE::Connect::SSLCertificate.reload if SUSE::Connect::SSLCertificate.respond_to?(:reload)
+
       # Check that last file was copied to return true or false
       File.exist?(new_files.last)
     end


### PR DESCRIPTION
## Problem

During installation (instsys context) the certificates are not installed
via SUSEConnect so explicit reloading of Golang's cert pool is needed.

- https://bugzilla.suse.com/show_bug.cgi?id=1195220
- https://openqa.suse.de/tests/8227446
- https://github.com/SUSE/connect-ng/pull/130 [required for this to work]


## Solution

Force reloading of SUSEConnect's cert pool after installing the certs.


## Testing

- *Tested manually*
