### PR TITLE
bsc#1200035: do no crash detecting activated products when credentials are missing

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun  7 12:37:04 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when cloning an unregistered system with
+  additional repositories (bsc#1200035).
+- 4.4.22
+
+-------------------------------------------------------------------
 Thu May  5 14:43:40 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Import the SSL certificate from the <reg_server_cert> AutoYaST

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.4.21
+Version:        4.4.22
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -178,7 +178,7 @@ module Registration
       log.info "Activated products: #{activated.map(&:identifier)}"
       activated
     rescue SUSE::Connect::MissingSccCredentialsFile
-      log.warn "Missing SCC credentials file is missing. No activated products."
+      log.warn "SCC credentials file is missing. No activated products."
       []
     end
 

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -177,6 +177,9 @@ module Registration
       activated = SUSE::Connect::YaST.status(connect_params).activated_products || []
       log.info "Activated products: #{activated.map(&:identifier)}"
       activated
+    rescue SUSE::Connect::MissingSccCredentialsFile
+      log.warn "Missing SCC credentials file is missing. No activated products."
+      []
     end
 
     # get the list of migration products

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -173,13 +173,12 @@ module Registration
     end
 
     def activated_products
+      return [] unless Registration.is_registered?
+
       log.info "Reading activated products..."
       activated = SUSE::Connect::YaST.status(connect_params).activated_products || []
       log.info "Activated products: #{activated.map(&:identifier)}"
       activated
-    rescue SUSE::Connect::MissingSccCredentialsFile
-      log.warn "SCC credentials file is missing. No activated products."
-      []
     end
 
     # get the list of migration products

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -110,17 +110,25 @@ describe Registration::Registration do
   end
 
   describe "#activated_products" do
-    it "returns list of activated products" do
-      status = double(activated_products: [])
-      expect(SUSE::Connect::YaST).to receive(:status).and_return(status)
+    let(:sles) { double("SLES", identifier: "sles") }
+    let(:registered?) { true }
 
-      expect(Registration::Registration.new.activated_products).to eq([])
+    before do
+      allow(Registration::Registration).to receive(:is_registered?)
+        .and_return(registered?)
     end
 
-    context "when the credentials file is missing" do
+    it "returns list of activated products" do
+      status = double(activated_products: [sles])
+      allow(SUSE::Connect::YaST).to receive(:status).and_return(status)
+      expect(Registration::Registration.new.activated_products).to eq([sles])
+    end
+
+    context "when the system is not registered" do
+      let(:registered?) { false }
+
       it "returns an empty array" do
-        allow(SUSE::Connect::YaST).to receive(:status)
-          .and_raise(SUSE::Connect::MissingSccCredentialsFile)
+        expect(SUSE::Connect::YaST).to_not receive(:status)
         expect(Registration::Registration.new.activated_products).to eq([])
       end
     end

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -116,6 +116,14 @@ describe Registration::Registration do
 
       expect(Registration::Registration.new.activated_products).to eq([])
     end
+
+    context "when the credentials file is missing" do
+      it "returns an empty array" do
+        allow(SUSE::Connect::YaST).to receive(:status)
+          .and_raise(SUSE::Connect::MissingSccCredentialsFile)
+        expect(Registration::Registration.new.activated_products).to eq([])
+      end
+    end
   end
 
   describe "#get_addon_list" do


### PR DESCRIPTION
## Problem

- [bsc#1200035](https://bugzilla.suse.com/show_bug.cgi?id=1200035)

When cloning a system, AutoYaST crashes if there are additional repositories (with no products) and the system is not registered.


## Solution

Check whether the system is registered before trying to search for activated products.


## Testing

- Added a new unit test
- Tested manually