### PR TITLE
Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Oct 31 10:14:45 UTC 2022 - Martin Vidner <mvidner@suse.com>
+
+- Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)
+- 4.5.8
+
+-------------------------------------------------------------------
 Tue Oct 25 12:19:45 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Improve logging, use the new "log.group" call to group logs for

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.5.7
+Version:        4.5.8
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/test/helpers_spec.rb
+++ b/test/helpers_spec.rb
@@ -166,14 +166,15 @@ describe Registration::Helpers do
   describe ".write_config" do
     it "writes the current configuration" do
       url = "https://example.com"
+      config = {
+        url:      url,
+        insecure: false
+      }
       expect(Registration::UrlHelpers).to receive(:registration_url) \
         .and_return(url)
       expect(Registration::Helpers).to receive(:insecure_registration) \
         .and_return(false)
-      expect(SUSE::Connect::YaST).to receive(:write_config).with(
-        url:      url,
-        insecure: false
-      )
+      expect(SUSE::Connect::YaST).to receive(:write_config).with(config)
 
       Registration::Helpers.write_config
     end

--- a/test/registration/clients/scc_auto_test.rb
+++ b/test/registration/clients/scc_auto_test.rb
@@ -47,8 +47,9 @@ describe Registration::Clients::SCCAuto do
     end
 
     it "imports given hash" do
-      expect(config).to receive(:import).with("reg_code" => "SOME-CODE")
-      subject.import("reg_code" => "SOME-CODE")
+      settings = { "reg_code" => "SOME-CODE" }
+      expect(config).to receive(:import).with(settings)
+      subject.import(settings)
     end
 
     context "when the registration code is not specified" do
@@ -65,7 +66,8 @@ describe Registration::Clients::SCCAuto do
       end
 
       it "reads the code from the registration codes loader" do
-        expect(config).to receive(:import).with("reg_code" => "INTERNAL-USE-ONLY")
+        imported = { "reg_code" => "INTERNAL-USE-ONLY" }
+        expect(config).to receive(:import).with(imported)
         subject.import({})
       end
 

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -62,8 +62,9 @@ describe Registration::Registration do
         receive(:registered)
 
       # the received product renames are passed to the software management
+      renames = { "SUSE_SLES_SAP" => "SLES_SAP" }
       expect(Registration::SwMgmt).to receive(:update_product_renames)
-        .with("SUSE_SLES_SAP" => "SLES_SAP")
+        .with(renames)
 
       allow(SUSE::Connect::YaST).to receive(:credentials)
         .with(SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE)


### PR DESCRIPTION
## Problem

- https://bugzilla.opensuse.org/show_bug.cgi?id=1204871 "- [Staging] rubygem-rspec-* 3.12 breaks various yast modules build"

New rspec-mocks distinguish between hash and keyword arguments passed to `with`.

The tested code does use hashes but we've used keywords in tests because
it's shorter to write. Fixed.

rspec-mocks 3.11.2 / 2022-10-25:

> Bug Fixes: Support keyword argument semantics when constraining argument
> expectations using with on Ruby 3.0+ with instance_double
> https://github.com/rspec/rspec-mocks/pull/1473

## Solution

Use hashes in tests instead of keywords

## Testing

- [x] Red-green tested with manually installed rspec 3.12.0

## Screenshots

Not affected
