### PR TITLE
[SLE12-SP5] Switch to the new SUSEConnect-ng (bsc#1212799)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 21 07:16:01 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
+
+- Switch to the new SUSEConnect-ng (bsc#1212799)
+  - Includes a SSL reload fix (bsc#1195220)
+- 3.3.2
+
+-------------------------------------------------------------------
 Thu Oct 10 13:39:18 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - fix crash of autoyast config dialog (bsc#1152913)

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,8 +1,11 @@
 -------------------------------------------------------------------
 Tue Nov 21 07:16:01 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
-- Switch to the new SUSEConnect-ng (bsc#1212799)
-  - Includes a SSL reload fix (bsc#1195220)
+- Switch to the new SUSEConnect-ng (bsc#1212799), includes
+  additional fixes:
+  - SSL reload fix (bsc#1195220)
+  - Detection of base products coming from SCC
+    (bsc#1194989, bsc#1217317)
 - 3.3.2
 
 -------------------------------------------------------------------

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        3.3.1
+Version:        3.3.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -32,15 +32,9 @@ Requires:       yast2 >= 3.1.26
 Requires:       yast2-pkg-bindings >= 3.1.34
 # N_() method
 Requires:       yast2-ruby-bindings >= 3.1.12
-# SUSE::Connect::YaST.list_installer_updates
-Requires:       rubygem(suse-connect) >= 0.2.37
 
-# NOTE: Workaround for bsc#947482, SUSEConnect is actually not needed by the
-# YaST registration module, it is used just to install the Connect dependencies.
-#
-# TODO: Remove it once the SUSEConnect dependencies are properly moved to the
-# suse-connect gem.
-Requires:       SUSEConnect >= 0.2.37
+# new suseconnect-ng
+Requires:       suseconnect-ruby-bindings >= 1.2.0
 
 Requires:       yast2-slp >= 3.1.9
 Requires:       yast2-add-on >= 3.1.8
@@ -53,7 +47,8 @@ BuildRequires:  update-desktop-files
 BuildRequires:  yast2-devtools >= 3.1.39
 BuildRequires:  rubygem(yast-rake) >= 0.2.5
 BuildRequires:  rubygem(rspec)
-BuildRequires:  rubygem(suse-connect) >= 0.3.11
+# new suseconnect-ng
+BuildRequires:  suseconnect-ruby-bindings >= 1.2.0
 BuildRequires:  yast2-slp >= 3.1.9
 # packager/product_patterns.rb
 BuildRequires:  yast2-packager >= 3.1.95

--- a/src/clients/scc_auto.rb
+++ b/src/clients/scc_auto.rb
@@ -353,7 +353,7 @@ module Yast
       handle_product_service { registration_ui.update_base_product }
     end
 
-    # @yieldreturn [Boolean, SUSE::Connect::Remote::Product] success flag and
+    # @yieldreturn [Boolean, OpenStruct success flag and
     #   remote product pair
     # @return [Boolean] true on success
     def handle_product_service(&block)

--- a/src/lib/registration/registration.rb
+++ b/src/lib/registration/registration.rb
@@ -147,8 +147,8 @@ module Registration
     end
 
     # get the list of migration products
-    # @param [Array<SUSE::Connect::Remote::Product>] installed_products
-    # @return [Array<Array<SUSE::Connect::Remote::Product>>] list of possible migrations,
+    # @param [Array<OpenStruct>] installed_products
+    # @return [Array<Array<OpenStruct>>] list of possible migrations,
     #   each migration contains a list of target products
     def migration_products(installed_products)
       log.info "Loading migration products for: #{installed_products}"
@@ -287,7 +287,7 @@ module Registration
     end
 
     # collect product renames
-    # @param products [Array<SUSE::Connect::Remote::Product>] remote products received from SCC
+    # @param products [Array<OpenStruct>] remote products received from SCC
     # @return [Hash] hash with product renames: { old_name => new_name }
     def collect_renames(products)
       renames = {}

--- a/src/lib/registration/ssl_certificate.rb
+++ b/src/lib/registration/ssl_certificate.rb
@@ -9,6 +9,8 @@ module Registration
   # class handling SSL certificate
   # TODO: move it to yast2 to share it?
   class SslCertificate
+    include Yast::Logger
+
     Yast.import "Stage"
 
     # Path to the registration certificate in the instsys

--- a/src/lib/registration/ssl_certificate.rb
+++ b/src/lib/registration/ssl_certificate.rb
@@ -79,6 +79,9 @@ module Registration
       # Cleanup
       FileUtils.rm_rf(TMP_CA_CERTS_DIR)
 
+      # Reload SUSEConnect internal cert pool (suseconnect-ng only)
+      SUSE::Connect::SSLCertificate.reload if SUSE::Connect::SSLCertificate.respond_to?(:reload)
+
       # Check that last file was copied to return true or false
       File.exist?(new_files.last)
     end

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -156,9 +156,9 @@ module Registration
       products
     end
 
-    # convert a libzypp Product Hash to a SUSE::Connect::Remote::Product object
+    # convert a libzypp Product Hash to a OpenStruct object
     # @param product [Hash] product Hash obtained from pkg-bindings
-    # @return [SUSE::Connect::Remote::Product] the remote product
+    # @return [OpenStruct] the remote product
     def self.remote_product(product)
       OpenStruct.new(
         arch:         product["arch"],

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -372,7 +372,7 @@ module Registration
 
       # update the $releasever
       def update_releasever
-        new_base = selected_migration.find(&:base)
+        new_base = selected_migration.find(&:isbase)
 
         if new_base
           log.info "Activating new $releasever for base product: #{new_base}"

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -36,7 +36,7 @@ module Registration
       attr_accessor :selected_migration, :manual_repo_selection, :installed_products
 
       # run the dialog
-      # @param [Array<SUSE::Connect::Remote::Product>] migrations the available migration targets
+      # @param [Array<OpenStruct>] migrations the available migration targets
       # @param [Array<Hash>] installed_products the currently installed products
       def self.run(migrations, installed_products)
         dialog = MigrationSelectionDialog.new(migrations, installed_products)
@@ -44,7 +44,7 @@ module Registration
       end
 
       # constructor
-      # @param [Array<SUSE::Connect::Remote::Product>] migrations the available migration targets
+      # @param [Array<OpenStruct>] migrations the available migration targets
       # @param [Array<Hash>] installed_products the currently installed products
       def initialize(migrations, installed_products)
         textdomain "registration"

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -164,6 +164,33 @@ module Registration
         end
       end
 
+      # @return [String] textual representation of base product living in arr
+      def base_product_text_for(arr)
+        base_product = arr.find(&:isbase)
+        base_product.friendly_name || base_product.short_name ||
+          (base_product.identifier + "-" + base_product.version)
+      end
+
+      # @return [String] textual representation of extensions living in arr
+      def extensions_text_for(arr)
+        extensions = arr.select { |p| p.product_type == "extension" }
+        return "" if extensions.empty?
+
+        # TRANSLATORS: number of extensions to upgrade. Will be used later to
+        #   construct whole status of upgrade
+        format(n_("%i extension", "%i extensions", extensions.size), extensions.size)
+      end
+
+      # @return [String] textual representation of modules living in arr
+      def modules_text_for(arr)
+        modules = arr.select { |p| p.product_type == "module" }
+        return "" if modules.empty?
+
+        # TRANSLATORS: number of modules to upgrade. Will be used later to
+        #   construct whole status of upgrade
+        format(n_("%i module", "%i modules", modules.size), modules.size)
+      end
+
       # update details about the selected migration
       def update_details
         log.info "updating details"

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -21,12 +21,12 @@ def suse_connect_product_generator(attrs = {})
 end
 
 def addon_generator(params = {})
-  SUSE::Connect::Remote::Product.new(suse_connect_product_generator(params))
+  OpenStruct.new(suse_connect_product_generator(params))
 end
 
 def addon_with_child_generator(parent_params = {})
-  prod_child = suse_connect_product_generator
-  SUSE::Connect::Remote::Product.new(
+  prod_child = OpenStruct.new(suse_connect_product_generator)
+  OpenStruct.new(
     suse_connect_product_generator(parent_params.merge("extensions" => [prod_child]))
   )
 end

--- a/test/fixtures/activated_products.yml
+++ b/test/fixtures/activated_products.yml
@@ -1,5 +1,5 @@
 ---
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1157
     :name: SUSE Linux Enterprise High Availability GEO Extension
@@ -34,7 +34,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1245
     :name: SUSE Linux Enterprise High Availability Extension
@@ -53,7 +53,7 @@
     - 1539
     - 1500
     :extensions:
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1157
         :name: SUSE Linux Enterprise High Availability GEO Extension
@@ -105,7 +105,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1117
     :name: SUSE Linux Enterprise Server
@@ -128,7 +128,7 @@
     - 1219
     - 1478
     :extensions:
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1222
         :name: SUSE Linux Enterprise Workstation Extension
@@ -189,7 +189,7 @@
           enabled: true
           autorefresh: true
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1223
         :name: SUSE Linux Enterprise Software Development Kit
@@ -233,7 +233,7 @@
           enabled: true
           autorefresh: true
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1150
         :name: Legacy Module
@@ -276,7 +276,7 @@
           enabled: true
           autorefresh: true
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1153
         :name: Web and Scripting Module
@@ -320,7 +320,7 @@
           enabled: true
           autorefresh: true
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1220
         :name: Public Cloud Module
@@ -362,7 +362,7 @@
           enabled: true
           autorefresh: true
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1212
         :name: Advanced Systems Management Module
@@ -402,7 +402,7 @@
           enabled: true
           autorefresh: true
       modifiable: true
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1245
         :name: SUSE Linux Enterprise High Availability Extension
@@ -421,7 +421,7 @@
         - 1539
         - 1500
         :extensions:
-        - !ruby/object:SUSE::Connect::Remote::Product
+        - !ruby/object:OpenStruct
           table:
             :id: 1157
             :name: SUSE Linux Enterprise High Availability GEO Extension

--- a/test/fixtures/available_addons.yml
+++ b/test/fixtures/available_addons.yml
@@ -213,7 +213,7 @@
       :successor_ids:
       - 1324
       :extensions:
-      - &1 !ruby/object:SUSE::Connect::Remote::Product
+      - &1 !ruby/object:OpenStruct
         table:
           :id: 1157
           :name: SUSE Linux Enterprise High Availability GEO Extension

--- a/test/fixtures/available_unknown_addons.yml
+++ b/test/fixtures/available_unknown_addons.yml
@@ -1,6 +1,6 @@
 ---
 - !ruby/object:Registration::Addon
-  pure_addon: !ruby/object:SUSE::Connect::Remote::Product
+  pure_addon: !ruby/object:OpenStruct
     table:
       :id: 1153
       :name: Web and Scripting Module
@@ -43,7 +43,7 @@
     modifiable: true
   children: []
 - !ruby/object:Registration::Addon
-  pure_addon: !ruby/object:SUSE::Connect::Remote::Product
+  pure_addon: !ruby/object:OpenStruct
     table:
       :id: 1212
       :name: Advanced Systems Management Module
@@ -84,7 +84,7 @@
     modifiable: true
   children: []
 - !ruby/object:Registration::Addon
-  pure_addon: !ruby/object:SUSE::Connect::Remote::Product
+  pure_addon: !ruby/object:OpenStruct
     table:
       :id: 1223
       :name: SUSE Linux Enterprise Software Development Kit
@@ -128,7 +128,7 @@
     modifiable: true
   children: []
 - !ruby/object:Registration::Addon
-  pure_addon: !ruby/object:SUSE::Connect::Remote::Product
+  pure_addon: !ruby/object:OpenStruct
     table:
       :id: 1150
       :name: Legacy Module
@@ -171,7 +171,7 @@
     modifiable: true
   children: []
 - !ruby/object:Registration::Addon
-  pure_addon: !ruby/object:SUSE::Connect::Remote::Product
+  pure_addon: !ruby/object:OpenStruct
     table:
       :id: 1220
       :name: Public Cloud Module
@@ -213,7 +213,7 @@
     modifiable: true
   children: []
 - !ruby/object:Registration::Addon
-  pure_addon: !ruby/object:SUSE::Connect::Remote::Product
+  pure_addon: !ruby/object:OpenStruct
     table:
       :id: 1222
       :name: SUSE Linux Enterprise Workstation Extension

--- a/test/fixtures/installed_sles12_product.yml
+++ b/test/fixtures/installed_sles12_product.yml
@@ -1,5 +1,5 @@
 ---
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :arch: x86_64
     :identifier: SLES

--- a/test/fixtures/legacy_module_services.yml
+++ b/test/fixtures/legacy_module_services.yml
@@ -1,10 +1,10 @@
 ---
-- !ruby/object:SUSE::Connect::Remote::Service
+- !ruby/object:OpenStruct
   table:
     :id: 1140
     :name: Legacy_Module_12_x86_64
     :url: https://scc.suse.com/access/services/1140?credentials=Legacy_Module_12_x86_64
-    :product: !ruby/object:SUSE::Connect::Remote::Product
+    :product: !ruby/object:OpenStruct
       table:
         :id: 1150
         :name: Legacy Module

--- a/test/fixtures/migration_service.yml
+++ b/test/fixtures/migration_service.yml
@@ -1,9 +1,9 @@
---- !ruby/object:SUSE::Connect::Remote::Service
+--- !ruby/object:OpenStruct
 table:
   :id: 1311
   :name: SUSE_Linux_Enterprise_Server_12_SP1_12.1_x86_64
   :url: https://scc.suse.com/access/services/1311?credentials=SUSE_Linux_Enterprise_Server_12_SP1_12.1_x86_64
-  :product: !ruby/object:SUSE::Connect::Remote::Product
+  :product: !ruby/object:OpenStruct
     table:
       :id: 1322
       :name: SUSE Linux Enterprise Server 12 SP1
@@ -54,7 +54,7 @@ table:
         autorefresh: false
       :product_type: base
       :extensions:
-      - !ruby/object:SUSE::Connect::Remote::Product
+      - !ruby/object:OpenStruct
         table:
           :id: 1323
           :name: SUSE Linux Enterprise Software Development Kit
@@ -110,7 +110,7 @@ table:
           :product_type: extension
           :extensions: []
         modifiable: true
-      - !ruby/object:SUSE::Connect::Remote::Product
+      - !ruby/object:OpenStruct
         table:
           :id: 1324
           :name: SUSE Linux Enterprise High Availability Extension

--- a/test/fixtures/migration_to_sles12_sp1.yml
+++ b/test/fixtures/migration_to_sles12_sp1.yml
@@ -1,5 +1,5 @@
 ---
-- - !ruby/object:SUSE::Connect::Remote::Product
+- - !ruby/object:OpenStruct
     table:
       :identifier: SLES
       :version: '12.1'

--- a/test/fixtures/migration_to_sles12_sp1.yml
+++ b/test/fixtures/migration_to_sles12_sp1.yml
@@ -7,3 +7,5 @@
       :release_type: 
       :friendly_name: SUSE Linux Enterprise Server SP1 x86_64
       :shortname: SLES12-SP1
+      :isbase: true
+      :product_type: base

--- a/test/fixtures/pure_addons.yml
+++ b/test/fixtures/pure_addons.yml
@@ -1,5 +1,5 @@
 ---
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1222
     :name: SUSE Linux Enterprise Workstation Extension
@@ -60,7 +60,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1223
     :name: SUSE Linux Enterprise Software Development Kit
@@ -103,7 +103,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1150
     :name: Legacy Module
@@ -146,7 +146,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1153
     :name: Web and Scripting Module
@@ -190,7 +190,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1220
     :name: Public Cloud Module
@@ -231,7 +231,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1212
     :name: Advanced Systems Management Module
@@ -271,7 +271,7 @@
       enabled: true
       autorefresh: true
   modifiable: true
-- !ruby/object:SUSE::Connect::Remote::Product
+- !ruby/object:OpenStruct
   table:
     :id: 1245
     :name: SUSE Linux Enterprise High Availability Extension
@@ -290,7 +290,7 @@
     - 1539
     - 1500
     :extensions:
-    - !ruby/object:SUSE::Connect::Remote::Product
+    - !ruby/object:OpenStruct
       table:
         :id: 1157
         :name: SUSE Linux Enterprise High Availability GEO Extension

--- a/test/fixtures/remote_product.yml
+++ b/test/fixtures/remote_product.yml
@@ -1,4 +1,4 @@
---- !ruby/object:SUSE::Connect::Remote::Product
+--- !ruby/object:OpenStruct
 table:
   :id: 1117
   :name: SUSE Linux Enterprise Server
@@ -21,7 +21,7 @@ table:
   - 1219
   - 1478
   :extensions:
-  - !ruby/object:SUSE::Connect::Remote::Product
+  - !ruby/object:OpenStruct
     table:
       :id: 1222
       :name: SUSE Linux Enterprise Workstation Extension
@@ -67,7 +67,7 @@ table:
         enabled: true
         autorefresh: true
     modifiable: true
-  - !ruby/object:SUSE::Connect::Remote::Product
+  - !ruby/object:OpenStruct
     table:
       :id: 1223
       :name: SUSE Linux Enterprise Software Development Kit
@@ -110,7 +110,7 @@ table:
         enabled: true
         autorefresh: true
     modifiable: true
-  - !ruby/object:SUSE::Connect::Remote::Product
+  - !ruby/object:OpenStruct
     table:
       :id: 1150
       :name: Legacy Module
@@ -143,7 +143,7 @@ table:
         enabled: true
         autorefresh: false
     modifiable: true
-  - !ruby/object:SUSE::Connect::Remote::Product
+  - !ruby/object:OpenStruct
     table:
       :id: 1153
       :name: Web and Scripting Module
@@ -176,7 +176,7 @@ table:
         enabled: true
         autorefresh: false
     modifiable: true
-  - !ruby/object:SUSE::Connect::Remote::Product
+  - !ruby/object:OpenStruct
     table:
       :id: 1220
       :name: Public Cloud Module
@@ -209,7 +209,7 @@ table:
         enabled: true
         autorefresh: false
     modifiable: true
-  - !ruby/object:SUSE::Connect::Remote::Product
+  - !ruby/object:OpenStruct
     table:
       :id: 1212
       :name: Advanced Systems Management Module
@@ -239,7 +239,7 @@ table:
         enabled: true
         autorefresh: false
     modifiable: true
-  - !ruby/object:SUSE::Connect::Remote::Product
+  - !ruby/object:OpenStruct
     table:
       :id: 1155
       :name: SUSE Linux Enterprise High Availability Extension
@@ -258,7 +258,7 @@ table:
       - 1242
       - 1500
       :extensions:
-      - !ruby/object:SUSE::Connect::Remote::Product
+      - !ruby/object:OpenStruct
         table:
           :id: 1157
           :name: SUSE Linux Enterprise High Availability GEO Extension

--- a/test/inst_scc_test.rb
+++ b/test/inst_scc_test.rb
@@ -63,6 +63,7 @@ describe "inst_scc client" do
     before do
       expect_any_instance_of(Yast::InstSccClient).to receive(:registration_check)
         .and_return(:update)
+      allow(Yast::Report).to receive(:Error)
     end
 
     it "switchs to manual registration when aborting selection of url" do

--- a/test/migration_repos_workflow_spec.rb
+++ b/test/migration_repos_workflow_spec.rb
@@ -53,6 +53,7 @@ describe Registration::UI::MigrationReposWorkflow do
       before do
         expect(Registration::SwMgmt).to receive(:init).at_least(1)
         allow_any_instance_of(Registration::RepoStateStorage).to receive(:write)
+        allow(Yast::Report).to receive(:Error)
       end
 
       let(:set_success_expectations) do

--- a/test/migration_repos_workflow_spec.rb
+++ b/test/migration_repos_workflow_spec.rb
@@ -110,7 +110,7 @@ describe Registration::UI::MigrationReposWorkflow do
       end
 
       it "reports error and aborts when no installed product is found" do
-        expect(Registration::SwMgmt).to receive(:installed_products)
+        allow(Registration::SwMgmt).to receive(:installed_products)
           .and_return([])
         expect(Yast::Report).to receive(:Error)
 
@@ -119,7 +119,7 @@ describe Registration::UI::MigrationReposWorkflow do
 
       it "reports error and aborts when no migration is available" do
         # installed SLES12
-        expect(Registration::SwMgmt).to receive(:installed_products)
+        allow(Registration::SwMgmt).to receive(:installed_products)
           .and_return([load_yaml_fixture("products_legacy_installation.yml")[1]])
         expect_any_instance_of(Registration::RegistrationUI).to receive(:migration_products)
           .and_return([])

--- a/test/registration/ui/addon_eula_dialog_spec.rb
+++ b/test/registration/ui/addon_eula_dialog_spec.rb
@@ -57,6 +57,7 @@ describe Registration::UI::AddonEulaDialog do
       before do
         allow(Yast::ProductLicense).to receive(:HandleLicenseDialogRet)
           .and_return(first_dialog_response, second_dialog_response)
+        allow(Yast::ProductLicense).to receive(:DisplayLicenseDialogWithTitle)
       end
 
       context "and the user wants to go back" do
@@ -98,6 +99,7 @@ describe Registration::UI::AddonEulaDialog do
       before do
         allow(Yast::ProductLicense).to receive(:HandleLicenseDialogRet)
           .and_return(:accepted)
+        allow(Yast::ProductLicense).to receive(:DisplayLicenseDialogWithTitle)
       end
 
       it "sets it as accepted" do
@@ -115,6 +117,7 @@ describe Registration::UI::AddonEulaDialog do
       before do
         allow(Yast::ProductLicense).to receive(:HandleLicenseDialogRet)
           .and_return(:refused)
+        allow(Yast::ProductLicense).to receive(:DisplayLicenseDialogWithTitle)
       end
 
       it "does not set it as accepted" do

--- a/test/registration_spec.rb
+++ b/test/registration_spec.rb
@@ -16,7 +16,6 @@ describe Registration::Registration do
       reg_code = "reg_code"
       target_distro = "sles-12-x86_64"
 
-      expect_any_instance_of(SUSE::Connect::Credentials).to receive(:write)
       expect(SUSE::Connect::YaST).to(receive(:announce_system)
         .with(hash_including(token: reg_code), target_distro)
         .and_return([username, password]))
@@ -43,10 +42,10 @@ describe Registration::Registration do
       service_data = {
         "name"    => "service",
         "url"     => "https://example.com",
-        "product" => product
+        "product" => OpenStruct.new(product)
       }
 
-      service = SUSE::Connect::Remote::Service.new(service_data)
+      let(:service) { OpenStruct.new(service_data) }
 
       expect(SUSE::Connect::YaST).to receive(connect_method).and_return(service)
 
@@ -60,17 +59,22 @@ describe Registration::Registration do
       expect(Registration::SwMgmt).to receive(:update_product_renames)
         .with("SUSE_SLES_SAP" => "SLES_SAP")
 
-      allow(File).to receive(:exist?).with(
-        SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE
-      ).and_return(true)
-      allow(File).to receive(:read).with(
-        SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE
-      ).and_return(
-        "username=SCC_foo\npassword=bar"
-      )
+      expect(SUSE::Connect::YaST).to receive(:credentials)
+        .with(SUSE::Connect::YaST::GLOBAL_CREDENTIALS_FILE)
+        .and_return(OpenStruct.new(username: "SCC_foo", password: "bar"))
+    end
 
-      registered_service = Registration::Registration.new.send(yast_method, product)
+    it "adds the selected product and returns added zypp services" do
+      registered_service = subject.send(yast_method, product)
       expect(registered_service).to eq(service)
+    end
+
+    it "does not add the target system prefix if not at upgrade" do
+      allow(Yast::Mode).to receive(:update).and_return(false)
+      allow(Yast::Stage).to receive(:initial).and_return(false)
+      expect(Yast::Installation).to_not receive(:destdir)
+
+      subject.send(yast_method, product)
     end
   end
 

--- a/test/registration_ui_test.rb
+++ b/test/registration_ui_test.rb
@@ -120,6 +120,7 @@ describe "Registration::RegistrationUI" do
 
       # stub the registration
       allow(registration).to receive(:register_product)
+      allow(Registration::SwMgmt).to receive(:service_repos).and_return([])
     end
 
     context "when the addons are free" do

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -132,9 +132,9 @@ describe Registration::SwMgmt do
 
   describe ".add_services" do
     let(:service_url) { "https://example.com/foo/bar?credentials=TEST_credentials" }
-    let(:credentials) { SUSE::Connect::Credentials.new("user", "password", "file") }
+    let(:credentials) { OpenStruct.new(username: "user", password: "password", file: "file") }
     let(:product_service) do
-      SUSE::Connect::Remote::Service.new(
+      OpenStruct.new(
         "name"    => service_name,
         "url"     => service_url,
         "product" => {}
@@ -145,7 +145,7 @@ describe Registration::SwMgmt do
       expect(Yast::Pkg).to receive(:SourceSaveAll).and_return(true).twice
       expect(Yast::Pkg).to receive(:ServiceForceRefresh).with(service_name).and_return(true)
       expect(Yast::Pkg).to receive(:ServiceSave).with(service_name).and_return(true)
-      expect_any_instance_of(SUSE::Connect::Credentials).to receive(:write)
+      expect(SUSE::Connect::YaST).to receive(:create_credentials_file)
 
       allow(Yast::Pkg).to receive(:SourceGetCurrent).with(false).and_return(repos.keys)
       repos.each do |id, repo|

--- a/test/url_helpers_spec.rb
+++ b/test/url_helpers_spec.rb
@@ -109,15 +109,6 @@ describe "Registration::UrlHelpers" do
           .and_return(false)
         expect(Registration::UrlHelpers.registration_url).to be_nil
       end
-
-      it "reads the URL from config file if present" do
-        # stub config file reading
-        url = "https://example.com"
-        expect(File).to receive(:exist?).with(SUSE::Connect::YaST::DEFAULT_CONFIG_FILE)
-          .and_return(true).twice
-        expect(YAML).to receive(:load_file).and_return("url" => url, "insecure" => false)
-        expect(Registration::UrlHelpers.registration_url).to eq(url)
-      end
     end
 
     context "at upgrade" do
@@ -165,7 +156,7 @@ describe "Registration::UrlHelpers" do
         end
 
         it "returns URL of SMT server" do
-          expect(File).to receive(:exist?).with(fixtures_file("SUSEConnect")).and_return(true)
+          allow(File).to receive(:exist?).with(fixtures_file("SUSEConnect")).and_return(true)
           expect(SUSE::Connect::Config).to receive(:new).with(suse_connect)
             .and_return(SUSE::Connect::Config.new(fixtures_file("SUSEConnect")))
           expect(Registration::UrlHelpers.registration_url).to eq("https://myserver.com")

--- a/test/wizard_client_spec.rb
+++ b/test/wizard_client_spec.rb
@@ -34,6 +34,7 @@ describe Registration::UI::WizardClient do
     end
 
     it "returns :abort when an exception is raised" do
+      allow(Yast::Report).to receive(:Error)
       expect(subject).to receive(:run_sequence).and_raise("Error")
       expect(subject.run).to eq(:abort)
     end


### PR DESCRIPTION
## Problem

- The SLE12-SP5 release will switch to the new SUSEConnect-ng (rewritten from Ruby to Go)
- See related #585 for more details

## Solution

- Backported these pull requests:
  - #585 
  - #588
  - #561
- Added some more fixes to make the unit tests pass

## Testing

- Updated unit tests, all pass
- Tested building the package using `osc`
- Tested manually in SLE12-SP5

## Notes

I manually checked the [Ruby changes history](https://en.wikipedia.org/wiki/History_of_Ruby) because SLE12 contains Ruby 2.1 and SLE15 includes Ruby 2.5.
I haven't found any new Ruby feature used like safe navigation operator `&.` or `Regexp#match?` method.
Additionally Rubocop also did not find any problem (we use `TargetRubyVersion: 2.1` setting).

