### PR TITLE
Adapt to SCC API Change: 'base' -> 'isbase' [SLE-15-SP1]

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 22 09:19:08 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Adapted to SCC API change 'base' -> 'isbase' (bsc#1217317):
+  Cherry-picked igonzalezsosa's commit 431d937b78c209c0d35
+- 4.1.28
+
+-------------------------------------------------------------------
 Wed Aug  2 08:44:51 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Switch to the new SUSEConnect-ng (bsc#1212799)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.1.27
+Version:        4.1.28
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -527,7 +527,7 @@ module Registration
 
       # update the $releasever
       def update_releasever
-        new_base = selected_migration.find(&:base)
+        new_base = selected_migration.find(&:isbase)
 
         if new_base
           log.info "Activating new $releasever for base product: #{new_base}"

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -181,7 +181,7 @@ module Registration
 
       # @return [String] textual representation of base product living in arr
       def base_product_text_for(arr)
-        base_product = arr.find(&:base)
+        base_product = arr.find(&:isbase)
         base_product.friendly_name || base_product.short_name ||
           (base_product.identifier + "-" + base_product.version)
       end

--- a/test/fixtures/migration_sles15_offline_migrations.yml
+++ b/test/fixtures/migration_sles15_offline_migrations.yml
@@ -7,7 +7,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: true
+      :isbase: true
       :product_type: base
       :free: false
       :release_stage: beta
@@ -19,7 +19,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -31,7 +31,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -43,7 +43,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -55,7 +55,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -67,7 +67,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -79,7 +79,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -91,7 +91,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -103,7 +103,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released
@@ -115,7 +115,7 @@
       :version: '15'
       :arch: x86_64
       :release_type: 
-      :base: false
+      :isbase: false
       :product_type: module
       :free: true
       :release_stage: released

--- a/test/fixtures/migration_to_sles12_sp1.yml
+++ b/test/fixtures/migration_to_sles12_sp1.yml
@@ -7,5 +7,5 @@
       :release_type: 
       :friendly_name: SUSE Linux Enterprise Server SP1 x86_64
       :shortname: SLES12-SP1
-      :base: true
+      :isbase: true
       :product_type: base


### PR DESCRIPTION
## Target Branch

_This is for **SLE-15-SP1**._ This is the **original PR** which will be merged forward to SLE-15-SP2 and SP3.


See section _Related PRs_ below for other target branches.



## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1217317


## Problem

Migration to a newer SLE-15 SP fails with an unrecoverable exception

_**Caught error: NoMethodError: "undefined method `friendly_name' for nil:NilClass"**_

Notice that this happens with the _old_ release while preparing the migration, even before the installation media with the newer release is booted.


## Cause

The API of SCC changed. The previous boolean field / method `base` was renamed to `isbase`.

This should never have happened in the first place during the lifetime of SLE-15. But now that the damage is done, we have to adapt to the change to minimize customer impact.


## Fix

Cherry-picked @imobachgs's fix 431d937b78c209c0d35ce911a98f9f05978e77ca which does a global `s/base/isbase/` in this source repo for the code and the test case.


## Affected Scenarios

@lslezak wrote on IRC:
> This code is fortunately used in offline migration only, so it could only happen with new QU media.


## Target Branches and Related PRs

- Original PR where this patch was cherry-picked from: https://github.com/yast/yast-registration/pull/561
- For SLE-15-SP2:  _TBD_
- For SLE-15-SP3:  _TBD_

- SLE-15-SP4, -SP5, -SP6 are not affected; the original patch was for SP4 and merged forward.

- SLE-15-GA went out of support.
