### PR TITLE
Improved logging, use "log.group" call (bsc#1204625)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 25 12:19:45 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Improve logging, use the new "log.group" call to group logs for
+  each registration step (bsc#1204625)
+- 4.5.7
+
+-------------------------------------------------------------------
 Wed Oct 19 08:13:54 UTC 2022 - José Iván López González <jlopez@suse.com>
 
 - Add reader for products defined in a YAML file.

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.5.6
+Version:        4.5.7
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only
@@ -38,15 +38,15 @@ BuildRequires:  suseconnect-ruby-bindings > 0.0.4
 # ProductSpec API
 BuildRequires:  yast2-packager >= 4.4.13
 BuildRequires:  yast2-update >= 3.1.36
-# yast/rspec/helpers.rb
-BuildRequires:  yast2-ruby-bindings >= 4.4.7
+# log.group call
+BuildRequires:  yast2-ruby-bindings >= 4.5.4
 
 # Y2Packager::NewRepositorySetup
 Requires:       yast2 >= 4.4.42
 # "dupAllowVendorChange" option in Pkg.SetSolverFlags()
 Requires:       yast2-pkg-bindings >= 3.1.34
-# N_() method
-Requires:       yast2-ruby-bindings >= 3.1.12
+# log.group call
+Requires:       yast2-ruby-bindings >= 4.5.4
 # uses Fiddle instead of FFI
 Requires:       suseconnect-ruby-bindings > 0.0.4
 Requires:       yast2-add-on >= 3.1.8

--- a/test/registration_ui_test.rb
+++ b/test/registration_ui_test.rb
@@ -46,7 +46,7 @@ describe "Registration::RegistrationUI" do
         .and_return([])
 
       options = Registration::Storage::InstallationOptions.instance
-      allow(options).to receive(:email).twice.and_return(email)
+      allow(options).to receive(:email).and_return(email)
       allow(options).to receive(:reg_code).and_return(reg_code)
       allow(options).to receive(:base_registered).and_return(false)
 


### PR DESCRIPTION
## Problem

- Improve the registration log, group the registration steps
- Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1204625

## Review Notes

- Use the "Hide whitespace" diff option otherwise the diff is too long and harder to read.
- Simply use [this link]()

## Solution

- Use the new `log.group` call from https://github.com/yast/yast-ruby-bindings/pull/287

## Testing

- Tested manually
