### PR TITLE
bsc#1200035: do no crash detecting activated products when credentials are missing

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun  7 12:37:04 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when cloning an unregistered system with
+  additional repositories (bsc#1200035).
+- 4.5.5
+
+-------------------------------------------------------------------
 Thu May 26 14:55:59 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Support managing system in a chroot (bsc#1199840)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.5.4
+Version:        4.5.5
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -181,6 +181,8 @@ module Registration
     end
 
     def activated_products
+      return [] unless Registration.is_registered?
+
       log.info "Reading activated products..."
       activated = SUSE::Connect::YaST.status(connect_params).activated_products || []
       log.info "Activated products: #{activated.map(&:identifier)}"

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -110,11 +110,27 @@ describe Registration::Registration do
   end
 
   describe "#activated_products" do
-    it "returns list of activated products" do
-      status = double(activated_products: [])
-      expect(SUSE::Connect::YaST).to receive(:status).and_return(status)
+    let(:sles) { double("SLES", identifier: "sles") }
+    let(:registered?) { true }
 
-      expect(Registration::Registration.new.activated_products).to eq([])
+    before do
+      allow(Registration::Registration).to receive(:is_registered?)
+        .and_return(registered?)
+    end
+
+    it "returns list of activated products" do
+      status = double(activated_products: [sles])
+      allow(SUSE::Connect::YaST).to receive(:status).and_return(status)
+      expect(Registration::Registration.new.activated_products).to eq([sles])
+    end
+
+    context "when the system is not registered" do
+      let(:registered?) { false }
+
+      it "returns an empty array" do
+        expect(SUSE::Connect::YaST).to_not receive(:status)
+        expect(Registration::Registration.new.activated_products).to eq([])
+      end
     end
   end
 


### PR DESCRIPTION
Merge #578 into `master`.