### PR TITLE
[SP4] Reload SSL certificates after import

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 22 10:32:15 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Reload the SUSEConnect cache after importing a SSL certificate
+  (bsc#1195220) (by jacek.tomasiak@gmail.com)
+- 4.4.19
+
+-------------------------------------------------------------------
 Tue Mar 22 15:08:21 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed migration rollback in Leap => SLES migration

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.4.18
+Version:        4.4.19
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/ssl_certificate.rb
+++ b/src/lib/registration/ssl_certificate.rb
@@ -103,6 +103,9 @@ module Registration
       # Cleanup
       FileUtils.rm_rf(TMP_CA_CERTS_DIR)
 
+      # Reload SUSEConnect internal cert pool (suseconnect-ng only)
+      SUSE::Connect::SSLCertificate.reload if defined?(SUSE::Connect::SSLCertificate.reload)
+
       # Check that last file was copied to return true or false
       File.exist?(new_files.last)
     end

--- a/src/lib/registration/ssl_certificate.rb
+++ b/src/lib/registration/ssl_certificate.rb
@@ -104,7 +104,7 @@ module Registration
       FileUtils.rm_rf(TMP_CA_CERTS_DIR)
 
       # Reload SUSEConnect internal cert pool (suseconnect-ng only)
-      SUSE::Connect::SSLCertificate.reload if defined?(SUSE::Connect::SSLCertificate.reload)
+      SUSE::Connect::SSLCertificate.reload if SUSE::Connect::SSLCertificate.respond_to?(:reload)
 
       # Check that last file was copied to return true or false
       File.exist?(new_files.last)


### PR DESCRIPTION
## Problem

- The Go language needs explicitly reload the SSL cache after importing an SSL certificate.
- https://bugzilla.suse.com/show_bug.cgi?id=1195220
- See https://github.com/yast/yast-registration/pull/569