### PR TITLE
[SLE15-SP1] Switch to the new SUSEConnect-ng (bsc#1212799)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug  2 08:44:51 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Switch to the new SUSEConnect-ng (bsc#1212799)
+  - Includes a SSL reload fix (bsc#1195220)
+- 4.1.27
+
+-------------------------------------------------------------------
 Thu May 28 10:50:51 UTC 2020 - Martin Vidner <mvidner@suse.com>
 
 - Declining/refusal of an addon license means canceling all addons.

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.1.26
+Version:        4.1.27
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -29,15 +29,9 @@ Requires:       yast2 >= 4.0.63
 Requires:       yast2-pkg-bindings >= 3.1.34
 # N_() method
 Requires:       yast2-ruby-bindings >= 3.1.12
-# SUSE::Connect::YaST.list_installer_updates
-Requires:       rubygem(suse-connect) >= 0.2.37
 
-# NOTE: Workaround for bsc#947482, SUSEConnect is actually not needed by the
-# YaST registration module, it is used just to install the Connect dependencies.
-#
-# TODO: Remove it once the SUSEConnect dependencies are properly moved to the
-# suse-connect gem.
-Requires:       SUSEConnect >= 0.2.37
+# new suseconnect-ng
+Requires:       suseconnect-ruby-bindings >= 1.2.0
 
 Requires:       yast2-add-on >= 3.1.8
 Requires:       yast2-slp >= 3.1.9
@@ -51,7 +45,8 @@ BuildRequires:  yast2 >= 4.0.63
 BuildRequires:  yast2-devtools >= 3.1.39
 BuildRequires:  yast2-slp >= 3.1.9
 BuildRequires:  rubygem(rspec)
-BuildRequires:  rubygem(suse-connect) >= 0.3.11
+# new suseconnect-ng
+BuildRequires:  suseconnect-ruby-bindings >= 1.2.0
 BuildRequires:  rubygem(yast-rake) >= 0.2.5
 # updated product renames
 BuildRequires:  yast2-packager >= 4.0.40

--- a/src/lib/registration/ssl_certificate.rb
+++ b/src/lib/registration/ssl_certificate.rb
@@ -98,6 +98,9 @@ module Registration
       # Cleanup
       FileUtils.rm_rf(TMP_CA_CERTS_DIR)
 
+      # Reload SUSEConnect internal cert pool (suseconnect-ng only)
+      SUSE::Connect::SSLCertificate.reload if SUSE::Connect::SSLCertificate.respond_to?(:reload)
+
       # Check that last file was copied to return true or false
       File.exist?(new_files.last)
     end


### PR DESCRIPTION
## Problem

- The SLE15-SP1 release will switch to the new SUSEConnect-ng
- See https://bugzilla.suse.com/show_bug.cgi?id=1212799
- They provide compatible Ruby bindings but it still needs some small updates

## Solution

- We need to backport these related fixes:
  - Update the package dependencies: https://github.com/yast/yast-registration/pull/549
  - Workaround for Go to force reloading the known SSL certificates: https://github.com/yast/yast-registration/pull/571
- According to [this comment](https://bugzilla.suse.com/show_bug.cgi?id=1212799#c20) the required version should be `>= 1.2.0`
