### PR TITLE
Ensure add_on_others in autoyast profile are added (bsc#1223301)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed May 29 13:34:10 UTC 2024 - Martin Vidner <mvidner@suse.com>
+
+- Ensure add_on_others in autoyast profile are added (bsc#1223301)
+- 4.5.10
+
+-------------------------------------------------------------------
 Fri Mar  8 14:39:20 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Set the new product mapping when upgrading SLE_HPC to SLES SP6+

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.5.9
+Version:        4.5.10
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/ui/offline_migration_workflow.rb
+++ b/src/lib/registration/ui/offline_migration_workflow.rb
@@ -79,6 +79,7 @@ module Registration
       # force reloading of the old repositories so we can detect and remove the obsoleted
       # services during migration (bsc#1159433)
       def reinit_repos
+        Yast::Pkg.SourceSaveAll
         Yast::Pkg.SourceFinishAll
         Yast::Pkg.SourceRestore
       end


### PR DESCRIPTION
## Problem

When upgrading from SLE12 (SP5) to SLE15-SP5 via AutoYaST,
when [`<add_on_others>` repositories](https://doc.opensuse.org/projects/autoyast/#Software-Selections-additional) are specified in the profile ("others" meaning, plain, non-_product_ repos),
these repos are not present when the upgrade finishes.

- https://bugzilla.suse.com/show_bug.cgi?id=1223301
- https://trello.com/c/sppEpu4L

## Solution

Add a `Pkg.SourceSaveAll` call to `reinit_repos` that reinits the repos in the middle of the upgrade.


## Testing

Tested manually. After the upgrade, the `add_on_others` repo is present and SLE12 repos are not present.

- [x] with AutoYaST and registration
- [x] manually,  with registration
- [x] manually, without registration (full medium)

Helpful tools:
- When you start an upgrade but abort it in the proposal screen before hitting the big green button, SCC considers it upgraded/migrated already. Use `suseconnect --rollback` to revert its records
- `yupdate overlay create` ([https://github.com/yast/yast-installation/blob/master/doc/yupdate.md](yupdate.md))

## Screenshots

N/A
