### PR TITLE
Run in container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ package/*.bz2
 /nbproject/
 test-driver
 .yardoc/
+test/fixtures/anchors/*/*.0

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu May 26 14:55:59 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Support managing system in a chroot (bsc#1199840)
+- 4.5.4
+
+-------------------------------------------------------------------
 Fri May  6 07:14:08 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Import the SSL certificate from the <reg_server_cert> AutoYaST

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.5.3
+Version:        4.5.4
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/clients/inst_migration_repos.rb
+++ b/src/lib/registration/clients/inst_migration_repos.rb
@@ -51,18 +51,6 @@ module Registration
         # import the SMT/RMT certificate to inst-sys
         SslCertificate.import_from_system
       end
-
-      # Log the certificate details
-      # @param cert [Registration::SslCertificate] the SSL certificate
-      def log_certificate(cert)
-        # log also the dates
-        log.info("#{SslCertificateDetails.new(cert).summary}\n" \
-        "Issued on: #{cert.issued_on}\nExpires on: #{cert.expires_on}")
-
-        # log a warning for expired certificate
-        expires = cert.x509_cert.not_after.localtime
-        log.warn("The certificate has EXPIRED! (#{expires})") if expires < Time.now
-      end
     end
   end
 end

--- a/src/lib/registration/clients/inst_migration_repos.rb
+++ b/src/lib/registration/clients/inst_migration_repos.rb
@@ -49,25 +49,7 @@ module Registration
         SwMgmt.copy_old_credentials(destdir)
 
         # import the SMT/RMT certificate to inst-sys
-        import_ssl_certificates
-      end
-
-      # Import the old SSL certificate if present. Tries all known locations.
-      def import_ssl_certificates
-        prefix = Yast::Installation.destdir
-
-        SslCertificate::PATHS.each do |file|
-          cert_file = File.join(prefix, file)
-          if File.exist?(cert_file)
-            log.info("Importing the SSL certificate from the old system: (#{prefix})#{file} ...")
-            cert = SslCertificate.load_file(cert_file)
-            log_certificate(cert)
-            target_path = File.join(SslCertificate::INSTSYS_CERT_DIR, File.basename(cert_file))
-            cert.import_to_instsys(target_path)
-          else
-            log.debug("SSL certificate (#{prefix})#{file} not found in the system")
-          end
-        end
+        SslCertificate.import_from_system
       end
 
       # Log the certificate details

--- a/src/lib/registration/clients/inst_scc.rb
+++ b/src/lib/registration/clients/inst_scc.rb
@@ -281,9 +281,7 @@ module Yast
     def finish
       # when managing a system in chroot copy the config file and the SSL certificate
       # to the chroot target
-      if WFM.scr_chrooted?
-        ::Registration::FinishDialog.new.run("Write")
-      end
+      ::Registration::FinishDialog.new.run("Write") if WFM.scr_chrooted?
 
       :next
     end

--- a/src/lib/registration/clients/inst_scc.rb
+++ b/src/lib/registration/clients/inst_scc.rb
@@ -27,6 +27,7 @@ require "cgi"
 
 require "registration/addon"
 require "registration/exceptions"
+require "registration/finish_dialog"
 require "registration/helpers"
 require "registration/connect_helpers"
 require "registration/sw_mgmt"
@@ -208,6 +209,13 @@ module Yast
         )
       end
 
+      # when running in a container copy the credentials and the SSL certificate
+      # from the host system
+      if Arch.is_management_container
+        ::Registration::SwMgmt.copy_old_credentials(Installation.destdir)
+        ::Registration::SslCertificate.import_from_system
+      end
+
       if Mode.update
         ::Registration::SwMgmt.copy_old_credentials(Installation.destdir)
 
@@ -268,6 +276,16 @@ module Yast
       end
     end
 
