### PR TITLE
Disable the SLE_BCI repository after registration (PED-8817)

### DIFF
--- a/package/yast2-registration.changes
+++ b/package/yast2-registration.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep 24 11:43:29 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Disable the SLE_BCI repository after registration (PED-8817)
+- 4.6.3
+
+-------------------------------------------------------------------
 Wed May 29 13:34:10 UTC 2024 - Martin Vidner <mvidner@suse.com>
 
 - Ensure add_on_others in autoyast profile are added (bsc#1223301)

--- a/package/yast2-registration.spec
+++ b/package/yast2-registration.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-registration
-Version:        4.6.2
+Version:        4.6.3
 Release:        0
 Summary:        YaST2 - Registration Module
 License:        GPL-2.0-only

--- a/src/lib/registration/clients/inst_scc.rb
+++ b/src/lib/registration/clients/inst_scc.rb
@@ -115,8 +115,15 @@ module Yast
       base_reg_dialog = ::Registration::UI::BaseSystemRegistrationDialog.new
       ret = base_reg_dialog.run
 
-      # remember the created registration object for later use
-      @registration = base_reg_dialog.registration if ret == :next
+      if ret == :next
+        # remember the created registration object for later use
+        @registration = base_reg_dialog.registration
+
+        # disable the BCI repository after registering, it is intended for
+        # not registered systems
+        Registration::SwMgmt.disable_bci
+      end
+
       # tell #registration_check whether the user wants to go back (bnc#940915)
       @back_from_register = (ret == :back)
 

--- a/src/lib/registration/sw_mgmt.rb
+++ b/src/lib/registration/sw_mgmt.rb
@@ -599,6 +599,23 @@ module Registration
       end
     end
 
+    # name of the SLE BCI repository
+    SLE_BCI = "SLE_BCI".freeze
+
+    # disable the BCI repository
+    def self.disable_bci
+      enabled_repos = Yast::Pkg.SourceGetCurrent(true)
+
+      enabled_repos.each do |repo|
+        repo_data = Yast::Pkg.SourceGeneralData(repo)
+
+        if repo_data["alias"] == SLE_BCI
+          log.info "Disabling #{SLE_BCI} repository"
+          Yast::Pkg.SourceSetEnabled(repo, false)
+        end
+      end
+    end
+
     # a helper method for iterating over repositories
     # @param repo_aliases [Array<String>] list of repository aliases
     # @param block block evaluated for each found repository

--- a/test/sw_mgmt_spec.rb
+++ b/test/sw_mgmt_spec.rb
@@ -746,4 +746,22 @@ describe Registration::SwMgmt do
     end
   end
 
+  describe ".disable_bci" do
+    it "disables the SLE_BCI repository" do
+      expect(Yast::Pkg).to receive(:SourceGetCurrent).and_return([42])
+      expect(Yast::Pkg).to receive(:SourceGeneralData).with(42).and_return("alias" => "SLE_BCI")
+      expect(Yast::Pkg).to receive(:SourceSetEnabled).with(42, false)
+
+      subject.disable_bci
+    end
+
+    it "does not change anything if the SLE_BCI repository is not present" do
+      expect(Yast::Pkg).to receive(:SourceGetCurrent).and_return([42])
+      expect(Yast::Pkg).to receive(:SourceGeneralData).with(42).and_return("alias" => "repo")
+      expect(Yast::Pkg).not_to receive(:SourceSetEnabled)
+
+      subject.disable_bci
+    end
+  end
+
 end


### PR DESCRIPTION
## Problem

- After registration the default `SLE_BCI` repository is still enabled
- This free repository is intended for unregistered systems, after registration it should be disabled
- See https://jira.suse.com/browse/PED-8817

## Solution

- Disable the `SLE_BCI` repository after registering the base product

## Notes

- After deregistering the system using `SUSEConnect -d` the BCI repository needs to be enabled back manually (`zypper modifyrepo --enable SLE_BCI`)

## Testing

- Added a new unit test
- Tested manually

## Screenshots

Before registration the BCI repository is enabled

![wsl_before_registration](https://github.com/user-attachments/assets/8e0c20eb-3a08-476c-af96-f7190e62be00)

After registration the BCI repository is disabled

![wsl_after_registration](https://github.com/user-attachments/assets/17f4a3bc-e88e-4c74-a84b-8c4c2a6f18fd)
