### PR TITLE
[SLE15-SP6] Same product mapping API as in SP5 and older (bsc#1220567)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ Metrics/BlockNesting:
 
 # TODO: this need some non-trivial refactoring...
 Metrics/ClassLength:
-  Max: 480
+  Max: 490
 
 # TODO: this need some non-trivial refactoring...
 Metrics/CyclomaticComplexity:

--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 12 14:57:15 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Use the new product mapping API (related to bsc#1220567)
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only
@@ -35,8 +35,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake) >= 0.2.5
 # uses Fiddle instead of FFI
 BuildRequires:  suseconnect-ruby-bindings > 0.0.4
-# ProductSpec API
-BuildRequires:  yast2-packager >= 4.4.13
+# new product mapping API
+BuildRequires:  yast2-packager >= 4.6.9
 BuildRequires:  yast2-update >= 3.1.36
 # log.group call
 BuildRequires:  yast2-ruby-bindings >= 4.5.4
@@ -51,8 +51,8 @@ Requires:       yast2-ruby-bindings >= 4.5.4
 Requires:       suseconnect-ruby-bindings > 0.0.4
 Requires:       yast2-add-on >= 3.1.8
 Requires:       yast2-slp >= 3.1.9
-# ProductSpec API
-Requires:       yast2-packager >= 4.4.13
+# new product mapping API
+Requires:       yast2-packager >= 4.6.9
 Requires:       yast2-update >= 3.1.36
 
 # new calls in AutoinstGeneral

--- a/src/lib/registration/ui/migration_repos_workflow.rb
+++ b/src/lib/registration/ui/migration_repos_workflow.rb
@@ -688,6 +688,13 @@ module Registration
         products = Y2Packager::ProductSpec.base_products
                                           .select { |p| p.is_a?(Y2Packager::RepoProductSpec) }
         log.info("Found base products on the offline medium: #{products.pretty_inspect}")
+
+        # in SP6+ always use the new product mapping
+        new_migration = true
+        log.info "Using SP6+ product upgrade mapping: #{new_migration}"
+        Y2Packager::ProductUpgrade.new_renames = new_migration
+        Yast::AddOnProduct.new_renames = new_migration
+
         products
       end
 
@@ -706,7 +713,7 @@ module Registration
         # first check if there is a product rename defined for the installed products
         # and the new renamed base product is available
         # key in the mapping: list of installed products, value: the new base product
-        Y2Packager::ProductUpgrade::MAPPING.each do |k, v|
+        Y2Packager::ProductUpgrade.mapping.each do |k, v|
           if (k - installed_names).empty?
             new_base = base_products.find { |p| p.name == v }
           end

--- a/src/lib/registration/ui/migration_selection_dialog.rb
+++ b/src/lib/registration/ui/migration_selection_dialog.rb
@@ -18,6 +18,7 @@ require "yast"
 require "registration/addon_sorter"
 require "registration/sw_mgmt"
 require "registration/url_helpers"
+require "y2packager/product_upgrade"
 
 module Registration
   module UI
@@ -212,7 +213,17 @@ module Registration
         selected = Yast::UI.QueryWidget(:migration_targets, :CurrentItem)
         return unless selected
 
+        update_product_mapping
         Yast::UI.ChangeWidget(Id(:details), :Value, migration_details(selected))
+      end
+
+      # helper method to update the product mapping in Y2Packager::ProductUpgrade
+      def update_product_mapping
+        # in SP6+ always use the new product mapping
+        new_migration = true
+        log.info "Using SP6+ product upgrade mapping: #{new_migration}"
+        Y2Packager::ProductUpgrade.new_renames = new_migration
+        Yast::AddOnProduct.new_renames = new_migration
       end
 
       # get migration details
@@ -339,6 +350,7 @@ module Registration
 
       # store the current UI values
       def store_values
+        update_product_mapping
         self.selected_migration = current_migration
         self.manual_repo_selection = Yast::UI.QueryWidget(:manual_repos, :Value)
       end


### PR DESCRIPTION
## Problem

- Related to https://github.com/yast/yast-packager/pull/653
- That PR changed the API in SP5 and older
- Having a different API could make troubles in the future

## Solution

- Backport the API change to SP6