### PR TITLE
Import the SSL certificate also in the self-update step (bsc#1199091)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May  5 14:43:40 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Import the SSL certificate from the <reg_server_cert> AutoYaST
+  data also in the self-update step (bsc#1199091)
+- 4.4.21
+
+-------------------------------------------------------------------
 Thu May  5 06:04:55 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed importing SSL certificates (bsc#1195220)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.4.20
+Version:        4.4.21
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/connect_helpers.rb
+++ b/src/lib/registration/connect_helpers.rb
@@ -228,6 +228,18 @@ module Registration
           Yast::Report.Error(_("Received SSL Certificate does not match " \
                 "the expected certificate."))
         end
+      elsif Yast::Mode.autoinst && Storage::Config.instance.reg_server_cert &&
+          !Storage::Config.instance.reg_server_cert.empty?
+
+        # try just once to avoid endless loop
+        if !certificate_imported
+          cert_url = Storage::Config.instance.reg_server_cert
+          log.info "Importing certificate from #{cert_url}..."
+          cert = SslCertificate.download(cert_url)
+          return true if cert.import
+        end
+
+        report_ssl_error(error.message, cert, error_code)
       else
         report_ssl_error(error.message, cert, error_code)
       end


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1199091
- The self-update step uses the SMT/RMT server defined in the `<suse_register>` section in the AutoYaST profile
- However, the server certificate specified in the `<reg_server_cert>` section was not used so the connection failed because of an unknown self-signed certificate.

## Solution

- When an SSL problem happens check if the `<reg_server_cert>` value is defined. If yes then download the specified certificate, import it to the inst-sys and retry.


## Testing

- Tested manually with this snippet:
  ```xml
  <reg_server>https://openqa-rmt.suse.de</reg_server>
  <reg_server_cert>http://openqa-rmt.suse.de/rmt.crt</reg_server_cert>
  ```