+    def finish
+      # when running in a container copy the credentials and the SSL certificate
+      # back to the host system
+      if Arch.is_management_container
+        ::Registration::FinishDialog.new.run("Write")
+      end
+
+      :next
+    end
+
     def registration_ui
       ::Registration::RegistrationUI.new(@registration)
     end
@@ -283,7 +301,8 @@ module Yast
         "addon_eula"             => ->() { addon_eula },
         "register_addons"        => ->() { register_addons },
         "update_autoyast_config" => ->() { update_autoyast_config },
-        "pkg_manager"            => ->() { pkg_manager }
+        "pkg_manager"            => ->() { pkg_manager },
+        "finish"                 => ->() { finish }
       }
     end
 
@@ -332,6 +351,10 @@ module Yast
           next:  "pkg_manager"
         },
         "pkg_manager"            => {
+          abort: :abort,
+          next:  "finish"
+        },
+        "finish"                 => {
           abort: :abort,
           next:  :next
         }

--- a/src/lib/registration/clients/inst_scc.rb
+++ b/src/lib/registration/clients/inst_scc.rb
@@ -209,9 +209,9 @@ module Yast
         )
       end
 
-      # when running in a container copy the credentials and the SSL certificate
-      # from the host system
-      if Arch.is_management_container
+      # when managing a system in chroot copy the credentials and the SSL certificate
+      # from the chroot to the current system
+      if Yast::WFM.scr_chrooted?
         ::Registration::SwMgmt.copy_old_credentials(Installation.destdir)
         ::Registration::SslCertificate.import_from_system
       end
@@ -276,10 +276,12 @@ module Yast
       end
     end
 
+    # finish the registration workflow
+    # @return [symbol] result symbol (:next)
     def finish
-      # when running in a container copy the credentials and the SSL certificate
-      # back to the host system
-      if Arch.is_management_container
+      # when managing a system in chroot copy the config file and the SSL certificate
+      # to the chroot target
+      if WFM.scr_chrooted?
         ::Registration::FinishDialog.new.run("Write")
       end
 

--- a/src/lib/registration/finish_dialog.rb
+++ b/src/lib/registration/finish_dialog.rb
@@ -59,7 +59,7 @@ module Registration
         remove_ncc_credentials
         nil
       else
-        raise "Uknown action #{func} passed as first parameter"
+        raise "Unknown action #{func} passed as first parameter"
       end
     end
 

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -64,8 +64,8 @@ module Registration
       # write the global credentials
       SUSE::Connect::YaST.create_credentials_file(login, password)
 
-      # when running in a management container copy the credentials to the host system
-      if Yast::Arch.is_management_container
+      # when managing a system in chroot copy the credentials to the target system
+      if Yast::WFM.scr_chrooted?
         target_path = File.join(Yast::Installation.destdir, self.class.credentials_path)
         ::FileUtils.cp(self.class.credentials_path, target_path)
         ::Registration::FinishDialog.new.run("Write")

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -62,6 +62,12 @@ module Registration
 
       # write the global credentials
       SUSE::Connect::YaST.create_credentials_file(login, password)
+
+      # when running in a management container copy the credentials to the host system
+      if Yast::Arch.is_management_container
+        target_path = File.join(Yast::Installation.destdir, self.class.credentials_path)
+          ::FileUtils.cp(self.class.credentials_path, target_path)
+      end
     end
 
     def register_product(product, email = nil)

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -24,6 +24,7 @@ require "yast"
 require "y2packager/new_repository_setup"
 require "suse/connect"
 require "registration/connect_helpers"
+require "registration/finish_dialog"
 
 require "registration/addon"
 require "registration/helpers"
@@ -66,7 +67,8 @@ module Registration
       # when running in a management container copy the credentials to the host system
       if Yast::Arch.is_management_container
         target_path = File.join(Yast::Installation.destdir, self.class.credentials_path)
-          ::FileUtils.cp(self.class.credentials_path, target_path)
+        ::FileUtils.cp(self.class.credentials_path, target_path)
+        ::Registration::FinishDialog.new.run("Write")
       end
     end
 

--- a/src/lib/registration/ssl_certificate.rb
+++ b/src/lib/registration/ssl_certificate.rb
@@ -244,7 +244,6 @@ module Registration
     end
 
     # Log the certificate details
-    # @param cert [Registration::SslCertificate] the SSL certificate
     def log_details
       require "registration/ssl_certificate_details"
       # log also the dates

--- a/src/lib/registration/ssl_certificate.rb
+++ b/src/lib/registration/ssl_certificate.rb
@@ -230,7 +230,7 @@ module Registration
         if File.exist?(cert_file)
           log.info("Importing the SSL certificate from other system: (#{prefix})#{file} ...")
           cert = SslCertificate.load_file(cert_file)
-          log_certificate(cert)
+          cert.log_details
           if Yast::Stage.initial
             target_path = File.join(SslCertificate::INSTSYS_CERT_DIR, File.basename(cert_file))
             cert.import_to_instsys(target_path)
@@ -241,6 +241,19 @@ module Registration
           log.debug("SSL certificate (#{prefix})#{file} not found in the system")
         end
       end
+    end
+
+    # Log the certificate details
+    # @param cert [Registration::SslCertificate] the SSL certificate
+    def log_details
+      require "registration/ssl_certificate_details"
+      # log also the dates
+      log.info("#{SslCertificateDetails.new(self).summary}\n" \
+      "Issued on: #{issued_on}\nExpires on: #{expires_on}")
+
+      # log a warning for expired certificate
+      expires = x509_cert.not_after.localtime
+      log.warn("The certificate has EXPIRED! (#{expires})") if expires < Time.now
     end
 
   private

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -365,7 +365,7 @@ module Registration
       credentials_file = UrlHelpers.credentials_from_url(product_service.url)
 
       if credentials_file
-        if Mode.update || Yast::Arch.is_management_container
+        if Mode.update || Yast::WFM.scr_chrooted?
           # at update libzypp is already switched to /mnt target,
           # update the path accordingly
           credentials_file = File.join(Installation.destdir,

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -365,13 +365,13 @@ module Registration
       credentials_file = UrlHelpers.credentials_from_url(product_service.url)
 
       if credentials_file
-        if Mode.update
+        if Mode.update || Yast::Arch.is_management_container
           # at update libzypp is already switched to /mnt target,
           # update the path accordingly
           credentials_file = File.join(Installation.destdir,
             ::SUSE::Connect::YaST::DEFAULT_CREDENTIALS_DIR,
             credentials_file)
-          log.info "Using #{credentials_file} credentials path in update mode"
+          log.info "Using #{credentials_file} credentials path"
         end
         # SCC uses the same credentials for all services, just save them to
         # a different file

--- a/test/inst_migration_repos_spec.rb
+++ b/test/inst_migration_repos_spec.rb
@@ -12,6 +12,7 @@ describe Registration::Clients::InstMigrationRepos do
   before do
     allow(Yast::WFM).to receive(:call)
     allow(Yast::Installation).to receive(:destdir).and_return(destdir)
+    allow(Yast::Stage).to receive(:initial).and_return(true)
     allow(Registration::SwMgmt).to receive(:copy_old_credentials)
     allow(File).to receive(:exist?).and_return(false)
   end


### PR DESCRIPTION
## Problem

- Adapt the registration module to be able to run in a management container

## Solution

- At the beginning we need to copy some<sup>*</sup> files from the host system to the container
- At the end we need to copy some<sup>*</sup> files back to the host system
- In a management container it is set to `/mnt`
- In a normal running system is set to `/`

<sup>*</sup>) This includes the SMT/RMT SSL certificate, the libzypp credentials and the SUSEConnect config file

## Notes

- See related PR:
  - https://github.com/yast/yast-yast2/pull/1258
  - https://github.com/yast/yast-ruby-bindings/pull/284/

## Testing

- Tested manually
